### PR TITLE
feat: add opt-in meta-feature steering with strict validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Opt-in soft meta-feature steering with bounded deterministic candidate selection
+- New generation CLI controls: `--diagnostics`, `--steer-meta`, and repeatable `--meta-target key=min:max[:weight]`
+- Steering metadata payload propagation on generated bundles when steering is enabled
+
+### Changed
+
+- Added top-level `GeneratorConfig.meta_feature_targets` and `SteeringConfig` with disabled-by-default safe defaults
+- Target resolution now merges legacy `diagnostics.meta_feature_targets` with top-level targets (top-level precedence)
+
 ## [0.1.5] - 2025-02-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ uv sync --group dev
 uv run cauchy-gen generate --config configs/default.yaml --num-datasets 10 --out data/run1
 ```
 
+```bash
+# Enable diagnostics artifacts and opt-in meta-feature steering
+uv run cauchy-gen generate \
+  --config configs/default.yaml \
+  --num-datasets 50 \
+  --diagnostics \
+  --steer-meta \
+  --meta-target linearity_proxy=0.25:0.75:1.5
+```
+
 ### Benchmarking Performance
 
 ```bash

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -1,4 +1,5 @@
 seed: 1
+meta_feature_targets: {}
 dataset:
   task: classification
   n_train: 768
@@ -30,6 +31,10 @@ diagnostics:
   underrepresented_threshold: 0.5
   meta_feature_targets: {}
   out_dir: null
+steering:
+  enabled: false
+  max_attempts: 3
+  temperature: 0.35
 benchmark:
   profile_name: medium_cuda
   suite: standard

--- a/src/cauchy_generator/cli.py
+++ b/src/cauchy_generator/cli.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import math
+import sys
+from dataclasses import fields
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +25,7 @@ from cauchy_generator.diagnostics import (
     write_coverage_summary_json,
     write_coverage_summary_markdown,
 )
+from cauchy_generator.diagnostics.types import DatasetMetrics
 from cauchy_generator.hardware import (
     HardwareInfo,
     apply_hardware_profile,
@@ -30,6 +34,10 @@ from cauchy_generator.hardware import (
 from cauchy_generator.io.parquet_writer import write_parquet_shards_stream
 
 DEVICE_CHOICES = ("auto", "cpu", "cuda", "mps")
+META_TARGET_SUPPORTED_METRICS = frozenset(
+    field_info.name for field_info in fields(DatasetMetrics) if field_info.name != "task"
+)
+CLASSIFICATION_ONLY_METRICS = frozenset({"class_entropy", "majority_minority_ratio", "n_classes"})
 
 
 def _positive_int(value: str) -> int:
@@ -50,31 +58,130 @@ def _non_negative_int(value: str) -> int:
     return parsed
 
 
-def _coerce_target_bands(
-    raw: object,
-) -> dict[str, tuple[float, float]]:
-    """Normalize diagnostics target bands from config payload into tuple ranges."""
+def _parse_meta_target_arg(raw: str) -> tuple[str, tuple[float, float, float]]:
+    """argparse type: parse `metric=min:max[:weight]` target overrides."""
 
-    normalized: dict[str, tuple[float, float]] = {}
+    value = raw.strip()
+    if "=" not in value:
+        raise argparse.ArgumentTypeError(
+            f"Invalid --meta-target '{raw}'. Expected format: key=min:max[:weight]."
+        )
+    metric_name, band = value.split("=", maxsplit=1)
+    metric_name = metric_name.strip()
+    if not metric_name:
+        raise argparse.ArgumentTypeError(
+            f"Invalid --meta-target '{raw}'. Metric key must be non-empty."
+        )
+    if metric_name not in META_TARGET_SUPPORTED_METRICS:
+        supported = ", ".join(sorted(META_TARGET_SUPPORTED_METRICS))
+        raise argparse.ArgumentTypeError(
+            f"Unsupported --meta-target metric '{metric_name}'. Supported metrics: {supported}."
+        )
+    parts = [part.strip() for part in band.split(":")]
+    if len(parts) not in {2, 3}:
+        raise argparse.ArgumentTypeError(
+            f"Invalid --meta-target '{raw}'. Expected exactly two or three values after '='."
+        )
+    try:
+        lo = float(parts[0])
+        hi = float(parts[1])
+        weight = float(parts[2]) if len(parts) == 3 else 1.0
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"Invalid --meta-target '{raw}'. min/max/weight must be numeric."
+        ) from exc
+    if not (math.isfinite(lo) and math.isfinite(hi) and math.isfinite(weight)):
+        raise argparse.ArgumentTypeError(
+            f"Invalid --meta-target '{raw}'. min/max/weight must be finite."
+        )
+    if weight <= 0:
+        raise argparse.ArgumentTypeError(f"Invalid --meta-target '{raw}'. weight must be > 0.")
+    if lo > hi:
+        lo, hi = hi, lo
+    return metric_name, (lo, hi, weight)
+
+
+def _coerce_meta_target_specs(raw: object) -> dict[str, tuple[float, float, float]]:
+    """Normalize config target payload into `(min, max, weight)` specs."""
+
+    normalized: dict[str, tuple[float, float, float]] = {}
     if not isinstance(raw, dict):
         return normalized
     for metric_name, band in raw.items():
-        if not isinstance(metric_name, str):
+        if not isinstance(metric_name, str) or metric_name not in META_TARGET_SUPPORTED_METRICS:
             continue
-        if not isinstance(band, (list, tuple)) or len(band) != 2:
+        if not isinstance(band, (list, tuple)) or len(band) not in {2, 3}:
             continue
         try:
             lo = float(band[0])
             hi = float(band[1])
+            weight = float(band[2]) if len(band) == 3 else 1.0
         except (TypeError, ValueError):
             continue
-        if not (lo == lo and hi == hi):
+        if not (math.isfinite(lo) and math.isfinite(hi) and math.isfinite(weight)):
             continue
-        if lo <= hi:
-            normalized[metric_name] = (lo, hi)
-        else:
-            normalized[metric_name] = (hi, lo)
+        if weight <= 0:
+            continue
+        if lo > hi:
+            lo, hi = hi, lo
+        normalized[metric_name] = (lo, hi, weight)
     return normalized
+
+
+def _resolve_meta_target_specs(
+    config: GeneratorConfig,
+    cli_overrides: list[tuple[str, tuple[float, float, float]]] | None,
+) -> dict[str, tuple[float, float, float]]:
+    """Merge target specs across legacy diagnostics, top-level config, and CLI."""
+
+    resolved = _coerce_meta_target_specs(config.diagnostics.meta_feature_targets)
+    resolved.update(_coerce_meta_target_specs(config.meta_feature_targets))
+    if cli_overrides:
+        for metric_name, spec in cli_overrides:
+            resolved[metric_name] = spec
+    return resolved
+
+
+def _target_specs_to_bands(
+    target_specs: dict[str, tuple[float, float, float]],
+) -> dict[str, tuple[float, float]]:
+    """Drop steering weights for diagnostics coverage aggregation payload."""
+
+    return {metric_name: (spec[0], spec[1]) for metric_name, spec in target_specs.items()}
+
+
+def _validate_target_specs_for_task(
+    *,
+    task: str,
+    target_specs: dict[str, tuple[float, float, float]],
+) -> tuple[str, ...]:
+    """Return metrics that are incompatible with the configured task."""
+
+    normalized_task = task.strip().lower()
+    if normalized_task != "regression":
+        return ()
+    incompatible = sorted(set(target_specs).intersection(CLASSIFICATION_ONLY_METRICS))
+    return tuple(incompatible)
+
+
+def _collect_unknown_target_metrics_from_config(config: GeneratorConfig) -> tuple[str, ...]:
+    """Collect unsupported target metric keys from config payloads."""
+
+    unknown: set[str] = set()
+    for raw in (config.diagnostics.meta_feature_targets, config.meta_feature_targets):
+        if not isinstance(raw, dict):
+            continue
+        for metric_name in raw:
+            if isinstance(metric_name, str) and metric_name not in META_TARGET_SUPPORTED_METRICS:
+                unknown.add(metric_name)
+    return tuple(sorted(unknown))
+
+
+def _raise_usage_error(message: str) -> None:
+    """Exit with argparse-compatible usage error semantics."""
+
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(2)
 
 
 def _coerce_quantiles(raw: object) -> tuple[float, ...]:
@@ -126,14 +233,30 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Generate in memory only and do not write parquet files.",
     )
     g.add_argument(
-        "--coverage",
+        "--diagnostics",
         action="store_true",
         help="Enable diagnostics coverage aggregation artifacts for this run.",
     )
     g.add_argument(
-        "--coverage-out-dir",
+        "--diagnostics-out-dir",
         default=None,
-        help="Optional directory for coverage artifacts (defaults to output directory).",
+        help="Optional directory for diagnostics artifacts (defaults to output directory).",
+    )
+    g.add_argument(
+        "--steer-meta",
+        action="store_true",
+        help="Enable soft steering toward configured meta-feature target bands.",
+    )
+    g.add_argument(
+        "--meta-target",
+        action="append",
+        default=None,
+        type=_parse_meta_target_arg,
+        metavar="KEY=MIN:MAX[:WEIGHT]",
+        help=(
+            "Repeatable meta-feature target override used by diagnostics and steering. "
+            "Format: key=min:max[:weight]."
+        ),
     )
     g.add_argument(
         "--curriculum",
@@ -257,24 +380,60 @@ def _run_generate(args: argparse.Namespace) -> int:
             if args.curriculum == CURRICULUM_STAGE_AUTO
             else int(args.curriculum)
         )
