### PR TITLE
feat: add dataset-level diagnostics metric extractors (#10)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cauchy-generator"
-version = "0.1.3"
+version = "0.1.4"
 description = "High-performance synthetic tabular data generator scaffold aligned with TabICLv2 Appendix E."
 readme = "README.md"
 license = "MIT"

--- a/src/cauchy_generator/diagnostics/__init__.py
+++ b/src/cauchy_generator/diagnostics/__init__.py
@@ -1,0 +1,6 @@
+"""Dataset-level diagnostics metrics extraction."""
+
+from .metrics import extract_dataset_metrics, extract_metrics_batch
+from .types import DatasetMetrics
+
+__all__ = ["DatasetMetrics", "extract_dataset_metrics", "extract_metrics_batch"]

--- a/src/cauchy_generator/diagnostics/metrics.py
+++ b/src/cauchy_generator/diagnostics/metrics.py
@@ -1,0 +1,475 @@
+"""Dataset-level meta-feature metrics extractors."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+import torch
+
+from cauchy_generator.filtering import apply_torch_rf_filter
+from cauchy_generator.math_utils import to_numpy as _to_numpy
+from cauchy_generator.types import DatasetBundle
+
+from .types import DatasetMetrics
+
+_TASK_CLASSIFICATION = "classification"
+_TASK_REGRESSION = "regression"
+_RIDGE_LAMBDA = 1e-6
+_NUM_BOOTSTRAP = 200
+_EPS = 1e-12
+
+
+def extract_metrics_batch(
+    bundles: Sequence[DatasetBundle], *, include_spearman: bool = False
+) -> list[DatasetMetrics]:
+    """Extract dataset-level metrics for a sequence of bundles in order."""
+
+    return [
+        extract_dataset_metrics(bundle, include_spearman=include_spearman) for bundle in bundles
+    ]
+
+
+def extract_dataset_metrics(
+    bundle: DatasetBundle, *, include_spearman: bool = False
+) -> DatasetMetrics:
+    """Extract deterministic dataset-level metrics from one generated bundle."""
+
+    x_train = _as_2d_float(_to_numpy(bundle.X_train), name="X_train")
+    x_test = _as_2d_float(_to_numpy(bundle.X_test), name="X_test")
+    y_train = _as_target_array(_to_numpy(bundle.y_train), name="y_train")
+    y_test = _as_target_array(_to_numpy(bundle.y_test), name="y_test")
+
+    _validate_shapes(bundle, x_train, x_test, y_train, y_test)
+
+    x_all = np.concatenate([x_train, x_test], axis=0)
+    y_all = _concat_targets(y_train, y_test)
+    task = _resolve_task(bundle.metadata, y_all)
+
+    pearson_abs_mean, pearson_abs_max = _pearson_abs_stats(x_all)
+    spearman_abs_mean: float | None = None
+    spearman_abs_max: float | None = None
+    if include_spearman:
+        spearman_abs_mean, spearman_abs_max = _spearman_abs_stats(x_all)
+
+    (
+        n_categorical_features,
+        categorical_ratio,
+        cat_cardinality_min,
+        cat_cardinality_mean,
+        cat_cardinality_max,
+    ) = _categorical_cardinality_stats(x_all, bundle.feature_types)
+
+    linearity_proxy = _compute_linearity_proxy(
+        x_train=x_train,
+        x_test=x_test,
+        y_train=y_train,
+        y_test=y_test,
+        task=task,
+    )
+    wins_ratio_proxy = _compute_wins_ratio_proxy(x=x_all, y=y_all, task=task)
+    nonlinearity_proxy = None
+    if linearity_proxy is not None and wins_ratio_proxy is not None:
+        nonlinearity_proxy = max(0.0, wins_ratio_proxy - linearity_proxy)
+
+    class_entropy: float | None = None
+    majority_minority_ratio: float | None = None
+    n_classes: int | None = None
+    if task == _TASK_CLASSIFICATION:
+        y_labels = _classification_labels(y_all)
+        n_classes = int(np.unique(y_labels).size)
+        class_entropy, majority_minority_ratio = _class_imbalance_stats(y_labels)
+
+    snr_proxy_db = _compute_snr_proxy_db(
+        x_train=x_train,
+        x_all=x_all,
+        y_train=y_train,
+        y_all=y_all,
+        task=task,
+    )
+
+    return DatasetMetrics(
+        task=task,
+        n_rows=int(x_all.shape[0]),
+        n_features=int(x_all.shape[1]),
+        n_classes=n_classes,
+        n_categorical_features=n_categorical_features,
+        categorical_ratio=categorical_ratio,
+        linearity_proxy=linearity_proxy,
+        nonlinearity_proxy=nonlinearity_proxy,
+        wins_ratio_proxy=wins_ratio_proxy,
+        pearson_abs_mean=pearson_abs_mean,
+        pearson_abs_max=pearson_abs_max,
+        spearman_abs_mean=spearman_abs_mean,
+        spearman_abs_max=spearman_abs_max,
+        class_entropy=class_entropy,
+        majority_minority_ratio=majority_minority_ratio,
+        snr_proxy_db=snr_proxy_db,
+        cat_cardinality_min=cat_cardinality_min,
+        cat_cardinality_mean=cat_cardinality_mean,
+        cat_cardinality_max=cat_cardinality_max,
+    )
+
+
+def _as_2d_float(value: np.ndarray, *, name: str) -> np.ndarray:
+    arr = np.asarray(value, dtype=np.float64)
+    if arr.ndim != 2:
+        raise ValueError(f"{name} must be a rank-2 array, got shape={arr.shape!r}")
+    return arr
+
+
+def _as_target_array(value: np.ndarray, *, name: str) -> np.ndarray:
+    arr = np.asarray(value)
+    if arr.ndim not in {1, 2}:
+        raise ValueError(f"{name} must be rank-1 or rank-2, got shape={arr.shape!r}")
+    return arr
+
+
+def _validate_shapes(
+    bundle: DatasetBundle,
+    x_train: np.ndarray,
+    x_test: np.ndarray,
+    y_train: np.ndarray,
+    y_test: np.ndarray,
+) -> None:
+    if x_train.shape[1] != x_test.shape[1]:
+        raise ValueError(
+            f"X_train/X_test feature mismatch: {x_train.shape[1]} != {x_test.shape[1]}"
+        )
+    if x_train.shape[0] != y_train.shape[0]:
+        raise ValueError(f"X_train/y_train row mismatch: {x_train.shape[0]} != {y_train.shape[0]}")
+    if x_test.shape[0] != y_test.shape[0]:
+        raise ValueError(f"X_test/y_test row mismatch: {x_test.shape[0]} != {y_test.shape[0]}")
+    if x_train.shape[0] + x_test.shape[0] <= 0:
+        raise ValueError("Dataset must contain at least one row across train and test splits.")
+    if len(bundle.feature_types) != x_train.shape[1]:
+        raise ValueError(
+            "feature_types length must match feature count: "
+            f"{len(bundle.feature_types)} != {x_train.shape[1]}"
+        )
+
+
+def _concat_targets(y_train: np.ndarray, y_test: np.ndarray) -> np.ndarray:
+    if y_train.ndim == y_test.ndim:
+        return np.concatenate([y_train, y_test], axis=0)
+
+    if y_train.ndim == 1 and y_test.ndim == 2 and y_test.shape[1] == 1:
+        return np.concatenate([y_train[:, np.newaxis], y_test], axis=0)
+
+    if y_train.ndim == 2 and y_test.ndim == 1 and y_train.shape[1] == 1:
+        return np.concatenate([y_train, y_test[:, np.newaxis]], axis=0)
+
+    raise ValueError(
+        f"y_train/y_test rank mismatch is unsupported: {y_train.shape!r} vs {y_test.shape!r}"
+    )
+
+
+def _resolve_task(metadata: dict[str, Any], y_all: np.ndarray) -> str:
+    config = metadata.get("config")
+    if isinstance(config, dict):
+        dataset_cfg = config.get("dataset")
+        if isinstance(dataset_cfg, dict):
+            raw_task = dataset_cfg.get("task")
+            if raw_task in {_TASK_CLASSIFICATION, _TASK_REGRESSION}:
+                return str(raw_task)
+
+    labels = np.ravel(np.asarray(y_all))
+    if labels.size == 0:
+        raise ValueError("Cannot infer task from empty target array.")
+    if np.issubdtype(labels.dtype, np.integer):
+        return _TASK_CLASSIFICATION
+
+    finite_mask = np.isfinite(labels)
+    if finite_mask.any():
+        finite_vals = labels[finite_mask]
+        rounded = np.rint(finite_vals)
+        if np.all(np.abs(finite_vals - rounded) <= 1e-8):
+            n_unique = int(np.unique(rounded.astype(np.int64)).size)
+            max_classes = max(10, int(np.sqrt(float(finite_vals.size))) + 1)
+            if 2 <= n_unique <= max_classes:
+                return _TASK_CLASSIFICATION
+
+    return _TASK_REGRESSION
+
+
+def _classification_labels(y: np.ndarray) -> np.ndarray:
+    arr = np.asarray(y)
+    if arr.ndim == 2:
+        if arr.shape[1] != 1:
+            raise ValueError(
+                "Classification targets must be rank-1 or single-column rank-2 arrays, "
+                f"got shape={arr.shape!r}."
+            )
+        arr = arr[:, 0]
+    if arr.ndim != 1:
+        raise ValueError(f"Classification targets must be rank-1, got shape={arr.shape!r}.")
+    return np.rint(arr).astype(np.int64)
+
+
+def _regression_target_matrix(y: np.ndarray) -> np.ndarray:
+    arr = np.asarray(y, dtype=np.float64)
+    if arr.ndim == 1:
+        return arr[:, np.newaxis]
+    if arr.ndim == 2:
+        return arr
+    raise ValueError(f"Regression targets must be rank-1 or rank-2, got shape={arr.shape!r}.")
+
+
+def _classification_targets_for_splits(
+    y_train: np.ndarray,
+    y_test: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    y_train_labels = _classification_labels(y_train)
+    y_test_labels = _classification_labels(y_test)
+    all_labels = np.concatenate([y_train_labels, y_test_labels], axis=0)
+    classes, inverse = np.unique(all_labels, return_inverse=True)
+    n_classes = int(classes.size)
+    if n_classes <= 0:
+        raise ValueError("Classification targets must include at least one class.")
+    eye = np.eye(n_classes, dtype=np.float64)
+    y_train_targets = eye[inverse[: y_train_labels.shape[0]]]
+    y_test_targets = eye[inverse[y_train_labels.shape[0] :]]
+    return y_train_targets, y_test_targets, all_labels
+
+
+def _ridge_predict(
+    x_train: np.ndarray,
+    y_train: np.ndarray,
+    x_pred: np.ndarray,
+    *,
+    ridge_lambda: float = _RIDGE_LAMBDA,
+) -> np.ndarray:
+    train_design = np.concatenate(
+        [np.ones((x_train.shape[0], 1), dtype=np.float64), x_train],
+        axis=1,
+    )
+    pred_design = np.concatenate(
+        [np.ones((x_pred.shape[0], 1), dtype=np.float64), x_pred],
+        axis=1,
+    )
+    gram = train_design.T @ train_design
+    reg = np.eye(gram.shape[0], dtype=np.float64) * float(ridge_lambda)
+    reg[0, 0] = 0.0
+    rhs = train_design.T @ y_train
+    try:
+        weights = np.linalg.solve(gram + reg, rhs)
+    except np.linalg.LinAlgError:
+        weights = np.linalg.pinv(gram + reg) @ rhs
+    return pred_design @ weights
+
+
+def _bootstrap_wins_ratio(pred: np.ndarray, target: np.ndarray, baseline: np.ndarray) -> float:
+    n_rows = int(target.shape[0])
+    if n_rows <= 0:
+        raise ValueError("Bootstrap wins ratio requires at least one row.")
+    rng = np.random.default_rng(0)
+    wins = 0
+    for _ in range(_NUM_BOOTSTRAP):
+        idx = rng.integers(0, n_rows, size=n_rows)
+        sampled_target = target[idx]
+        sampled_pred = pred[idx]
+        mse_pred = float(np.mean((sampled_pred - sampled_target) ** 2))
+        mse_base = float(np.mean((baseline - sampled_target) ** 2))
+        wins += int(mse_pred < mse_base)
+    return float(wins / _NUM_BOOTSTRAP)
+
+
+def _compute_linearity_proxy(
+    *,
+    x_train: np.ndarray,
+    x_test: np.ndarray,
+    y_train: np.ndarray,
+    y_test: np.ndarray,
+    task: str,
+) -> float | None:
+    if x_train.shape[0] <= 0 or x_test.shape[0] <= 0:
+        return None
+
+    if task == _TASK_CLASSIFICATION:
+        y_train_targets, y_test_targets, _ = _classification_targets_for_splits(y_train, y_test)
+    elif task == _TASK_REGRESSION:
+        y_train_targets = _regression_target_matrix(y_train)
+        y_test_targets = _regression_target_matrix(y_test)
+    else:
+        raise ValueError(f"Unsupported task '{task}'.")
+
+    pred_test = _ridge_predict(x_train, y_train_targets, x_test)
+    baseline = np.mean(y_train_targets, axis=0, keepdims=True)
+    wins_ratio = _bootstrap_wins_ratio(pred=pred_test, target=y_test_targets, baseline=baseline)
+    return _finite_or_none(wins_ratio)
+
+
+def _compute_wins_ratio_proxy(*, x: np.ndarray, y: np.ndarray, task: str) -> float | None:
+    try:
+        x_tensor = torch.as_tensor(x, dtype=torch.float32, device="cpu")
+        if task == _TASK_CLASSIFICATION:
+            labels = _classification_labels(y)
+            _, dense = np.unique(labels, return_inverse=True)
+            y_tensor = torch.as_tensor(dense.astype(np.int64), dtype=torch.int64, device="cpu")
+        elif task == _TASK_REGRESSION:
+            y_matrix = _regression_target_matrix(y).astype(np.float32, copy=False)
+            if y_matrix.shape[1] == 1:
+                y_tensor = torch.as_tensor(y_matrix[:, 0], dtype=torch.float32, device="cpu")
+            else:
+                y_tensor = torch.as_tensor(y_matrix, dtype=torch.float32, device="cpu")
+        else:
+            raise ValueError(f"Unsupported task '{task}'.")
+
+        _, details = apply_torch_rf_filter(
+            x_tensor,
+            y_tensor,
+            task=task,
+            seed=0,
+            threshold=0.0,
+        )
+    except Exception:
+        return None
+
+    value = details.get("wins_ratio")
+    if isinstance(value, (int, float)):
+        return _finite_or_none(float(value))
+    return None
+
+
+def _compute_snr_proxy_db(
+    *,
+    x_train: np.ndarray,
+    x_all: np.ndarray,
+    y_train: np.ndarray,
+    y_all: np.ndarray,
+    task: str,
+) -> float | None:
+    if x_train.shape[0] <= 0:
+        return None
+
+    if task == _TASK_CLASSIFICATION:
+        y_train_labels = _classification_labels(y_train)
+        y_all_labels = _classification_labels(y_all)
+        classes, y_all_inverse = np.unique(y_all_labels, return_inverse=True)
+        n_classes = int(classes.size)
+        if n_classes <= 0:
+            return None
+        y_train_inverse = np.searchsorted(classes, y_train_labels)
+        eye = np.eye(n_classes, dtype=np.float64)
+        y_train_target = eye[y_train_inverse]
+        y_all_target = eye[y_all_inverse]
+    elif task == _TASK_REGRESSION:
+        y_train_target = _regression_target_matrix(y_train)
+        y_all_target = _regression_target_matrix(y_all)
+    else:
+        raise ValueError(f"Unsupported task '{task}'.")
+
+    pred_all = _ridge_predict(x_train, y_train_target, x_all)
+    residual = y_all_target - pred_all
+    signal_var = float(np.var(pred_all))
+    noise_var = float(np.var(residual))
+    if not math.isfinite(signal_var) or not math.isfinite(noise_var):
+        return None
+    if signal_var <= 0.0:
+        return None
+    noise_var = max(noise_var, _EPS)
+    snr = signal_var / noise_var
+    if not math.isfinite(snr) or snr <= 0.0:
+        return None
+    return float(10.0 * math.log10(snr))
+
+
+def _pearson_abs_stats(x: np.ndarray) -> tuple[float | None, float | None]:
+    if x.shape[1] < 2:
+        return None, None
+    with np.errstate(invalid="ignore", divide="ignore"):
+        corr = np.corrcoef(x, rowvar=False)
+    if corr.ndim != 2:
+        return None, None
+    upper = np.triu_indices(corr.shape[0], k=1)
+    values = np.abs(corr[upper])
+    values = values[np.isfinite(values)]
+    if values.size == 0:
+        return None, None
+    return float(np.mean(values)), float(np.max(values))
+
+
+def _rankdata_average(values: np.ndarray) -> np.ndarray:
+    arr = np.asarray(values, dtype=np.float64)
+    ranks = np.full(arr.shape[0], np.nan, dtype=np.float64)
+    finite_mask = np.isfinite(arr)
+    if not finite_mask.any():
+        return ranks
+
+    finite_values = arr[finite_mask]
+    order = np.argsort(finite_values, kind="mergesort")
+    sorted_values = finite_values[order]
+    finite_ranks = np.empty(finite_values.shape[0], dtype=np.float64)
+
+    i = 0
+    n = sorted_values.shape[0]
+    while i < n:
+        j = i + 1
+        while j < n and sorted_values[j] == sorted_values[i]:
+            j += 1
+        mean_rank = (i + j - 1) * 0.5 + 1.0
+        finite_ranks[order[i:j]] = mean_rank
+        i = j
+
+    ranks[finite_mask] = finite_ranks
+    return ranks
+
+
+def _spearman_abs_stats(x: np.ndarray) -> tuple[float | None, float | None]:
+    ranked = np.empty_like(x, dtype=np.float64)
+    for i in range(x.shape[1]):
+        ranked[:, i] = _rankdata_average(x[:, i])
+    return _pearson_abs_stats(ranked)
+
+
+def _class_imbalance_stats(y_labels: np.ndarray) -> tuple[float | None, float | None]:
+    if y_labels.size == 0:
+        return None, None
+    _, counts = np.unique(y_labels, return_counts=True)
+    if counts.size == 0:
+        return None, None
+    probs = counts.astype(np.float64) / float(np.sum(counts))
+    entropy = float(-np.sum(probs * np.log(np.clip(probs, _EPS, None))))
+    positive_counts = counts[counts > 0]
+    if positive_counts.size == 0:
+        return entropy, None
+    ratio = float(np.max(positive_counts) / np.min(positive_counts))
+    return entropy, ratio
+
+
+def _categorical_cardinality_stats(
+    x_all: np.ndarray,
+    feature_types: list[str],
+) -> tuple[int, float, int | None, float | None, int | None]:
+    n_features = int(x_all.shape[1])
+    if len(feature_types) != n_features:
+        raise ValueError(
+            f"feature_types length must match feature count: {len(feature_types)} != {n_features}"
+        )
+    cat_indices = [i for i, kind in enumerate(feature_types) if kind == "cat"]
+    n_categorical = int(len(cat_indices))
+    cat_ratio = float(n_categorical / max(1, n_features))
+    if n_categorical == 0:
+        return n_categorical, cat_ratio, None, None, None
+
+    cardinalities: list[int] = []
+    for idx in cat_indices:
+        col = x_all[:, idx]
+        finite = col[np.isfinite(col)]
+        cardinalities.append(int(np.unique(finite).size))
+
+    if not cardinalities:
+        return n_categorical, cat_ratio, None, None, None
+    return (
+        n_categorical,
+        cat_ratio,
+        int(min(cardinalities)),
+        float(np.mean(cardinalities)),
+        int(max(cardinalities)),
+    )
+
+
+def _finite_or_none(value: float) -> float | None:
+    return float(value) if math.isfinite(value) else None

--- a/src/cauchy_generator/diagnostics/types.py
+++ b/src/cauchy_generator/diagnostics/types.py
@@ -1,0 +1,34 @@
+"""Typed payloads for dataset-level diagnostics metrics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class DatasetMetrics:
+    """Stable dataset-level metrics payload used by diagnostics extractors."""
+
+    task: str
+    n_rows: int
+    n_features: int
+    n_classes: int | None
+    n_categorical_features: int
+    categorical_ratio: float
+
+    linearity_proxy: float | None
+    nonlinearity_proxy: float | None
+    wins_ratio_proxy: float | None
+
+    pearson_abs_mean: float | None
+    pearson_abs_max: float | None
+    spearman_abs_mean: float | None
+    spearman_abs_max: float | None
+
+    class_entropy: float | None
+    majority_minority_ratio: float | None
+    snr_proxy_db: float | None
+
+    cat_cardinality_min: int | None
+    cat_cardinality_mean: float | None
+    cat_cardinality_max: int | None

--- a/tests/test_diagnostics_metrics.py
+++ b/tests/test_diagnostics_metrics.py
@@ -1,0 +1,158 @@
+import numpy as np
+import pytest
+
+from cauchy_generator.config import GeneratorConfig
+from cauchy_generator.core.dataset import generate_batch, generate_one
+from cauchy_generator.diagnostics import extract_dataset_metrics, extract_metrics_batch
+from cauchy_generator.types import DatasetBundle
+
+
+def _tiny_config(task: str) -> GeneratorConfig:
+    cfg = GeneratorConfig.from_yaml("configs/default.yaml")
+    cfg.dataset.task = task
+    cfg.dataset.n_train = 64
+    cfg.dataset.n_test = 32
+    cfg.dataset.n_features_min = 8
+    cfg.dataset.n_features_max = 8
+    cfg.dataset.n_classes_min = 2
+    cfg.dataset.n_classes_max = 4
+    cfg.graph.n_nodes_min = 2
+    cfg.graph.n_nodes_max = 6
+    return cfg
+
+
+def test_extract_dataset_metrics_classification_invariants(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _stub_filter(*_args, **_kwargs):
+        return True, {"wins_ratio": 0.75, "n_valid_oob": 64, "backend": "torch_rf"}
+
+    monkeypatch.setattr("cauchy_generator.diagnostics.metrics.apply_torch_rf_filter", _stub_filter)
+    bundle = generate_one(_tiny_config("classification"), seed=7, device="cpu")
+
+    metrics = extract_dataset_metrics(bundle, include_spearman=True)
+    assert metrics.task == "classification"
+    assert metrics.n_rows == bundle.X_train.shape[0] + bundle.X_test.shape[0]
+    assert metrics.n_features == bundle.X_train.shape[1]
+    assert metrics.n_classes is not None and metrics.n_classes >= 2
+    assert metrics.class_entropy is not None and metrics.class_entropy >= 0.0
+    assert metrics.majority_minority_ratio is not None and metrics.majority_minority_ratio >= 1.0
+    assert metrics.linearity_proxy is not None and 0.0 <= metrics.linearity_proxy <= 1.0
+    assert metrics.wins_ratio_proxy == pytest.approx(0.75)
+    assert metrics.nonlinearity_proxy is not None and metrics.nonlinearity_proxy >= 0.0
+    assert 0.0 <= metrics.categorical_ratio <= 1.0
+    if metrics.pearson_abs_mean is not None:
+        assert 0.0 <= metrics.pearson_abs_mean <= 1.0
+    if metrics.pearson_abs_max is not None:
+        assert 0.0 <= metrics.pearson_abs_max <= 1.0
+    if metrics.spearman_abs_mean is not None:
+        assert 0.0 <= metrics.spearman_abs_mean <= 1.0
+    if metrics.spearman_abs_max is not None:
+        assert 0.0 <= metrics.spearman_abs_max <= 1.0
+
+
+def test_extract_dataset_metrics_regression_branch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _stub_filter(*_args, **_kwargs):
+        return True, {"wins_ratio": 0.55, "n_valid_oob": 64, "backend": "torch_rf"}
+
+    monkeypatch.setattr("cauchy_generator.diagnostics.metrics.apply_torch_rf_filter", _stub_filter)
+    bundle = generate_one(_tiny_config("regression"), seed=17, device="cpu")
+
+    metrics = extract_dataset_metrics(bundle)
+    assert metrics.task == "regression"
+    assert metrics.n_classes is None
+    assert metrics.class_entropy is None
+    assert metrics.majority_minority_ratio is None
+    assert metrics.linearity_proxy is not None and 0.0 <= metrics.linearity_proxy <= 1.0
+    assert metrics.wins_ratio_proxy == pytest.approx(0.55)
+    assert metrics.snr_proxy_db is None or np.isfinite(metrics.snr_proxy_db)
+
+
+def test_extract_dataset_metrics_spearman_toggle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _stub_filter(*_args, **_kwargs):
+        return True, {"wins_ratio": 0.61, "n_valid_oob": 6, "backend": "torch_rf"}
+
+    monkeypatch.setattr("cauchy_generator.diagnostics.metrics.apply_torch_rf_filter", _stub_filter)
+    bundle = DatasetBundle(
+        X_train=np.asarray([[0.0, 10.0], [1.0, 20.0], [2.0, 30.0], [3.0, 40.0]], dtype=np.float32),
+        y_train=np.asarray([0.0, 1.0, 2.0, 3.0], dtype=np.float32),
+        X_test=np.asarray([[4.0, 50.0], [5.0, 60.0]], dtype=np.float32),
+        y_test=np.asarray([4.0, 5.0], dtype=np.float32),
+        feature_types=["num", "num"],
+        metadata={"config": {"dataset": {"task": "regression"}}},
+    )
+
+    disabled = extract_dataset_metrics(bundle, include_spearman=False)
+    enabled = extract_dataset_metrics(bundle, include_spearman=True)
+    assert disabled.spearman_abs_mean is None
+    assert disabled.spearman_abs_max is None
+    assert enabled.spearman_abs_mean is not None
+    assert enabled.spearman_abs_max is not None
+    assert enabled.spearman_abs_mean == pytest.approx(1.0)
+    assert enabled.spearman_abs_max == pytest.approx(1.0)
+
+
+def test_extract_dataset_metrics_reproducible_for_fixed_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _stub_filter(*_args, **_kwargs):
+        return True, {"wins_ratio": 0.42, "n_valid_oob": 64, "backend": "torch_rf"}
+
+    monkeypatch.setattr("cauchy_generator.diagnostics.metrics.apply_torch_rf_filter", _stub_filter)
+    cfg = _tiny_config("classification")
+    bundle_a = generate_one(cfg, seed=123, device="cpu")
+    bundle_b = generate_one(cfg, seed=123, device="cpu")
+
+    metrics_1 = extract_dataset_metrics(bundle_a)
+    metrics_2 = extract_dataset_metrics(bundle_a)
+    metrics_3 = extract_dataset_metrics(bundle_b)
+    assert metrics_1 == metrics_2
+    assert metrics_1 == metrics_3
+
+
+def test_extract_dataset_metrics_handles_degenerate_constant_columns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _stub_filter(*_args, **_kwargs):
+        return False, {"reason": "insufficient_oob_predictions", "n_valid_oob": 0}
+
+    monkeypatch.setattr("cauchy_generator.diagnostics.metrics.apply_torch_rf_filter", _stub_filter)
+    bundle = DatasetBundle(
+        X_train=np.ones((8, 3), dtype=np.float32),
+        y_train=np.linspace(0.0, 1.0, num=8, dtype=np.float32),
+        X_test=np.ones((4, 3), dtype=np.float32),
+        y_test=np.linspace(1.0, 2.0, num=4, dtype=np.float32),
+        feature_types=["num", "cat", "cat"],
+        metadata={"config": {"dataset": {"task": "regression"}}},
+    )
+
+    metrics = extract_dataset_metrics(bundle, include_spearman=True)
+    assert metrics.pearson_abs_mean is None
+    assert metrics.pearson_abs_max is None
+    assert metrics.spearman_abs_mean is None
+    assert metrics.spearman_abs_max is None
+    assert metrics.wins_ratio_proxy is None
+    assert metrics.nonlinearity_proxy is None
+    assert metrics.n_categorical_features == 2
+    assert metrics.cat_cardinality_min == 1
+    assert metrics.cat_cardinality_mean == pytest.approx(1.0)
+    assert metrics.cat_cardinality_max == 1
+
+
+def test_extract_metrics_batch_preserves_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _stub_filter(*_args, **_kwargs):
+        return True, {"wins_ratio": 0.8, "n_valid_oob": 64, "backend": "torch_rf"}
+
+    monkeypatch.setattr("cauchy_generator.diagnostics.metrics.apply_torch_rf_filter", _stub_filter)
+    cfg = _tiny_config("classification")
+    bundles = generate_batch(cfg, num_datasets=2, seed=900, device="cpu")
+
+    metrics_batch = extract_metrics_batch(bundles)
+    expected = [extract_dataset_metrics(bundle) for bundle in bundles]
+    assert metrics_batch == expected

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.13"
 
 [[package]]
 name = "cauchy-generator"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- add new diagnostics module with typed dataset-level metric payloads
- implement deterministic extractors for linearity/nonlinearity proxy, correlation stats, class imbalance, SNR proxy, categorical cardinality stats, and control dimensions
- add batch extraction API and package exports
- add comprehensive diagnostics tests for invariants, branch coverage, reproducibility, and degenerate cases
- bump package version from 0.1.3 to 0.1.4

## Testing
- uv run ruff check src tests
- uv run mypy src
- uv run pytest -q

Closes #10