### PR TITLE
feat(bench+docs): integrate coverage diagnostics into benchmark workflow and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Opt-in soft meta-feature steering with bounded deterministic candidate selection
 - New generation CLI controls: `--diagnostics`, `--steer-meta`, and repeatable `--meta-target key=min:max[:weight]`
 - Steering metadata payload propagation on generated bundles when steering is enabled
+- Benchmark diagnostics collection controls: `cauchy-gen benchmark --diagnostics [--diagnostics-out-dir ...]`
+- Per-profile benchmark diagnostics artifacts and summary pointers under `diagnostics/<profile>/`
+- New presets: `configs/preset_diagnostics_on.yaml` and `configs/preset_steering_conservative.yaml`
 
 ### Changed
 
 - Added top-level `GeneratorConfig.meta_feature_targets` and `SteeringConfig` with disabled-by-default safe defaults
 - Target resolution now merges legacy `diagnostics.meta_feature_targets` with top-level targets (top-level precedence)
+- Benchmark markdown reports now surface diagnostics state and artifact pointers per profile
+- Script/README benchmark workflow examples now include diagnostics and conservative steering presets
 
 ## [0.1.5] - 2025-02-22
 

--- a/README.md
+++ b/README.md
@@ -68,11 +68,26 @@ uv run cauchy-gen generate \
   --meta-target linearity_proxy=0.25:0.75:1.5
 ```
 
+```bash
+# Use discoverable presets for diagnostics-only and conservative steering runs
+uv run cauchy-gen generate --config configs/preset_diagnostics_on.yaml --num-datasets 25 --diagnostics --out data/run_diag
+uv run cauchy-gen generate --config configs/preset_steering_conservative.yaml --num-datasets 25 --diagnostics --out data/run_steering
+```
+
 ### Benchmarking Performance
 
 ```bash
 # Run the standard benchmark suite across all detected hardware profiles
 uv run cauchy-gen benchmark --suite standard --profile cpu
+```
+
+```bash
+# Collect diagnostics during benchmark runs and emit artifact pointers in summary outputs
+uv run cauchy-gen benchmark \
+  --suite smoke \
+  --profile cpu \
+  --diagnostics \
+  --out-dir benchmarks/results/smoke_cpu_diag
 ```
 
 ______________________________________________________________________

--- a/configs/preset_diagnostics_on.yaml
+++ b/configs/preset_diagnostics_on.yaml
@@ -1,0 +1,23 @@
+seed: 7
+
+dataset:
+  task: classification
+
+runtime:
+  device: auto
+
+output:
+  out_dir: data/run_diagnostics
+
+diagnostics:
+  enabled: true
+  include_spearman: false
+  histogram_bins: 12
+  quantiles: [0.05, 0.25, 0.5, 0.75, 0.95]
+  underrepresented_threshold: 0.5
+  meta_feature_targets:
+    linearity_proxy: [0.2, 0.8]
+    nonlinearity_proxy: [0.1, 0.9]
+
+steering:
+  enabled: false

--- a/configs/preset_steering_conservative.yaml
+++ b/configs/preset_steering_conservative.yaml
@@ -1,0 +1,27 @@
+seed: 11
+
+meta_feature_targets:
+  n_features: [18, 40, 0.8]
+  categorical_ratio: [0.1, 0.55, 0.7]
+  linearity_proxy: [0.2, 0.75, 1.2]
+
+dataset:
+  task: classification
+
+runtime:
+  device: auto
+
+output:
+  out_dir: data/run_steering_conservative
+
+diagnostics:
+  enabled: true
+  include_spearman: false
+  histogram_bins: 10
+  quantiles: [0.05, 0.25, 0.5, 0.75, 0.95]
+  underrepresented_threshold: 0.5
+
+steering:
+  enabled: true
+  max_attempts: 3
+  temperature: 0.25

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cauchy-generator"
-version = "0.1.5"
+version = "0.1.6"
 description = "High-performance synthetic tabular data generator scaffold aligned with TabICLv2 Appendix E."
 readme = "README.md"
 license = "MIT"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,10 +17,10 @@ These wrappers call `uv run cauchy-gen ...` from the repo root.
   - `curriculum` accepts `auto`, `1`, `2`, or `3`.
 - `scripts/fetch-additional-references.sh`
   - Downloads the additional arXiv papers listed in `reference/ADDITIONAL_PAPERS.md`.
-- `scripts/benchmark-suite.sh [suite] [profile] [out_dir]`
-  - Runs `cauchy-gen benchmark` with suite/profile selection.
-- `scripts/benchmark-smoke.sh [profile]`
-  - Quick smoke benchmark for a single profile.
+- `scripts/benchmark-suite.sh [suite] [profile] [out_dir] [diagnostics] [diagnostics_out_dir]`
+  - Runs `cauchy-gen benchmark` with suite/profile selection and optional diagnostics.
+- `scripts/benchmark-smoke.sh [profile] [diagnostics] [diagnostics_out_dir]`
+  - Quick smoke benchmark for a single profile with optional diagnostics.
 - `scripts/bump-version.sh <major|minor|patch> [--dry-run] [--tag]`
   - Bump the semver version in `pyproject.toml`. Use `--tag` to commit and create a git tag.
 
@@ -37,9 +37,18 @@ These wrappers call `uv run cauchy-gen ...` from the repo root.
 ./scripts/generate-curriculum.sh 5 cpu data/run_stage3 123 3
 ./scripts/fetch-additional-references.sh
 ./scripts/benchmark-smoke.sh cpu
+./scripts/benchmark-smoke.sh cpu on benchmarks/results/smoke_diag
 ./scripts/benchmark-suite.sh standard all benchmarks/results/latest
+./scripts/benchmark-suite.sh smoke cpu benchmarks/results/smoke_cpu_diag on
+uv run cauchy-gen generate --config configs/preset_diagnostics_on.yaml --num-datasets 25 --diagnostics --out data/run_diag
+uv run cauchy-gen generate --config configs/preset_steering_conservative.yaml --num-datasets 25 --diagnostics --out data/run_steering
 ./scripts/bump-version.sh patch --dry-run
 ./scripts/bump-version.sh minor --tag
 ```
 
 `benchmark-suite.sh` with profile `all` includes CUDA profiles and will hard-fail if CUDA is unavailable.