+    steering_requested = bool(config.steering.enabled or args.steer_meta or bool(args.meta_target))
+    resolved_target_specs = _resolve_meta_target_specs(config, args.meta_target)
+    if steering_requested:
+        unknown_metrics = _collect_unknown_target_metrics_from_config(config)
+        if unknown_metrics:
+            unknown = ", ".join(unknown_metrics)
+            supported = ", ".join(sorted(META_TARGET_SUPPORTED_METRICS))
+            _raise_usage_error(
+                f"Unsupported steering target metric(s): {unknown}. Supported metrics: {supported}."
+            )
+        incompatible_metrics = _validate_target_specs_for_task(
+            task=str(config.dataset.task),
+            target_specs=resolved_target_specs,
+        )
+        if incompatible_metrics:
+            metrics = ", ".join(incompatible_metrics)
+            _raise_usage_error(
+                "Incompatible --meta-target metrics for regression task: "
+                f"{metrics}. Remove these metrics or switch task=classification."
+            )
+    if resolved_target_specs:
+        config.meta_feature_targets = {
+            metric_name: [lo, hi, weight]
+            for metric_name, (lo, hi, weight) in sorted(resolved_target_specs.items())
+        }
+    elif args.meta_target:
+        config.meta_feature_targets = {}
+    if args.steer_meta or bool(args.meta_target):
+        config.steering.enabled = True
+    if args.diagnostics:
+        config.diagnostics.enabled = True
+
     seed = args.seed if args.seed is not None else config.seed
     out_dir = args.out or config.output.out_dir
-    coverage_enabled = bool(config.diagnostics.enabled or args.coverage)
-    coverage_out_dir: Path | None = None
-    coverage_aggregator: CoverageAggregator | None = None
-    if coverage_enabled:
-        coverage_root = args.coverage_out_dir or config.diagnostics.out_dir or out_dir
-        if coverage_root is None:
-            coverage_root = "coverage_artifacts"
-        coverage_out_dir = Path(coverage_root)
-        coverage_aggregator = CoverageAggregator(
+    diagnostics_enabled = bool(config.diagnostics.enabled)
+    diagnostics_out_dir: Path | None = None
+    diagnostics_aggregator: CoverageAggregator | None = None
+    if diagnostics_enabled:
+        diagnostics_root = args.diagnostics_out_dir or config.diagnostics.out_dir or out_dir
+        if diagnostics_root is None:
+            diagnostics_root = "diagnostics_artifacts"
+        diagnostics_out_dir = Path(diagnostics_root)
+        diagnostics_aggregator = CoverageAggregator(
             CoverageAggregationConfig(
                 include_spearman=bool(config.diagnostics.include_spearman),
                 histogram_bins=int(config.diagnostics.histogram_bins),
                 quantiles=_coerce_quantiles(config.diagnostics.quantiles),
                 underrepresented_threshold=float(config.diagnostics.underrepresented_threshold),
-                target_bands=_coerce_target_bands(config.diagnostics.meta_feature_targets),
+                target_bands=_target_specs_to_bands(resolved_target_specs),
             )
+        )
+    if bool(config.steering.enabled) and not resolved_target_specs:
+        print(
+            "Steering enabled but no valid meta-feature targets were resolved; steering is a no-op."
         )
     print(
         f"Hardware backend={hw.backend} device='{hw.device_name}' "
@@ -287,28 +446,28 @@ def _run_generate(args: argparse.Namespace) -> int:
         seed=seed,
         device=args.device,
     )
-    if coverage_aggregator is not None:
+    if diagnostics_aggregator is not None:
         base_stream = stream
 
-        def _stream_with_coverage():
+        def _stream_with_diagnostics():
             for bundle in base_stream:
-                coverage_aggregator.update_bundle(bundle)
+                diagnostics_aggregator.update_bundle(bundle)
                 yield bundle
 
-        stream = _stream_with_coverage()
+        stream = _stream_with_diagnostics()
 
     if args.no_write:
         generated = sum(1 for _ in stream)
-        if coverage_aggregator is not None:
-            assert coverage_out_dir is not None
-            summary = coverage_aggregator.build_summary()
+        if diagnostics_aggregator is not None:
+            assert diagnostics_out_dir is not None
+            summary = diagnostics_aggregator.build_summary()
             json_path = write_coverage_summary_json(
-                summary, coverage_out_dir / "coverage_summary.json"
+                summary, diagnostics_out_dir / "coverage_summary.json"
             )
             md_path = write_coverage_summary_markdown(
-                summary, coverage_out_dir / "coverage_summary.md"
+                summary, diagnostics_out_dir / "coverage_summary.md"
             )
-            print(f"Wrote coverage artifacts: {json_path} and {md_path}")
+            print(f"Wrote diagnostics artifacts: {json_path} and {md_path}")
         print(f"Generated {generated} datasets (no-write mode).")
         return 0
 
@@ -318,12 +477,16 @@ def _run_generate(args: argparse.Namespace) -> int:
         shard_size=config.output.shard_size,
         compression=config.output.compression,
     )
-    if coverage_aggregator is not None:
-        assert coverage_out_dir is not None
-        summary = coverage_aggregator.build_summary()
-        json_path = write_coverage_summary_json(summary, coverage_out_dir / "coverage_summary.json")
-        md_path = write_coverage_summary_markdown(summary, coverage_out_dir / "coverage_summary.md")
-        print(f"Wrote coverage artifacts: {json_path} and {md_path}")
+    if diagnostics_aggregator is not None:
+        assert diagnostics_out_dir is not None
+        summary = diagnostics_aggregator.build_summary()
+        json_path = write_coverage_summary_json(
+            summary, diagnostics_out_dir / "coverage_summary.json"
+        )
+        md_path = write_coverage_summary_markdown(
+            summary, diagnostics_out_dir / "coverage_summary.md"
+        )
+        print(f"Wrote diagnostics artifacts: {json_path} and {md_path}")
     print(f"Wrote {written} datasets to: {Path(out_dir)}")
     return 0
 

--- a/src/cauchy_generator/config.py
+++ b/src/cauchy_generator/config.py
@@ -89,6 +89,13 @@ class DiagnosticsConfig:
 
 
 @dataclass(slots=True)
+class SteeringConfig:
+    enabled: bool = False
+    max_attempts: int = 3
+    temperature: float = 0.35
+
+
+@dataclass(slots=True)
 class BenchmarkConfig:
     profile_name: str = "medium_cuda"
     num_datasets: int = 2000
@@ -127,11 +134,13 @@ class FilterConfig:
 class GeneratorConfig:
     seed: int = 1
     curriculum_stage: str | int = CURRICULUM_STAGE_DEFAULT
+    meta_feature_targets: dict[str, list[float] | tuple[float, ...]] = field(default_factory=dict)
     dataset: DatasetConfig = field(default_factory=DatasetConfig)
     graph: GraphConfig = field(default_factory=GraphConfig)
     runtime: RuntimeConfig = field(default_factory=RuntimeConfig)
     output: OutputConfig = field(default_factory=OutputConfig)
     diagnostics: DiagnosticsConfig = field(default_factory=DiagnosticsConfig)
+    steering: SteeringConfig = field(default_factory=SteeringConfig)
     benchmark: BenchmarkConfig = field(default_factory=BenchmarkConfig)
     filter: FilterConfig = field(default_factory=FilterConfig)
 
@@ -150,18 +159,23 @@ class GeneratorConfig:
         runtime = RuntimeConfig(**(data.get("runtime") or {}))
         output = OutputConfig(**(data.get("output") or {}))
         diagnostics = DiagnosticsConfig(**(data.get("diagnostics") or {}))
+        steering = SteeringConfig(**(data.get("steering") or {}))
         benchmark = BenchmarkConfig(**(data.get("benchmark") or {}))
         filter_cfg = FilterConfig(**(data.get("filter") or {}))
+        raw_meta_targets = data.get("meta_feature_targets")
+        meta_feature_targets = dict(raw_meta_targets) if isinstance(raw_meta_targets, dict) else {}
         seed = int(data.get("seed", 1))
         curriculum_stage: str | int = data.get("curriculum_stage", CURRICULUM_STAGE_DEFAULT)
         return cls(
             seed=seed,
             curriculum_stage=curriculum_stage,
+            meta_feature_targets=meta_feature_targets,
             dataset=dataset,
             graph=graph,
             runtime=runtime,
             output=output,
             diagnostics=diagnostics,
+            steering=steering,
             benchmark=benchmark,
             filter=filter_cfg,
         )