+
+When diagnostics is enabled for benchmark scripts, coverage artifacts are written under:
+
+- `<out_dir>/diagnostics/<profile>/coverage_summary.json`
+- `<out_dir>/diagnostics/<profile>/coverage_summary.md`

--- a/scripts/benchmark-smoke.sh
+++ b/scripts/benchmark-smoke.sh
@@ -2,10 +2,20 @@
 set -euo pipefail
 
 PROFILE="${1:-cpu}"
+DIAGNOSTICS="${2:-off}"
+DIAGNOSTICS_OUT_DIR="${3:-}"
 
 if ! command -v uv >/dev/null 2>&1; then
   echo "error: uv not found in PATH" >&2
   exit 1
 fi
 
-uv run cauchy-gen benchmark --suite smoke --profile "$PROFILE"
+args=(benchmark --suite smoke --profile "$PROFILE")
+if [[ "$DIAGNOSTICS" == "on" || "$DIAGNOSTICS" == "true" || "$DIAGNOSTICS" == "1" ]]; then
+  args+=(--diagnostics)
+fi
+if [[ -n "$DIAGNOSTICS_OUT_DIR" ]]; then
+  args+=(--diagnostics-out-dir "$DIAGNOSTICS_OUT_DIR")
+fi
+
+uv run cauchy-gen "${args[@]}"

--- a/scripts/benchmark-suite.sh
+++ b/scripts/benchmark-suite.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 SUITE="${1:-standard}"
 PROFILE="${2:-all}"
 OUT_DIR="${3:-}"
+DIAGNOSTICS="${4:-off}"
+DIAGNOSTICS_OUT_DIR="${5:-}"
 
 if ! command -v uv >/dev/null 2>&1; then
   echo "error: uv not found in PATH" >&2
@@ -13,6 +15,12 @@ fi
 args=(benchmark --suite "$SUITE" --profile "$PROFILE")
 if [[ -n "$OUT_DIR" ]]; then
   args+=(--out-dir "$OUT_DIR")
+fi
+if [[ "$DIAGNOSTICS" == "on" || "$DIAGNOSTICS" == "true" || "$DIAGNOSTICS" == "1" ]]; then
+  args+=(--diagnostics)
+fi
+if [[ -n "$DIAGNOSTICS_OUT_DIR" ]]; then
+  args+=(--diagnostics-out-dir "$DIAGNOSTICS_OUT_DIR")
 fi
 
 uv run cauchy-gen "${args[@]}"

--- a/src/cauchy_generator/bench/report.py
+++ b/src/cauchy_generator/bench/report.py
@@ -34,10 +34,11 @@ def _build_profile_table(profile_results: list[dict[str, Any]]) -> list[str]:
     """Create a markdown table summarizing per-profile performance metrics."""
 
     lines = [
-        "| Profile | Device | Backend | Datasets/min | Elapsed (s) | Latency p95 (ms) | Peak RSS (MB) |",
-        "|---|---|---:|---:|---:|---:|---:|",
+        "| Profile | Device | Backend | Datasets/min | Elapsed (s) | Latency p95 (ms) | Peak RSS (MB) | Diagnostics |",
+        "|---|---|---:|---:|---:|---:|---:|---|",
     ]
     for result in profile_results:
+        diagnostics_state = "on" if bool(result.get("diagnostics_enabled")) else "off"
         lines.append(
             "| "
             f"{result.get('profile_key', '-')} | "
@@ -46,8 +47,31 @@ def _build_profile_table(profile_results: list[dict[str, Any]]) -> list[str]:
             f"{_format_float(result.get('datasets_per_minute'), 2)} | "
             f"{_format_float(result.get('elapsed_seconds'), 3)} | "
             f"{_format_float(result.get('latency_p95_ms'), 2)} | "
-            f"{_format_float(result.get('peak_rss_mb'), 2)} |"
+            f"{_format_float(result.get('peak_rss_mb'), 2)} | "
+            f"{diagnostics_state} |"
         )
+    return lines
+
+
+def _build_diagnostics_table(profile_results: list[dict[str, Any]]) -> list[str]:
+    """Create a markdown table with per-profile diagnostics artifact pointers."""
+
+    lines = [
+        "| Profile | Coverage JSON | Coverage Markdown |",
+        "|---|---|---|",
+    ]
+    for result in profile_results:
+        artifacts = result.get("diagnostics_artifacts")
+        json_path = "-"
+        md_path = "-"
+        if isinstance(artifacts, dict):
+            json_value = artifacts.get("json")
+            md_value = artifacts.get("markdown")
+            if isinstance(json_value, str) and json_value:
+                json_path = f"`{json_value}`"
+            if isinstance(md_value, str) and md_value:
+                md_path = f"`{md_value}`"
+        lines.append(f"| {result.get('profile_key', '-')} | {json_path} | {md_path} |")
     return lines
 
 
@@ -74,6 +98,10 @@ def write_suite_markdown(summary: dict[str, Any], out_path: str | Path) -> Path:
         lines.append("## Profiles")
         lines.extend(_build_profile_table(profile_results))
         lines.append("")
+        if any(bool(result.get("diagnostics_enabled")) for result in profile_results):
+            lines.append("## Diagnostics Artifacts")
+            lines.extend(_build_diagnostics_table(profile_results))
+            lines.append("")
 
     if isinstance(regression, dict) and regression.get("issues"):
         lines.append("## Regression Issues")

--- a/src/cauchy_generator/bench/suite.py
+++ b/src/cauchy_generator/bench/suite.py
@@ -3,13 +3,18 @@
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
+import math
+import re
 import resource
 import sys
 import time