--- a/src/cauchy_generator/core/dataset.py
+++ b/src/cauchy_generator/core/dataset.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-from dataclasses import asdict
+from dataclasses import asdict, fields
+import math
 from typing import Any
 
 import numpy as np
@@ -23,6 +24,8 @@ from cauchy_generator.core.node_pipeline import (
 )
 from cauchy_generator.filtering import apply_torch_rf_filter
 from cauchy_generator.graph import sample_cauchy_dag
+from cauchy_generator.diagnostics import extract_dataset_metrics
+from cauchy_generator.diagnostics.types import DatasetMetrics
 from cauchy_generator.postprocess import postprocess_dataset
 from cauchy_generator.rng import SeedManager
 from cauchy_generator.sampling import CorrelatedSampler
@@ -38,6 +41,12 @@ _CURRICULUM_STAGE1_TRAIN_FRACTION_MAX = 0.90
 _CURRICULUM_STAGE23_TRAIN_FRACTION = 0.80
 _DEFAULT_CONFIGURED_N_TRAIN = int(DatasetConfig().n_train)
 _DEFAULT_CONFIGURED_N_TEST = int(DatasetConfig().n_test)
+_STEERING_SUPPORTED_METRICS = frozenset(
+    field_info.name for field_info in fields(DatasetMetrics) if field_info.name != "task"
+)
+_STEERING_CLASSIFICATION_ONLY_METRICS = frozenset(
+    {"class_entropy", "majority_minority_ratio", "n_classes"}
+)
 
 
 def _sample_log_uniform_int(rng: np.random.Generator, low: int, high: int) -> int:
@@ -549,6 +558,297 @@ def _generate_one_seeded(
     )
 
 