-import torch
+from collections import Counter
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
+import torch
 from cauchy_generator.bench.baseline import compare_summary_to_baseline
 from cauchy_generator.bench.micro import run_microbenchmarks
 from cauchy_generator.bench.metrics import (
@@ -19,6 +24,12 @@ from cauchy_generator.bench.metrics import (
 from cauchy_generator.bench.throughput import run_throughput_benchmark
 from cauchy_generator.config import GeneratorConfig
 from cauchy_generator.core.dataset import generate_batch_iter, generate_one
+from cauchy_generator.diagnostics import (
+    CoverageAggregationConfig,
+    CoverageAggregator,
+    write_coverage_summary_json,
+    write_coverage_summary_markdown,
+)
 from cauchy_generator.hardware import (
     HardwareInfo,
     apply_hardware_profile,
@@ -161,6 +172,68 @@ def _prepare_config_for_profile(
     return cfg, requested_device, hw
 
 
+def _coerce_target_bands(raw: object) -> dict[str, tuple[float, float]]:
+    """Normalize target band mappings into finite `(lo, hi)` tuples."""
+
+    normalized: dict[str, tuple[float, float]] = {}
+    if not isinstance(raw, dict):
+        return normalized
+    for key, value in raw.items():
+        if not isinstance(key, str):
+            continue
+        if not isinstance(value, (list, tuple)) or len(value) < 2:
+            continue
+        try:
+            lo = float(value[0])
+            hi = float(value[1])
+        except (TypeError, ValueError):
+            continue
+        if not (math.isfinite(lo) and math.isfinite(hi)):
+            continue
+        normalized[key] = (lo, hi) if lo <= hi else (hi, lo)
+    return normalized
+
+
+def _resolve_target_bands(config: GeneratorConfig) -> dict[str, tuple[float, float]]:
+    """Merge diagnostics and top-level target mappings for coverage aggregation."""
+
+    merged = _coerce_target_bands(config.diagnostics.meta_feature_targets)
+    merged.update(_coerce_target_bands(config.meta_feature_targets))
+    return merged
+
+
+def _coerce_quantiles(raw: object) -> tuple[float, ...]:
+    """Normalize diagnostics quantiles into finite values."""
+
+    if not isinstance(raw, (list, tuple)):
+        return ()
+    normalized: list[float] = []
+    for item in raw:
+        try:
+            value = float(item)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(value):
+            normalized.append(value)
+    return tuple(normalized)
+
+
+def _sanitize_profile_key(profile_key: str) -> str:
+    """Normalize profile key into a filesystem-safe unique path segment."""
+
+    normalized = re.sub(r"[^A-Za-z0-9._-]+", "_", profile_key).strip("._-")
+    if not normalized:
+        normalized = "profile"
+    suffix = hashlib.sha1(profile_key.encode("utf-8")).hexdigest()[:8]
+    return f"{normalized}_{suffix}"
+
+
+def _artifact_pointer(path: Path) -> str:
+    """Return a summary-safe pointer for diagnostics artifacts."""
+
+    return str(path.resolve())
+
+
 def run_profile_benchmark(
     spec: ProfileRunSpec,
     *,
@@ -171,6 +244,10 @@ def run_profile_benchmark(
     collect_reproducibility: bool,
     include_micro: bool,
     no_hardware_aware: bool,
+    collect_diagnostics: bool,
+    diagnostics_root_dir: Path | None,
+    diagnostics_occurrence_index: int,
+    diagnostics_occurrence_total: int,
 ) -> dict[str, Any]:
     """Run one benchmark profile and collect throughput, latency, and optional diagnostics."""
 
@@ -195,11 +272,27 @@ def run_profile_benchmark(
         except Exception:
             pass
 
+    diagnostics_enabled = bool(collect_diagnostics and diagnostics_root_dir is not None)
+    diagnostics_aggregator: CoverageAggregator | None = None
+    if diagnostics_enabled:
+        diagnostics_aggregator = CoverageAggregator(
+            CoverageAggregationConfig(
+                include_spearman=bool(config.diagnostics.include_spearman),
+                histogram_bins=max(1, int(config.diagnostics.histogram_bins)),
+                quantiles=_coerce_quantiles(config.diagnostics.quantiles),
+                underrepresented_threshold=float(config.diagnostics.underrepresented_threshold),
+                target_bands=_resolve_target_bands(config),
+            )
+        )
+
     result = run_throughput_benchmark(
         config,
         num_datasets=num_datasets,
         warmup_datasets=warmup,
         device=requested_device,
+        on_bundle=(
+            diagnostics_aggregator.update_bundle if diagnostics_aggregator is not None else None
+        ),
     )
     result["profile_key"] = spec.key
     result["suite"] = suite
@@ -209,6 +302,8 @@ def run_profile_benchmark(
     result["hardware_memory_gb"] = hw.total_memory_gb
     result["hardware_peak_flops"] = hw.peak_flops
     result["hardware_profile"] = hw.profile
+    result["diagnostics_enabled"] = diagnostics_enabled
+    result["diagnostics_artifacts"] = None
 
     latency_stats = _collect_latency(
         config,
@@ -239,6 +334,27 @@ def run_profile_benchmark(
 
     if include_micro:
         result.update(run_microbenchmarks(config, device=requested_device, repeats=3))
+
+    if (
+        diagnostics_enabled
+        and diagnostics_aggregator is not None
+        and diagnostics_root_dir is not None
+    ):
+        profile_segment = _sanitize_profile_key(spec.key)
+        if diagnostics_occurrence_total > 1:
+            profile_segment = f"{profile_segment}_run{diagnostics_occurrence_index + 1}"
+        profile_diagnostics_dir = diagnostics_root_dir / "diagnostics" / profile_segment
+        summary = diagnostics_aggregator.build_summary()
+        json_path = write_coverage_summary_json(
+            summary, profile_diagnostics_dir / "coverage_summary.json"
+        )
+        md_path = write_coverage_summary_markdown(
+            summary, profile_diagnostics_dir / "coverage_summary.md"
+        )
+        result["diagnostics_artifacts"] = {
+            "json": _artifact_pointer(json_path),
+            "markdown": _artifact_pointer(md_path),
+        }
 
     return result
 
@@ -301,6 +417,8 @@ def run_benchmark_suite(
     warmup_override: int | None,
     collect_memory: bool,
     collect_reproducibility: bool,
+    collect_diagnostics: bool,
+    diagnostics_root_dir: Path | None,
     fail_on_regression: bool,
     no_hardware_aware: bool,
 ) -> dict[str, Any]:
@@ -309,12 +427,18 @@ def run_benchmark_suite(
     normalized_suite = suite.lower().strip()
     if normalized_suite not in {"smoke", "standard", "full"}:
         raise ValueError(f"Unsupported suite: {suite}")
+    if collect_diagnostics and diagnostics_root_dir is None:
+        raise ValueError("Benchmark diagnostics collection requires a diagnostics_root_dir.")
 
     include_micro = normalized_suite == "full"
     enable_repro = collect_reproducibility or normalized_suite == "full"
+    key_totals: Counter[str] = Counter(spec.key for spec in profile_specs)
+    key_seen: dict[str, int] = {}
 
     profile_results: list[dict[str, Any]] = []
     for spec in profile_specs:
+        occurrence_index = key_seen.get(spec.key, 0)
+        key_seen[spec.key] = occurrence_index + 1
         profile_results.append(
             run_profile_benchmark(
                 spec,
@@ -323,8 +447,12 @@ def run_benchmark_suite(
                 warmup_override=warmup_override,
                 collect_memory=collect_memory,
                 collect_reproducibility=enable_repro,
+                collect_diagnostics=collect_diagnostics,
+                diagnostics_root_dir=diagnostics_root_dir,
                 include_micro=include_micro,
                 no_hardware_aware=no_hardware_aware,
+                diagnostics_occurrence_index=occurrence_index,
+                diagnostics_occurrence_total=key_totals[spec.key],
             )
         )
 

--- a/src/cauchy_generator/bench/throughput.py
+++ b/src/cauchy_generator/bench/throughput.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import time
+from typing import Any, Callable
 
 from cauchy_generator.config import GeneratorConfig
 from cauchy_generator.core.dataset import generate_batch_iter
+from cauchy_generator.types import DatasetBundle
 
 
 def _consume_generation(
@@ -14,16 +16,18 @@ def _consume_generation(
     num_datasets: int,
     seed: int,
     device: str | None,
+    on_bundle: Callable[[DatasetBundle], object] | None = None,
 ) -> None:
     """Run generation for ``num_datasets`` items while discarding outputs."""
 
-    for _ in generate_batch_iter(
+    for bundle in generate_batch_iter(
         config,
         num_datasets=num_datasets,
         seed=seed,
         device=device,
     ):
-        pass
+        if on_bundle is not None:
+            on_bundle(bundle)
 
 
 def run_throughput_benchmark(
@@ -32,7 +36,8 @@ def run_throughput_benchmark(
     num_datasets: int,
     warmup_datasets: int = 10,
     device: str | None = None,
-) -> dict[str, float | int | str | None]:
+    on_bundle: Callable[[DatasetBundle], object] | None = None,
+) -> dict[str, Any]:
     """Measure end-to-end generation throughput for a benchmark profile."""
 
     if warmup_datasets > 0:
@@ -49,6 +54,7 @@ def run_throughput_benchmark(
         num_datasets=num_datasets,
         seed=config.seed + 2,
         device=device,
+        on_bundle=on_bundle,
     )
     elapsed = time.perf_counter() - start
     dps = num_datasets / elapsed if elapsed > 0 else 0.0

--- a/src/cauchy_generator/cli.py
+++ b/src/cauchy_generator/cli.py
@@ -339,6 +339,16 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Optional path to write a baseline JSON derived from this run.",
     )
+    b.add_argument(
+        "--diagnostics",
+        action="store_true",
+        help="Enable diagnostics coverage aggregation artifacts for each benchmark profile run.",
+    )
+    b.add_argument(
+        "--diagnostics-out-dir",
+        default=None,
+        help="Optional root directory for benchmark diagnostics artifacts.",
+    )
 
     h = sub.add_parser("hardware", help="Inspect detected hardware and profile mapping.")
     h.add_argument(
@@ -499,31 +509,66 @@ def _default_benchmark_config(args: argparse.Namespace) -> GeneratorConfig:
     return GeneratorConfig()
 
 
-def _benchmark_artifact_dir(args: argparse.Namespace) -> Path | None:
+def _default_benchmark_artifact_dir() -> Path:
+    """Return a timestamped benchmark artifact directory path."""
+
+    timestamp = dt.datetime.now(dt.UTC).strftime("%Y%m%d_%H%M%S")
+    return Path("benchmarks") / "results" / timestamp
+
+
+def _benchmark_artifact_dir(
+    args: argparse.Namespace,
+) -> Path | None:
     """Resolve optional output directory for benchmark summary artifacts."""
 
     if args.out_dir:
         return Path(args.out_dir)
 
-    if not args.json_out:
-        timestamp = dt.datetime.now(dt.UTC).strftime("%Y%m%d_%H%M%S")
-        return Path("benchmarks") / "results" / timestamp
-    return None
+    if args.json_out:
+        return None
+    return _default_benchmark_artifact_dir()
+
+
+def _benchmark_diagnostics_root_dir(
+    args: argparse.Namespace,
+    *,
+    artifact_dir: Path | None,
+) -> Path | None:
+    """Resolve diagnostics artifact root for benchmark profile coverage summaries."""
+
+    if not bool(args.diagnostics):
+        return None
+    if args.diagnostics_out_dir:
+        return Path(args.diagnostics_out_dir)
+    if artifact_dir is not None:
+        return artifact_dir
+    return _default_benchmark_artifact_dir()
 
 
 def _print_profile_result_line(result: dict[str, Any]) -> None:
     """Print one compact profile benchmark summary line."""
+
+    diagnostics_hint = ""
+    artifacts = result.get("diagnostics_artifacts")
+    if isinstance(artifacts, dict):
+        json_pointer = artifacts.get("json")
+        if isinstance(json_pointer, str) and json_pointer:
+            diagnostics_hint = f" diagnostics={json_pointer}"
 
     print(
         f"[{result.get('profile_key')}] device={result.get('device')} "
         f"backend={result.get('hardware_backend')} "
         f"datasets/min={float(result.get('datasets_per_minute', 0.0)):.2f} "
         f"latency_p95_ms={float(result.get('latency_p95_ms', 0.0)):.2f}"
+        f"{diagnostics_hint}"
     )
 
 
 def _run_benchmark(args: argparse.Namespace) -> int:
     """Execute the ``benchmark`` command."""
+
+    artifact_dir = _benchmark_artifact_dir(args)
+    diagnostics_root_dir = _benchmark_diagnostics_root_dir(args, artifact_dir=artifact_dir)
 
     default_cfg = _default_benchmark_config(args)
     suite = (args.suite or default_cfg.benchmark.suite).strip().lower()
@@ -560,6 +605,8 @@ def _run_benchmark(args: argparse.Namespace) -> int:
             bool(args.collect_reproducibility)
             or bool(default_cfg.benchmark.collect_reproducibility)
         ),
+        collect_diagnostics=bool(args.diagnostics),
+        diagnostics_root_dir=diagnostics_root_dir,
         fail_on_regression=bool(args.fail_on_regression),
         no_hardware_aware=bool(args.no_hardware_aware),
     )
@@ -572,7 +619,6 @@ def _run_benchmark(args: argparse.Namespace) -> int:
         f"Regression status={regression.get('status', 'pass')} issues={len(regression.get('issues', []))}"
     )
 
-    artifact_dir = _benchmark_artifact_dir(args)
     if artifact_dir is not None:
         json_path = write_suite_json(summary, artifact_dir / "summary.json")
         md_path = write_suite_markdown(summary, artifact_dir / "summary.md")

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 from cauchy_generator.cli import main
 
@@ -68,3 +69,120 @@ def test_benchmark_cli_fail_on_regression(tmp_path) -> None:
         ]
     )
     assert code == 1
+
+
+def test_benchmark_cli_diagnostics_emits_artifacts(tmp_path) -> None:
+    out_dir = tmp_path / "bench_results"
+    code = main(
+        [
+            "benchmark",
+            "--config",
+            "configs/default.yaml",
+            "--profile",
+            "custom",
+            "--suite",
+            "smoke",
+            "--num-datasets",
+            "2",
+            "--warmup",
+            "0",
+            "--no-hardware-aware",
+            "--no-memory",
+            "--diagnostics",
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+    assert code == 0
+
+    summary_path = out_dir / "summary.json"
+    assert summary_path.exists()
+    payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    profile = payload["profile_results"][0]
+    assert profile["diagnostics_enabled"] is True
+
+    artifacts = profile["diagnostics_artifacts"]
+    assert isinstance(artifacts, dict)
+    assert isinstance(artifacts["json"], str)
+    assert isinstance(artifacts["markdown"], str)
+    assert Path(artifacts["json"]).exists()
+    assert Path(artifacts["markdown"]).exists()
+
+
+def test_benchmark_cli_json_out_diagnostics_does_not_emit_default_summary_artifacts(
+    tmp_path, monkeypatch
+) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    config_path = repo_root / "configs" / "default.yaml"
+    json_out = tmp_path / "summary.json"
+    diagnostics_out = tmp_path / "diag_out"
+    monkeypatch.chdir(tmp_path)
+
+    code = main(
+        [
+            "benchmark",
+            "--config",
+            str(config_path),
+            "--profile",
+            "custom",
+            "--suite",
+            "smoke",
+            "--num-datasets",
+            "2",
+            "--warmup",
+            "0",
+            "--no-hardware-aware",
+            "--no-memory",
+            "--diagnostics",
+            "--json-out",
+            str(json_out),
+            "--diagnostics-out-dir",
+            str(diagnostics_out),
+        ]
+    )
+    assert code == 0
+    assert json_out.exists()
+    assert not (tmp_path / "benchmarks").exists()
+
+
+def test_benchmark_cli_diagnostics_pointers_resolve_when_roots_differ(tmp_path) -> None:
+    out_dir = tmp_path / "bench_results"
+    diagnostics_out = tmp_path / "diag_out"
+    code = main(
+        [
+            "benchmark",
+            "--config",
+            "configs/default.yaml",
+            "--profile",
+            "custom",
+            "--suite",
+            "smoke",
+            "--num-datasets",
+            "2",
+            "--warmup",
+            "0",
+            "--no-hardware-aware",
+            "--no-memory",
+            "--diagnostics",
+            "--out-dir",
+            str(out_dir),
+            "--diagnostics-out-dir",
+            str(diagnostics_out),
+        ]
+    )
+    assert code == 0
+
+    summary_path = out_dir / "summary.json"
+    assert summary_path.exists()
+    payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    profile = payload["profile_results"][0]
+    artifacts = profile["diagnostics_artifacts"]
+    assert isinstance(artifacts, dict)
+    json_path = Path(artifacts["json"])
+    md_path = Path(artifacts["markdown"])
+    assert json_path.is_absolute()
+    assert md_path.is_absolute()
+    assert json_path.exists()
+    assert md_path.exists()
+    assert json_path.resolve().is_relative_to(diagnostics_out.resolve())
+    assert md_path.resolve().is_relative_to(diagnostics_out.resolve())

--- a/tests/test_benchmark_suite.py
+++ b/tests/test_benchmark_suite.py
@@ -1,4 +1,5 @@
 import numpy as np
+from pathlib import Path
 
 import cauchy_generator.bench.suite as suite_mod
 from cauchy_generator.bench.micro import run_microbenchmarks
@@ -44,6 +45,8 @@ def test_run_benchmark_suite_smoke_single_profile() -> None:
         warmup_override=0,
         collect_memory=False,
         collect_reproducibility=False,
+        collect_diagnostics=False,
+        diagnostics_root_dir=None,
         fail_on_regression=False,
         no_hardware_aware=True,
     )
@@ -108,3 +111,78 @@ def test_collect_reproducibility_uses_streaming_generation(
     assert out["reproducibility_match"] is True
     assert len(calls) == 2
     assert calls[0] == calls[1]
+
+
+def test_run_benchmark_suite_sanitizes_profile_key_for_diagnostics_paths(tmp_path) -> None:
+    cfg = _tiny_cpu_config()
+    spec = ProfileRunSpec(key="../../escape", config=cfg, device="cpu")
+    diagnostics_root = tmp_path / "diag_root"
+
+    summary = run_benchmark_suite(
+        [spec],
+        suite="smoke",
+        warn_threshold_pct=10.0,
+        fail_threshold_pct=20.0,
+        baseline_payload=None,
+        num_datasets_override=2,
+        warmup_override=0,
+        collect_memory=False,
+        collect_reproducibility=False,
+        collect_diagnostics=True,
+        diagnostics_root_dir=diagnostics_root,
+        fail_on_regression=False,
+        no_hardware_aware=True,
+    )
+
+    result = summary["profile_results"][0]
+    artifacts = result["diagnostics_artifacts"]
+    assert isinstance(artifacts, dict)
+
+    json_path = Path(artifacts["json"]).resolve()
+    md_path = Path(artifacts["markdown"]).resolve()
+    assert json_path.exists()
+    assert md_path.exists()
+    assert json_path.is_relative_to(diagnostics_root.resolve())
+    assert md_path.is_relative_to(diagnostics_root.resolve())
+    assert not (tmp_path / "escape" / "coverage_summary.json").exists()
+
+
+def test_run_benchmark_suite_uses_unique_diagnostics_dirs_for_duplicate_profile_keys(
+    tmp_path,
+) -> None:
+    cfg_a = _tiny_cpu_config()
+    cfg_b = _tiny_cpu_config()
+    specs = [
+        ProfileRunSpec(key="cpu_test", config=cfg_a, device="cpu"),
+        ProfileRunSpec(key="cpu_test", config=cfg_b, device="cpu"),
+    ]
+    diagnostics_root = tmp_path / "diag_root"
+
+    summary = run_benchmark_suite(
+        specs,
+        suite="smoke",
+        warn_threshold_pct=10.0,
+        fail_threshold_pct=20.0,
+        baseline_payload=None,
+        num_datasets_override=2,
+        warmup_override=0,
+        collect_memory=False,
+        collect_reproducibility=False,
+        collect_diagnostics=True,
+        diagnostics_root_dir=diagnostics_root,
+        fail_on_regression=False,
+        no_hardware_aware=True,
+    )
+
+    results = summary["profile_results"]
+    assert len(results) == 2
+    art_0 = results[0]["diagnostics_artifacts"]
+    art_1 = results[1]["diagnostics_artifacts"]
+    assert isinstance(art_0, dict)
+    assert isinstance(art_1, dict)
+    assert art_0["json"] != art_1["json"]
+    assert art_0["markdown"] != art_1["markdown"]
+    assert Path(art_0["json"]).exists()
+    assert Path(art_1["json"]).exists()
+    assert Path(art_0["markdown"]).exists()
+    assert Path(art_1["markdown"]).exists()

--- a/tests/test_benchmark_throughput.py
+++ b/tests/test_benchmark_throughput.py
@@ -41,3 +41,36 @@ def test_run_throughput_benchmark_uses_streaming_generation(
     assert result["warmup_datasets"] == 2
 
     assert float(typing.cast(float, result["datasets_per_minute"])) >= 0.0
+
+
+def test_run_throughput_benchmark_updates_callback_on_measured_generation(
+    monkeypatch,
+) -> None:
+    observed: list[int] = []
+
+    def _stub_generate_batch_iter(
+        _config,
+        *,
+        num_datasets: int,
+        seed: int | None = None,
+        device: str | None = None,
+    ):
+        _ = seed
+        _ = device
+        for idx in range(num_datasets):
+            yield idx
+
+    monkeypatch.setattr(
+        "cauchy_generator.bench.throughput.generate_batch_iter",
+        _stub_generate_batch_iter,
+    )
+
+    cfg = GeneratorConfig()
+    run_throughput_benchmark(
+        cfg,
+        num_datasets=4,
+        warmup_datasets=2,
+        device="cpu",
+        on_bundle=lambda bundle: observed.append(int(bundle)),
+    )
+    assert observed == [0, 1, 2, 3]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,10 @@ def test_load_default_config() -> None:
     assert cfg.output.shard_size > 0
     assert cfg.diagnostics.enabled is False
     assert cfg.diagnostics.histogram_bins > 0
+    assert cfg.diagnostics.quantiles
+    assert cfg.diagnostics.underrepresented_threshold >= 0
+    assert cfg.diagnostics.meta_feature_targets == {}
+    assert cfg.diagnostics.out_dir is None
     assert cfg.steering.enabled is False
     assert cfg.steering.max_attempts == 3
     assert cfg.steering.temperature > 0
@@ -25,6 +29,22 @@ def test_load_cuda_presets() -> None:
     cfg_h100 = GeneratorConfig.from_yaml("configs/preset_cuda_h100.yaml")
     assert cfg_h100.runtime.device == "cuda"
     assert cfg_h100.dataset.n_features_max >= 128
+
+
+def test_load_diagnostics_and_steering_presets() -> None:
+    cfg_diag = GeneratorConfig.from_yaml("configs/preset_diagnostics_on.yaml")
+    assert cfg_diag.diagnostics.enabled is True
+    assert cfg_diag.steering.enabled is False
+    assert cfg_diag.diagnostics.histogram_bins >= 8
+    assert cfg_diag.diagnostics.quantiles
+
+    cfg_steering = GeneratorConfig.from_yaml("configs/preset_steering_conservative.yaml")
+    assert cfg_steering.steering.enabled is True
+    assert cfg_steering.steering.max_attempts >= 2
+    assert cfg_steering.steering.temperature > 0
+    assert cfg_steering.meta_feature_targets
+    for band in cfg_steering.meta_feature_targets.values():
+        assert len(band) in {2, 3}
 
 
 def test_load_benchmark_profiles() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.13"
 
 [[package]]
 name = "cauchy-generator"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- integrate optional diagnostics collection into benchmark suite runs and surface artifact pointers in benchmark summaries
- add diagnostics/steering presets, benchmark script flags, and README/script docs for end-to-end diagnostics plus steering workflows
- harden benchmark diagnostics outputs by fixing json-out behavior, using resolvable artifact pointers, sanitizing profile keys, and preventing duplicate-key artifact overwrites
- bump package version to 0.1.6

## Testing
- uv run pytest -q
- uv run ruff check src tests
- uv run mypy src

Closes #13