+def _coerce_meta_target_specs(raw: object) -> dict[str, tuple[float, float, float]]:
+    """Normalize target specs into `(min, max, weight)` tuples."""
+
+    normalized: dict[str, tuple[float, float, float]] = {}
+    if not isinstance(raw, dict):
+        return normalized
+    for metric_name, value in raw.items():
+        if not isinstance(metric_name, str) or metric_name not in _STEERING_SUPPORTED_METRICS:
+            continue
+        if not isinstance(value, (list, tuple)) or len(value) not in {2, 3}:
+            continue
+        try:
+            lo = float(value[0])
+            hi = float(value[1])
+            weight = float(value[2]) if len(value) == 3 else 1.0
+        except (TypeError, ValueError):
+            continue
+        if not (math.isfinite(lo) and math.isfinite(hi) and math.isfinite(weight)):
+            continue
+        if weight <= 0:
+            continue
+        if lo > hi:
+            lo, hi = hi, lo
+        normalized[metric_name] = (lo, hi, weight)
+    return normalized
+
+
+def _resolve_meta_target_specs(config: GeneratorConfig) -> dict[str, tuple[float, float, float]]:
+    """Merge target specs from legacy diagnostics and top-level config."""
+
+    merged = _coerce_meta_target_specs(config.diagnostics.meta_feature_targets)
+    merged.update(_coerce_meta_target_specs(config.meta_feature_targets))
+    return merged
+
+
+def _collect_unknown_steering_target_metrics(config: GeneratorConfig) -> tuple[str, ...]:
+    """Collect unsupported steering target keys from config payloads."""
+
+    unknown: set[str] = set()
+    for raw in (config.diagnostics.meta_feature_targets, config.meta_feature_targets):
+        if not isinstance(raw, dict):
+            continue
+        for metric_name in raw:
+            if isinstance(metric_name, str) and metric_name not in _STEERING_SUPPORTED_METRICS:
+                unknown.add(metric_name)
+    return tuple(sorted(unknown))
+
+
+def _validate_target_specs_for_task(
+    *,
+    task: str,
+    target_specs: dict[str, tuple[float, float, float]],
+) -> tuple[str, ...]:
+    """Return steering metrics that are incompatible with configured task."""
+
+    if task.strip().lower() != "regression":
+        return ()
+    incompatible = sorted(set(target_specs).intersection(_STEERING_CLASSIFICATION_ONLY_METRICS))
+    return tuple(incompatible)
+
+
+def _resolve_auto_stage(mode: str | int, *, seed: int) -> int:
+    """Resolve curriculum auto stage for a deterministic dataset seed."""
+
+    if mode == CURRICULUM_STAGE_AUTO:
+        stage_rng = SeedManager(seed).numpy_rng("curriculum", "stage")
+        return _sample_auto_stage(stage_rng)
+    if isinstance(mode, int):
+        return mode
+    return 1
+
+
+def _resolve_steering_settings(
+    config: GeneratorConfig,
+) -> tuple[bool, dict[str, tuple[float, float, float]], int, float, bool]:
+    """Resolve steering policy and validate runtime knobs when enabled."""
+
+    unknown_metrics = _collect_unknown_steering_target_metrics(config)
+    target_specs = _resolve_meta_target_specs(config)
+    enabled = bool(config.steering.enabled and target_specs)
+    max_attempts = max(1, int(config.steering.max_attempts))
+    temperature = float(config.steering.temperature)
+    if bool(config.steering.enabled):
+        if unknown_metrics:
+            unknown = ", ".join(unknown_metrics)
+            supported = ", ".join(sorted(_STEERING_SUPPORTED_METRICS))
+            raise ValueError(
+                f"Unsupported steering target metric(s): {unknown}. Supported metrics: {supported}."
+            )
+        incompatible = _validate_target_specs_for_task(
+            task=str(config.dataset.task),
+            target_specs=target_specs,
+        )
+        if incompatible:
+            metrics = ", ".join(incompatible)
+            raise ValueError(
+                "Incompatible steering target metrics for regression task: "
+                f"{metrics}. Remove these metrics or switch task=classification."
+            )
+        if int(config.steering.max_attempts) <= 0:
+            raise ValueError(
+                f"steering.max_attempts must be >= 1, got {config.steering.max_attempts!r}."
+            )
+        if not math.isfinite(temperature) or temperature <= 0:
+            raise ValueError(
+                f"steering.temperature must be a finite value > 0, got {temperature!r}."
+            )
+    include_spearman = bool(
+        "spearman_abs_mean" in target_specs or "spearman_abs_max" in target_specs
+    )
+    return enabled, target_specs, max_attempts, temperature, include_spearman
+
+
+def _distance_to_band(value: float, *, lo: float, hi: float) -> tuple[float, bool]:
+    """Return normalized distance to a target band and in-band flag."""
+
+    width = max(1e-6, hi - lo)
+    if value < lo:
+        return (lo - value) / width, False
+    if value > hi:
+        return (value - hi) / width, False
+    return 0.0, True
+
+
+def _score_candidate_against_targets(
+    *,
+    metrics: Any,
+    target_specs: dict[str, tuple[float, float, float]],
+    steering_state: dict[str, dict[str, int]],
+) -> tuple[float, dict[str, bool], dict[str, float | None]]:
+    """Score one candidate against target bands with under-coverage weighting."""
+
+    score_sum = 0.0
+    weight_sum = 0.0
+    in_band_flags: dict[str, bool] = {}
+    metric_values: dict[str, float | None] = {}
+    for metric_name, (lo, hi, base_weight) in sorted(target_specs.items()):
+        state = steering_state[metric_name]
+        selected_count = int(state["selected"])
+        in_band_count = int(state["in_band"])
+        in_band_fraction = float(in_band_count / selected_count) if selected_count > 0 else 0.0
+        under_coverage = max(0.0, 1.0 - in_band_fraction)
+        effective_weight = float(base_weight) * (1.0 + under_coverage)
+
+        raw_value = getattr(metrics, metric_name, None)
+        value = float(raw_value) if isinstance(raw_value, (int, float)) else None
+        if value is not None and not math.isfinite(value):
+            value = None
+
+        if value is None:
+            distance = 1.0
+            in_band = False
+        else:
+            distance, in_band = _distance_to_band(value, lo=lo, hi=hi)
+        in_band_flags[metric_name] = in_band
+        metric_values[metric_name] = value
+        score_sum += effective_weight * distance
+        weight_sum += effective_weight
+
+    score = score_sum / weight_sum if weight_sum > 0 else 0.0
+    return float(score), in_band_flags, metric_values
+
+
+def _select_softmax_candidate(
+    scores: list[float],
+    *,
+    temperature: float,
+    seed: int,
+) -> tuple[int, list[float]]:
+    """Sample one candidate index using a deterministic softmax selector."""
+
+    if not scores:
+        raise ValueError("Cannot select steering candidate from an empty score set.")
+    if len(scores) == 1:
+        return 0, [1.0]
+    score_arr = np.asarray(scores, dtype=np.float64)
+    shifted = score_arr - float(np.min(score_arr))
+    logits = -(shifted / float(temperature))
+    logits = logits - float(np.max(logits))
+    probs = np.exp(logits)
+    prob_sum = float(np.sum(probs))
+    if not math.isfinite(prob_sum) or prob_sum <= 0:
+        probs = np.full(score_arr.shape[0], 1.0 / score_arr.shape[0], dtype=np.float64)
+    else:
+        probs = probs / prob_sum
+    selector_rng = SeedManager(seed).numpy_rng("steering", "select")
+    idx = int(selector_rng.choice(np.arange(score_arr.shape[0]), p=probs))
+    return idx, probs.tolist()
+
+
+def _target_payload(
+    target_specs: dict[str, tuple[float, float, float]],
+) -> dict[str, dict[str, float]]:
+    """Build a JSON-safe target payload for steering metadata."""
+
+    return {
+        metric_name: {"min": lo, "max": hi, "weight": weight}
+        for metric_name, (lo, hi, weight) in sorted(target_specs.items())
+    }
+
+
+def _generate_one_steered(
+    config: GeneratorConfig,
+    *,
+    seed: int,
+    requested_device: str,
+    resolved_device: str,
+    mode: str | int,
+    target_specs: dict[str, tuple[float, float, float]],
+    max_attempts: int,
+    temperature: float,
+    include_spearman: bool,
+    steering_state: dict[str, dict[str, int]],
+) -> DatasetBundle:
+    """Generate bounded steering candidates and soft-select one deterministically."""
+
+    seed_manager = SeedManager(seed)
+    candidate_bundles: list[DatasetBundle] = []
+    candidate_seeds: list[int] = []
+    candidate_scores: list[float] = []
+    candidate_in_band: list[dict[str, bool]] = []
+    candidate_metric_values: list[dict[str, float | None]] = []
+    last_error = "unknown"
+
+    for candidate_idx in range(max_attempts):
+        candidate_seed = (
+            seed
+            if candidate_idx == 0
+            else seed_manager.child("steering", "candidate", candidate_idx)
+        )
+        auto_stage = _resolve_auto_stage(mode, seed=candidate_seed)
+        try:
+            bundle = _generate_one_seeded(
+                config,
+                seed=candidate_seed,
+                requested_device=requested_device,
+                resolved_device=resolved_device,
+                auto_stage=auto_stage,
+            )
+            metrics = extract_dataset_metrics(bundle, include_spearman=include_spearman)
+        except Exception as exc:
+            last_error = f"{exc.__class__.__name__}: {exc}"
+            continue
+        score, in_band_flags, metric_values = _score_candidate_against_targets(
+            metrics=metrics,
+            target_specs=target_specs,
+            steering_state=steering_state,
+        )
+        candidate_bundles.append(bundle)
+        candidate_seeds.append(candidate_seed)
+        candidate_scores.append(score)
+        candidate_in_band.append(in_band_flags)
+        candidate_metric_values.append(metric_values)
+
+    if not candidate_bundles:
+        raise ValueError(
+            "Steering failed to produce a valid candidate after "
+            f"{max_attempts} attempts. Last error: {last_error}"
+        )
+
+    selected_idx, probabilities = _select_softmax_candidate(
+        candidate_scores,
+        temperature=temperature,
+        seed=seed,
+    )
+    selected_bundle = candidate_bundles[selected_idx]
+    selected_in_band = candidate_in_band[selected_idx]
+    for metric_name, in_band in selected_in_band.items():
+        state = steering_state[metric_name]
+        state["selected"] += 1
+        if in_band:
+            state["in_band"] += 1
+
+    selected_bundle.metadata["steering"] = {
+        "enabled": True,
+        "max_attempts": int(max_attempts),
+        "temperature": float(temperature),
+        "candidate_count": len(candidate_bundles),
+        "candidate_seeds": candidate_seeds,
+        "scores": [float(score) for score in candidate_scores],
+        "probabilities": [float(prob) for prob in probabilities],
+        "selected_candidate_index": int(selected_idx),
+        "selected_candidate_seed": int(candidate_seeds[selected_idx]),
+        "selected_score": float(candidate_scores[selected_idx]),
+        "selected_in_band": dict(sorted(selected_in_band.items())),
+        "selected_metric_values": dict(sorted(candidate_metric_values[selected_idx].items())),
+        "targets": _target_payload(target_specs),
+    }
+    return selected_bundle
+
+
 def generate_one(
     config: GeneratorConfig,
     *,
@@ -558,12 +858,36 @@ def generate_one(
     """Generate one dataset bundle with deterministic per-dataset randomness."""
 
     mode = normalize_curriculum_stage(config.curriculum_stage)
+    (
+        steering_enabled,
+        target_specs,
+        steering_max_attempts,
+        steering_temperature,
+        steering_include_spearman,
+    ) = _resolve_steering_settings(config)
     auto_stage = 1
     if isinstance(mode, int):
         auto_stage = mode
     run_seed = seed if seed is not None else config.seed
     requested_device = (device or config.runtime.device or "auto").lower()
     resolved_device = _resolve_device(config, device)
+    if steering_enabled:
+        steering_mode: str | int = 1 if mode == CURRICULUM_STAGE_AUTO else mode
+        steering_state = {
+            metric_name: {"selected": 0, "in_band": 0} for metric_name in sorted(target_specs)
+        }
+        return _generate_one_steered(
+            config,
+            seed=run_seed,
+            requested_device=requested_device,
+            resolved_device=resolved_device,
+            mode=steering_mode,
+            target_specs=target_specs,
+            max_attempts=steering_max_attempts,
+            temperature=steering_temperature,
+            include_spearman=steering_include_spearman,
+            steering_state=steering_state,
+        )
     return _generate_one_seeded(
         config,
         seed=run_seed,
@@ -609,19 +933,39 @@ def generate_batch_iter(
     mode = normalize_curriculum_stage(config.curriculum_stage)
     requested_device = (device or config.runtime.device or "auto").lower()
     resolved_device = _resolve_device(config, device)
+    (
+        steering_enabled,
+        target_specs,
+        steering_max_attempts,
+        steering_temperature,
+        steering_include_spearman,
+    ) = _resolve_steering_settings(config)
+    steering_state = {
+        metric_name: {"selected": 0, "in_band": 0} for metric_name in sorted(target_specs)
+    }
     run_seed = seed if seed is not None else config.seed
     manager = SeedManager(run_seed)
     for i in range(num_datasets):
         dataset_seed = manager.child("dataset", i)
-        auto_stage = 1
-        if mode == CURRICULUM_STAGE_AUTO:
-            stage_rng = SeedManager(dataset_seed).numpy_rng("curriculum", "stage")
-            auto_stage = _sample_auto_stage(stage_rng)
+        if steering_enabled:
+            yield _generate_one_steered(
+                config,
+                seed=dataset_seed,
+                requested_device=requested_device,
+                resolved_device=resolved_device,
+                mode=mode,
+                target_specs=target_specs,
+                max_attempts=steering_max_attempts,
+                temperature=steering_temperature,
+                include_spearman=steering_include_spearman,
+                steering_state=steering_state,
+            )
+            continue
 
         yield _generate_one_seeded(
             config,
             seed=dataset_seed,
             requested_device=requested_device,
             resolved_device=resolved_device,
-            auto_stage=auto_stage,
+            auto_stage=_resolve_auto_stage(mode, seed=dataset_seed),
         )

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -236,3 +236,169 @@ def test_generate_cli_no_write_allows_null_output_dir_when_coverage_disabled(
         ]
     )
     assert code == 0
+
+
+def test_generate_cli_enables_diagnostics_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _stub_generate_batch_iter(
+        config,
+        *,
+        num_datasets: int,
+        seed: int | None = None,
+        device: str | None = None,
+    ):
+        captured["diagnostics_enabled"] = config.diagnostics.enabled
+        _ = seed
+        _ = device
+        for _ in range(num_datasets):
+            yield object()
+
+    monkeypatch.setattr("cauchy_generator.cli.generate_batch_iter", _stub_generate_batch_iter)
+    monkeypatch.setattr(
+        "cauchy_generator.cli.CoverageAggregator.update_bundle",
+        lambda self, _bundle: None,
+    )
+    code = main(
+        [
+            "generate",
+            "--config",
+            "configs/default.yaml",
+            "--num-datasets",
+            "1",
+            "--device",
+            "cpu",
+            "--diagnostics",
+            "--no-hardware-aware",
+            "--no-write",
+        ]
+    )
+    assert code == 0
+    assert captured["diagnostics_enabled"] is True
+
+
+def test_generate_cli_applies_meta_target_override_and_enables_steering(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _stub_generate_batch_iter(
+        config,
+        *,
+        num_datasets: int,
+        seed: int | None = None,
+        device: str | None = None,
+    ):
+        captured["steering_enabled"] = config.steering.enabled
+        captured["meta_feature_targets"] = config.meta_feature_targets
+        _ = seed
+        _ = device
+        for _ in range(num_datasets):
+            yield object()
+
+    monkeypatch.setattr("cauchy_generator.cli.generate_batch_iter", _stub_generate_batch_iter)
+
+    code = main(
+        [
+            "generate",
+            "--config",
+            "configs/default.yaml",
+            "--num-datasets",
+            "1",
+            "--device",
+            "cpu",
+            "--meta-target",
+            "linearity_proxy=0.2:0.8:2.5",
+            "--no-hardware-aware",
+            "--no-write",
+        ]
+    )
+    assert code == 0
+    assert captured["steering_enabled"] is True
+    assert captured["meta_feature_targets"]["linearity_proxy"] == [0.2, 0.8, 2.5]
+
+
+@pytest.mark.parametrize(
+    "meta_target",
+    [
+        "linearity_proxy",
+        "linearity_proxy=0.2",
+        "linearity_proxy=low:0.8",
+        "linearity_proxy=0.2:0.8:0",
+        "linearity_proxy=0.2:0.8:-1",
+        "linearity_proxy=0.2:0.8:inf",
+        "unknown_metric=0.1:0.9",
+    ],
+)
+def test_generate_cli_rejects_invalid_meta_target_override(meta_target: str) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main(
+            [
+                "generate",
+                "--config",
+                "configs/default.yaml",
+                "--num-datasets",
+                "1",
+                "--meta-target",
+                meta_target,
+                "--no-write",
+            ]
+        )
+    assert int(exc.value.code) == 2
+
+
+def test_generate_cli_rejects_task_incompatible_meta_target(
+    tmp_path,
+) -> None:
+    cfg = GeneratorConfig.from_yaml("configs/default.yaml")
+    cfg.dataset.task = "regression"
+    config_path = tmp_path / "regression.yaml"
+    config_path.write_text(yaml.safe_dump(cfg.to_dict()), encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        main(
+            [
+                "generate",
+                "--config",
+                str(config_path),
+                "--num-datasets",
+                "1",
+                "--meta-target",
+                "class_entropy=0.2:1.0",
+                "--no-write",
+            ]
+        )
+    assert int(exc.value.code) == 2
+
+
+def test_generate_cli_rejects_unknown_config_target_key_when_steering_enabled(
+    tmp_path,
+) -> None:
+    cfg = GeneratorConfig.from_yaml("configs/default.yaml")
+    cfg.dataset.task = "regression"
+    cfg.runtime.device = "cpu"
+    cfg.steering.enabled = True
+    cfg.meta_feature_targets = {
+        "linearity_proxy": [0.2, 0.8, 1.0],
+        "linarity_proxy": [0.2, 0.8, 1.0],
+    }
+    config_path = tmp_path / "unknown_target.yaml"
+    config_path.write_text(yaml.safe_dump(cfg.to_dict()), encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc:
+        main(
+            [
+                "generate",
+                "--config",
+                str(config_path),
+                "--num-datasets",
+                "1",
+                "--device",
+                "cpu",
+                "--no-hardware-aware",
+                "--no-write",
+            ]
+        )
+    assert int(exc.value.code) == 2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,11 +6,15 @@ from cauchy_generator.config import GeneratorConfig
 def test_load_default_config() -> None:
     cfg = GeneratorConfig.from_yaml("configs/default.yaml")
     assert cfg.curriculum_stage == "off"
+    assert cfg.meta_feature_targets == {}
     assert cfg.dataset.n_train > 0
     assert cfg.dataset.n_features_min <= cfg.dataset.n_features_max
     assert cfg.output.shard_size > 0
     assert cfg.diagnostics.enabled is False
     assert cfg.diagnostics.histogram_bins > 0
+    assert cfg.steering.enabled is False
+    assert cfg.steering.max_attempts == 3
+    assert cfg.steering.temperature > 0
     assert cfg.filter.n_trees > 0
     assert cfg.filter.depth >= 0
     assert cfg.filter.max_features == "auto"
@@ -45,6 +49,9 @@ def test_runtime_config_from_dict() -> None:
     cfg = GeneratorConfig.from_dict(
         {
             "curriculum_stage": 2,
+            "meta_feature_targets": {
+                "linearity_proxy": [0.1, 0.9, 1.5],
+            },
             "runtime": {
                 "device": "cpu",
                 "torch_dtype": "float64",
@@ -56,14 +63,22 @@ def test_runtime_config_from_dict() -> None:
                     "linearity_proxy": [0.2, 0.8],
                 },
             },
+            "steering": {
+                "enabled": True,
+                "max_attempts": 4,
+                "temperature": 0.25,
+            },
         }
     )
     assert cfg.curriculum_stage == 2
+    assert cfg.meta_feature_targets["linearity_proxy"] == [0.1, 0.9, 1.5]
     assert cfg.runtime.device == "cpu"
     assert cfg.runtime.torch_dtype == "float64"
     assert cfg.diagnostics.enabled is True
     assert cfg.diagnostics.histogram_bins == 12
     assert "linearity_proxy" in cfg.diagnostics.meta_feature_targets
+    assert cfg.steering.enabled is True
+    assert cfg.steering.max_attempts == 4
 
 
 def test_legacy_filter_keys_are_rejected() -> None:

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -1,0 +1,129 @@
+import numpy as np
+import pytest
+
+from cauchy_generator.config import GeneratorConfig
+from cauchy_generator.core.dataset import generate_batch, generate_one
+
+
+def _tiny_steering_config() -> GeneratorConfig:
+    cfg = GeneratorConfig.from_yaml("configs/default.yaml")
+    cfg.runtime.device = "cpu"
+    cfg.dataset.task = "regression"
+    cfg.dataset.n_train = 32
+    cfg.dataset.n_test = 16
+    cfg.dataset.n_features_min = 8
+    cfg.dataset.n_features_max = 16
+    cfg.graph.n_nodes_min = 2
+    cfg.graph.n_nodes_max = 6
+    cfg.filter.enabled = False
+    return cfg
+
+
+def _in_band_fraction(batch: list, *, lo: int, hi: int) -> float:
+    count = sum(1 for bundle in batch if lo <= int(bundle.metadata["n_features"]) <= hi)
+    return float(count / len(batch)) if batch else 0.0
+
+
+def test_steering_is_deterministic_and_bounded() -> None:
+    cfg = _tiny_steering_config()
+    cfg.meta_feature_targets = {"n_features": [12, 12, 1.0]}
+    cfg.steering.enabled = True
+    cfg.steering.max_attempts = 4
+    cfg.steering.temperature = 0.25
+
+    batch_a = generate_batch(cfg, num_datasets=4, seed=2026, device="cpu")
+    batch_b = generate_batch(cfg, num_datasets=4, seed=2026, device="cpu")
+
+    for bundle_a, bundle_b in zip(batch_a, batch_b, strict=True):
+        np.testing.assert_allclose(
+            np.asarray(bundle_a.X_train), np.asarray(bundle_b.X_train), atol=1e-6
+        )
+        assert bundle_a.metadata["seed"] == bundle_b.metadata["seed"]
+        steering_a = bundle_a.metadata["steering"]
+        steering_b = bundle_b.metadata["steering"]
+        assert steering_a == steering_b
+        assert steering_a["enabled"] is True
+        assert 1 <= int(steering_a["candidate_count"]) <= cfg.steering.max_attempts
+        assert int(steering_a["selected_candidate_index"]) < int(steering_a["candidate_count"])
+        assert "targets" in steering_a
+
+
+def test_steering_improves_target_band_coverage_vs_baseline() -> None:
+    baseline_cfg = _tiny_steering_config()
+    baseline_cfg.meta_feature_targets = {"n_features": [12, 12, 1.0]}
+    baseline_cfg.steering.enabled = False
+
+    steered_cfg = _tiny_steering_config()
+    steered_cfg.meta_feature_targets = {"n_features": [12, 12, 1.0]}
+    steered_cfg.steering.enabled = True
+    steered_cfg.steering.max_attempts = 5
+    steered_cfg.steering.temperature = 0.2
+
+    baseline = generate_batch(baseline_cfg, num_datasets=20, seed=77, device="cpu")
+    steered = generate_batch(steered_cfg, num_datasets=20, seed=77, device="cpu")
+
+    baseline_fraction = _in_band_fraction(baseline, lo=12, hi=12)
+    steered_fraction = _in_band_fraction(steered, lo=12, hi=12)
+    assert steered_fraction >= baseline_fraction + 0.10
+
+
+def test_non_steered_generation_ignores_meta_targets() -> None:
+    cfg_plain = _tiny_steering_config()
+    cfg_plain.steering.enabled = False
+
+    cfg_targets = _tiny_steering_config()
+    cfg_targets.meta_feature_targets = {"linearity_proxy": [0.1, 0.9, 1.0]}
+    cfg_targets.steering.enabled = False
+
+    batch_plain = generate_batch(cfg_plain, num_datasets=3, seed=15, device="cpu")
+    batch_targets = generate_batch(cfg_targets, num_datasets=3, seed=15, device="cpu")
+
+    for plain, with_targets in zip(batch_plain, batch_targets, strict=True):
+        np.testing.assert_allclose(
+            np.asarray(plain.X_train),
+            np.asarray(with_targets.X_train),
+            atol=1e-6,
+            rtol=1e-6,
+        )
+        assert plain.metadata["seed"] == with_targets.metadata["seed"]
+        assert "steering" not in plain.metadata
+        assert "steering" not in with_targets.metadata
+
+
+def test_generate_one_emits_steering_metadata_when_enabled() -> None:
+    cfg = _tiny_steering_config()
+    cfg.meta_feature_targets = {"linearity_proxy": [0.2, 0.8, 1.0]}
+    cfg.steering.enabled = True
+
+    bundle = generate_one(cfg, seed=123, device="cpu")
+    steering = bundle.metadata["steering"]
+    assert steering["enabled"] is True
+    assert int(steering["candidate_count"]) >= 1
+    assert "targets" in steering
+
+
+def test_generate_batch_rejects_unknown_steering_metric() -> None:
+    cfg = _tiny_steering_config()
+    cfg.meta_feature_targets = {"typo_metric": [0.2, 0.8, 1.0]}
+    cfg.steering.enabled = True
+
+    with pytest.raises(ValueError, match="Unsupported steering target metric"):
+        generate_batch(cfg, num_datasets=2, seed=11, device="cpu")
+
+
+def test_generate_batch_rejects_unknown_legacy_diagnostics_target() -> None:
+    cfg = _tiny_steering_config()
+    cfg.diagnostics.meta_feature_targets = {"bad_metric": [0.2, 0.8]}
+    cfg.steering.enabled = True
+
+    with pytest.raises(ValueError, match="bad_metric"):
+        generate_batch(cfg, num_datasets=2, seed=12, device="cpu")
+
+
+def test_generate_one_rejects_task_incompatible_steering_metric() -> None:
+    cfg = _tiny_steering_config()
+    cfg.meta_feature_targets = {"class_entropy": [0.2, 1.0, 1.0]}
+    cfg.steering.enabled = True
+
+    with pytest.raises(ValueError, match="class_entropy"):
+        generate_one(cfg, seed=13, device="cpu")


### PR DESCRIPTION
## Summary
- add opt-in soft steering in generation with bounded deterministic candidate attempts and temperature-based softmax selection
- add new config and CLI surfaces for diagnostics + steering (`GeneratorConfig.meta_feature_targets`, `SteeringConfig`, `--diagnostics`, `--steer-meta`, repeatable `--meta-target`)
- merge legacy diagnostics targets with top-level targets (top-level + CLI override precedence)
- enforce strict validation in both CLI and core APIs for malformed, unsupported, and task-incompatible target metrics
- propagate steering metadata on generated bundles and update docs/changelog

## Validation
- `uv run ruff check src tests`
- `uv run pytest -q` (`180 passed`)

## Context
- implements #12
- parent epic: #9
- depends on: #11
