### PR TITLE
feat(missingness): add config validation and deterministic mask samplers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Architecture documentation with mermaid diagrams (`docs/architecture.md`)
 - Torch-native steering metric extractor (`core/steering_metrics.py`) — avoids NumPy conversion during candidate scoring
+- Deterministic MCAR/MAR/MNAR missingness mask samplers with typed config validation coverage
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cauchy-generator"
-version = "0.1.8"
-description = "High-performance synthetic tabular data generator scaffold aligned with TabICLv2 Appendix E."
+version = "0.1.9"
+description = "High-performance synthetic tabular data generator"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.13"

--- a/src/cauchy_generator/config.py
+++ b/src/cauchy_generator/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Literal
@@ -25,6 +26,19 @@ _CURRICULUM_STAGE_VALUE_MAP: dict[str | int, CurriculumStage] = {
     3: 3,
 }
 
+MissingnessMechanism = Literal["none", "mcar", "mar", "mnar"]
+MISSINGNESS_MECHANISM_NONE: Literal["none"] = "none"
+MISSINGNESS_MECHANISM_MCAR: Literal["mcar"] = "mcar"
+MISSINGNESS_MECHANISM_MAR: Literal["mar"] = "mar"
+MISSINGNESS_MECHANISM_MNAR: Literal["mnar"] = "mnar"
+
+_MISSINGNESS_MECHANISM_VALUE_MAP: dict[str, MissingnessMechanism] = {
+    MISSINGNESS_MECHANISM_NONE: MISSINGNESS_MECHANISM_NONE,
+    MISSINGNESS_MECHANISM_MCAR: MISSINGNESS_MECHANISM_MCAR,
+    MISSINGNESS_MECHANISM_MAR: MISSINGNESS_MECHANISM_MAR,
+    MISSINGNESS_MECHANISM_MNAR: MISSINGNESS_MECHANISM_MNAR,
+}
+
 
 def normalize_curriculum_stage(value: str | int) -> CurriculumStage:
     """Normalize curriculum stage config into a validated internal value."""
@@ -36,6 +50,22 @@ def normalize_curriculum_stage(value: str | int) -> CurriculumStage:
     result = _CURRICULUM_STAGE_VALUE_MAP.get(value)
     if result is None:
         raise ValueError(f"Unsupported curriculum_stage '{value}'. Expected off, auto, 1, 2, or 3.")
+    return result
+
+
+def normalize_missing_mechanism(value: str) -> MissingnessMechanism:
+    """Normalize missingness mechanism into a validated internal value."""
+
+    if isinstance(value, bool) or not isinstance(value, str):
+        raise ValueError(
+            f"Unsupported missing_mechanism '{value}'. Expected none, mcar, mar, or mnar."
+        )
+    normalized = value.strip().lower()
+    result = _MISSINGNESS_MECHANISM_VALUE_MAP.get(normalized)
+    if result is None:
+        raise ValueError(
+            f"Unsupported missing_mechanism '{value}'. Expected none, mcar, mar, or mnar."
+        )
     return result
 
 
@@ -51,6 +81,66 @@ class DatasetConfig:
     categorical_ratio_min: float = -0.5
     categorical_ratio_max: float = 1.2
     max_categorical_cardinality: int = 9
+    missing_rate: float = 0.0
+    missing_mechanism: MissingnessMechanism = MISSINGNESS_MECHANISM_NONE
+    missing_mar_observed_fraction: float = 0.5
+    missing_mar_logit_scale: float = 1.0
+    missing_mnar_logit_scale: float = 1.0
+
+    def __post_init__(self) -> None:
+        if isinstance(self.missing_rate, bool):
+            raise ValueError(
+                f"dataset.missing_rate must be a finite value in [0, 1], got {self.missing_rate!r}."
+            )
+        self.missing_rate = float(self.missing_rate)
+        if not math.isfinite(self.missing_rate) or not (0.0 <= self.missing_rate <= 1.0):
+            raise ValueError(
+                f"dataset.missing_rate must be a finite value in [0, 1], got {self.missing_rate!r}."
+            )
+
+        self.missing_mechanism = normalize_missing_mechanism(self.missing_mechanism)
+        if self.missing_rate > 0.0 and self.missing_mechanism == MISSINGNESS_MECHANISM_NONE:
+            raise ValueError(
+                "dataset.missing_mechanism must be mcar, mar, or mnar when dataset.missing_rate > 0."
+            )
+
+        if isinstance(self.missing_mar_observed_fraction, bool):
+            raise ValueError(
+                "dataset.missing_mar_observed_fraction must be in (0, 1], got "
+                f"{self.missing_mar_observed_fraction!r}."
+            )
+        self.missing_mar_observed_fraction = float(self.missing_mar_observed_fraction)
+        if not math.isfinite(self.missing_mar_observed_fraction) or not (
+            0.0 < self.missing_mar_observed_fraction <= 1.0
+        ):
+            raise ValueError(
+                "dataset.missing_mar_observed_fraction must be in (0, 1], got "
+                f"{self.missing_mar_observed_fraction!r}."
+            )
+
+        if isinstance(self.missing_mar_logit_scale, bool):
+            raise ValueError(
+                "dataset.missing_mar_logit_scale must be a finite value > 0, got "
+                f"{self.missing_mar_logit_scale!r}."
+            )
+        self.missing_mar_logit_scale = float(self.missing_mar_logit_scale)
+        if not math.isfinite(self.missing_mar_logit_scale) or self.missing_mar_logit_scale <= 0.0:
+            raise ValueError(
+                "dataset.missing_mar_logit_scale must be a finite value > 0, got "
+                f"{self.missing_mar_logit_scale!r}."
+            )
+
+        if isinstance(self.missing_mnar_logit_scale, bool):
+            raise ValueError(
+                "dataset.missing_mnar_logit_scale must be a finite value > 0, got "
+                f"{self.missing_mnar_logit_scale!r}."
+            )
+        self.missing_mnar_logit_scale = float(self.missing_mnar_logit_scale)
+        if not math.isfinite(self.missing_mnar_logit_scale) or self.missing_mnar_logit_scale <= 0.0:
+            raise ValueError(
+                "dataset.missing_mnar_logit_scale must be a finite value > 0, got "
+                f"{self.missing_mnar_logit_scale!r}."
+            )
 
 
 @dataclass(slots=True)

--- a/src/cauchy_generator/sampling/__init__.py
+++ b/src/cauchy_generator/sampling/__init__.py
@@ -1,6 +1,7 @@
 """Sampling primitives for the prior."""
 
 from .correlated import CorrelatedSampler
+from .missingness import sample_missingness_mask
 from .random_weights import sample_random_weights
 
-__all__ = ["CorrelatedSampler", "sample_random_weights"]
+__all__ = ["CorrelatedSampler", "sample_missingness_mask", "sample_random_weights"]

--- a/src/cauchy_generator/sampling/missingness.py
+++ b/src/cauchy_generator/sampling/missingness.py
@@ -1,0 +1,208 @@
+"""Deterministic missingness mask samplers (MCAR/MAR/MNAR)."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+from cauchy_generator.config import (
+    DatasetConfig,
+    MISSINGNESS_MECHANISM_MAR,
+    MISSINGNESS_MECHANISM_MCAR,
+    MISSINGNESS_MECHANISM_MNAR,
+    MISSINGNESS_MECHANISM_NONE,
+    normalize_missing_mechanism,
+)
+from cauchy_generator.rng import SeedManager
+
+_MIN_STD = 1e-6
+_CALIBRATION_ITERS = 48
+_CALIBRATION_BOUND = 30.0
+
+
+def _standardize_columns(x: torch.Tensor) -> torch.Tensor:
+    """Column-wise z-score normalization with safe variance floor."""
+
+    means = x.mean(dim=0, keepdim=True)
+    stds = torch.clamp(x.std(dim=0, correction=0, keepdim=True), min=_MIN_STD)
+    return (x - means) / stds
+
+
+def _calibrate_intercept(base_logits: torch.Tensor, target_rate: float) -> float:
+    """Find intercept so mean(sigmoid(base_logits + intercept)) ~= target_rate."""
+
+    low = -_CALIBRATION_BOUND
+    high = _CALIBRATION_BOUND
+    for _ in range(_CALIBRATION_ITERS):
+        mid = (low + high) / 2.0
+        mean_prob = float(torch.sigmoid(base_logits + mid).mean().item())
+        if mean_prob < target_rate:
+            low = mid
+        else:
+            high = mid
+    return float((low + high) / 2.0)
+
+
+def _calibrated_probabilities(base_logits: torch.Tensor, target_rate: float) -> torch.Tensor:
+    """Return per-cell probabilities calibrated to a global target mean rate."""
+
+    if target_rate <= 0.0:
+        return torch.zeros_like(base_logits)
+    if target_rate >= 1.0:
+        return torch.ones_like(base_logits)
+    intercept = _calibrate_intercept(base_logits, target_rate)
+    return torch.sigmoid(base_logits + intercept)
+
+
+def _sample_mask_from_probabilities(
+    probabilities: torch.Tensor,
+    *,
+    generator: torch.Generator,
+) -> torch.Tensor:
+    """Draw a boolean mask from per-cell Bernoulli probabilities."""
+
+    draws = torch.rand(
+        probabilities.shape,
+        dtype=probabilities.dtype,
+        device=probabilities.device,
+        generator=generator,
+    )
+    return draws < probabilities
+
+
+def _sample_mcar_mask(
+    x: torch.Tensor,
+    *,
+    missing_rate: float,
+    seed_manager: SeedManager,
+    device: str,
+) -> torch.Tensor:
+    """MCAR sampler: each cell is independently missing with fixed probability."""
+
+    probs = torch.full_like(x, fill_value=float(missing_rate), dtype=torch.float32)
+    draw_generator = seed_manager.torch_rng("missingness", "mcar", "draws", device=device)
+    return _sample_mask_from_probabilities(probs, generator=draw_generator)
+
+
+def _sample_mar_mask(
+    x: torch.Tensor,
+    *,
+    dataset_cfg: DatasetConfig,
+    missing_rate: float,
+    seed_manager: SeedManager,
+    device: str,
+) -> torch.Tensor:
+    """MAR sampler: missingness depends on a sampled observed feature subset."""
+
+    x_standardized = _standardize_columns(x)
+    n_cols = int(x_standardized.shape[1])
+    observed_count = max(
+        1,
+        min(n_cols, int(math.ceil(float(dataset_cfg.missing_mar_observed_fraction) * n_cols))),
+    )
+
+    obs_generator = seed_manager.torch_rng("missingness", "mar", "observed_idx", device=device)
+    observed_perm = torch.randperm(n_cols, device=x_standardized.device, generator=obs_generator)
+    observed_mask = torch.zeros(n_cols, dtype=torch.bool, device=x_standardized.device)
+    observed_mask[observed_perm[:observed_count]] = True
+
+    weight_generator = seed_manager.torch_rng("missingness", "mar", "weights", device=device)
+    weights = torch.randn(
+        (n_cols, n_cols),
+        dtype=x_standardized.dtype,
+        device=x_standardized.device,
+        generator=weight_generator,
+    )
+    weights = weights * observed_mask.to(dtype=x_standardized.dtype).unsqueeze(1)
+    weights.fill_diagonal_(0.0)
+
+    raw_scores = x_standardized @ weights
+    raw_scores = raw_scores / math.sqrt(float(max(1, observed_count)))
+    base_logits = raw_scores * float(dataset_cfg.missing_mar_logit_scale)
+    probs = _calibrated_probabilities(base_logits, missing_rate)
+
+    draw_generator = seed_manager.torch_rng("missingness", "mar", "draws", device=device)
+    return _sample_mask_from_probabilities(probs, generator=draw_generator)
+
+
+def _sample_mnar_mask(
+    x: torch.Tensor,
+    *,
+    dataset_cfg: DatasetConfig,
+    missing_rate: float,
+    seed_manager: SeedManager,
+    device: str,
+) -> torch.Tensor:
+    """MNAR sampler: missingness depends on each feature's own standardized value."""
+
+    x_standardized = _standardize_columns(x)
+    n_cols = int(x_standardized.shape[1])
+    weight_generator = seed_manager.torch_rng("missingness", "mnar", "weights", device=device)
+    feature_weights = torch.randn(
+        (1, n_cols),
+        dtype=x_standardized.dtype,
+        device=x_standardized.device,
+        generator=weight_generator,
+    )
+    base_logits = (x_standardized * feature_weights) * float(dataset_cfg.missing_mnar_logit_scale)
+    probs = _calibrated_probabilities(base_logits, missing_rate)
+
+    draw_generator = seed_manager.torch_rng("missingness", "mnar", "draws", device=device)
+    return _sample_mask_from_probabilities(probs, generator=draw_generator)
+
+
+def sample_missingness_mask(
+    x: torch.Tensor,
+    *,
+    dataset_cfg: DatasetConfig,
+    seed_manager: SeedManager,
+    device: str = "cpu",
+) -> torch.Tensor:
+    """
+    Sample a deterministic missingness mask for one feature matrix.
+
+    The returned tensor is boolean with the same shape as `x`, where `True`
+    indicates missing entries to be injected by downstream integration.
+    """
+
+    if x.ndim != 2:
+        raise ValueError(f"Missingness sampler expects a 2D tensor, got shape {tuple(x.shape)!r}.")
+
+    missing_rate = float(dataset_cfg.missing_rate)
+    if missing_rate <= 0.0 or x.numel() == 0:
+        return torch.zeros_like(x, dtype=torch.bool)
+    if missing_rate >= 1.0:
+        return torch.ones_like(x, dtype=torch.bool)
+
+    mechanism = normalize_missing_mechanism(dataset_cfg.missing_mechanism)
+    if mechanism == MISSINGNESS_MECHANISM_NONE:
+        return torch.zeros_like(x, dtype=torch.bool)
+
+    work = x.to(device=device, dtype=torch.float32)
+    work = torch.nan_to_num(work, nan=0.0, posinf=0.0, neginf=0.0)
+
+    if mechanism == MISSINGNESS_MECHANISM_MCAR:
+        mask = _sample_mcar_mask(
+            work, missing_rate=missing_rate, seed_manager=seed_manager, device=device
+        )
+    elif mechanism == MISSINGNESS_MECHANISM_MAR:
+        mask = _sample_mar_mask(
+            work,
+            dataset_cfg=dataset_cfg,
+            missing_rate=missing_rate,
+            seed_manager=seed_manager,
+            device=device,
+        )
+    elif mechanism == MISSINGNESS_MECHANISM_MNAR:
+        mask = _sample_mnar_mask(
+            work,
+            dataset_cfg=dataset_cfg,
+            missing_rate=missing_rate,
+            seed_manager=seed_manager,
+            device=device,
+        )
+    else:
+        raise ValueError(f"Unsupported missingness mechanism: {mechanism!r}.")
+
+    return mask.to(device=x.device)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,10 @@
 import pytest
 
-from cauchy_generator.config import GeneratorConfig
+from cauchy_generator.config import (
+    MISSINGNESS_MECHANISM_MCAR,
+    MISSINGNESS_MECHANISM_NONE,
+    GeneratorConfig,
+)
 
 
 def test_load_default_config() -> None:
@@ -26,6 +30,11 @@ def test_load_default_config() -> None:
     assert cfg.filter.depth >= 0
     assert cfg.filter.max_features == "auto"
     assert cfg.filter.n_split_candidates > 0
+    assert cfg.dataset.missing_rate == 0.0
+    assert cfg.dataset.missing_mechanism == MISSINGNESS_MECHANISM_NONE
+    assert cfg.dataset.missing_mar_observed_fraction == 0.5
+    assert cfg.dataset.missing_mar_logit_scale == 1.0
+    assert cfg.dataset.missing_mnar_logit_scale == 1.0
 
 
 def test_load_cuda_presets() -> None:
@@ -117,3 +126,77 @@ def test_legacy_filter_keys_are_rejected() -> None:
                 }
             }
         )
+
+
+def test_missingness_mechanism_normalization_is_case_insensitive() -> None:
+    cfg = GeneratorConfig.from_dict(
+        {"dataset": {"missing_rate": 0.25, "missing_mechanism": "MCAR"}}
+    )
+    assert cfg.dataset.missing_mechanism == MISSINGNESS_MECHANISM_MCAR
+
+
+def test_missingness_rejects_none_mechanism_when_rate_is_positive() -> None:
+    with pytest.raises(
+        ValueError,
+        match="dataset.missing_mechanism must be mcar, mar, or mnar when dataset.missing_rate > 0",
+    ):
+        GeneratorConfig.from_dict({"dataset": {"missing_rate": 0.1, "missing_mechanism": "none"}})
+
+
+@pytest.mark.parametrize("value", [-0.1, 1.1, float("inf"), float("nan"), True])
+def test_missing_rate_bounds_are_validated(value: float | bool) -> None:
+    with pytest.raises(
+        ValueError, match="dataset.missing_rate must be a finite value in \\[0, 1\\]"
+    ):
+        GeneratorConfig.from_dict({"dataset": {"missing_rate": value}})
+
+
+@pytest.mark.parametrize("value", [0.0, -0.1, 1.1, float("inf"), float("nan"), True])
+def test_missing_mar_observed_fraction_bounds_are_validated(value: float | bool) -> None:
+    with pytest.raises(
+        ValueError, match="dataset.missing_mar_observed_fraction must be in \\(0, 1\\]"
+    ):
+        GeneratorConfig.from_dict({"dataset": {"missing_mar_observed_fraction": value}})
+
+
+@pytest.mark.parametrize(
+    ("field_name", "bad_value"),
+    [
+        ("missing_mar_logit_scale", 0.0),
+        ("missing_mar_logit_scale", -1.0),
+        ("missing_mar_logit_scale", float("inf")),
+        ("missing_mar_logit_scale", float("nan")),
+        ("missing_mar_logit_scale", True),
+        ("missing_mnar_logit_scale", 0.0),
+        ("missing_mnar_logit_scale", -1.0),
+        ("missing_mnar_logit_scale", float("inf")),
+        ("missing_mnar_logit_scale", float("nan")),
+        ("missing_mnar_logit_scale", True),
+    ],
+)
+def test_missing_logit_scale_bounds_are_validated(field_name: str, bad_value: float | bool) -> None:
+    with pytest.raises(ValueError, match=rf"dataset.{field_name} must be a finite value > 0"):
+        GeneratorConfig.from_dict({"dataset": {field_name: bad_value}})
+
+
+def test_invalid_missing_mechanism_string_is_rejected() -> None:
+    with pytest.raises(ValueError, match="Unsupported missing_mechanism"):
+        GeneratorConfig.from_dict({"dataset": {"missing_mechanism": "garbage"}})
+
+
+def test_unused_missingness_parameters_are_allowed_with_disabled_mechanism() -> None:
+    cfg = GeneratorConfig.from_dict(
+        {
+            "dataset": {
+                "missing_rate": 0.0,
+                "missing_mechanism": "none",
+                "missing_mar_observed_fraction": 0.8,
+                "missing_mar_logit_scale": 2.5,
+                "missing_mnar_logit_scale": 3.5,
+            }
+        }
+    )
+    assert cfg.dataset.missing_mechanism == MISSINGNESS_MECHANISM_NONE
+    assert cfg.dataset.missing_mar_observed_fraction == 0.8
+    assert cfg.dataset.missing_mar_logit_scale == 2.5
+    assert cfg.dataset.missing_mnar_logit_scale == 3.5

--- a/tests/test_missingness_sampling.py
+++ b/tests/test_missingness_sampling.py
@@ -1,0 +1,157 @@
+"""Tests for deterministic MCAR/MAR/MNAR missingness mask sampling."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from cauchy_generator.config import (
+    MISSINGNESS_MECHANISM_MAR,
+    MISSINGNESS_MECHANISM_MCAR,
+    MISSINGNESS_MECHANISM_MNAR,
+    MISSINGNESS_MECHANISM_NONE,
+    DatasetConfig,
+    MissingnessMechanism,
+)
+from cauchy_generator.rng import SeedManager
+from cauchy_generator.sampling import sample_missingness_mask
+
+
+def _feature_matrix(n_rows: int = 512, n_cols: int = 12) -> torch.Tensor:
+    """Create a deterministic, non-trivial feature matrix for sampler tests."""
+
+    grid = torch.linspace(-3.0, 3.0, steps=n_rows, dtype=torch.float32).unsqueeze(1)
+    freqs = torch.arange(1, n_cols + 1, dtype=torch.float32).unsqueeze(0)
+    return torch.sin(grid * freqs * 0.7) + torch.cos(grid * (freqs + 0.5) * 0.4)
+
+
+def _cfg(mechanism: MissingnessMechanism, *, missing_rate: float = 0.35) -> DatasetConfig:
+    return DatasetConfig(
+        missing_rate=missing_rate,
+        missing_mechanism=mechanism,
+        missing_mar_observed_fraction=0.5,
+        missing_mar_logit_scale=1.5,
+        missing_mnar_logit_scale=1.5,
+    )
+
+
+def test_missingness_mask_shape_and_dtype() -> None:
+    x = _feature_matrix(64, 7)
+    cfg = _cfg(MISSINGNESS_MECHANISM_MCAR, missing_rate=0.2)
+    mask = sample_missingness_mask(x, dataset_cfg=cfg, seed_manager=SeedManager(7), device="cpu")
+    assert mask.shape == x.shape
+    assert mask.dtype == torch.bool
+
+
+@pytest.mark.parametrize(
+    "mechanism",
+    [MISSINGNESS_MECHANISM_NONE, MISSINGNESS_MECHANISM_MCAR, MISSINGNESS_MECHANISM_MAR],
+)
+def test_missingness_rate_zero_returns_all_false(mechanism: str) -> None:
+    x = _feature_matrix(32, 5)
+    cfg = _cfg(mechanism, missing_rate=0.0)
+    mask = sample_missingness_mask(x, dataset_cfg=cfg, seed_manager=SeedManager(1), device="cpu")
+    assert not torch.any(mask)
+
+
+def test_mcar_rate_one_returns_all_true() -> None:
+    x = _feature_matrix(32, 5)
+    cfg = _cfg(MISSINGNESS_MECHANISM_MCAR, missing_rate=1.0)
+    mask = sample_missingness_mask(x, dataset_cfg=cfg, seed_manager=SeedManager(1), device="cpu")
+    assert torch.all(mask)
+
+
+def test_mcar_empirical_rate_close_to_target() -> None:
+    x = _feature_matrix(2000, 10)
+    target_rate = 0.30
+    cfg = _cfg(MISSINGNESS_MECHANISM_MCAR, missing_rate=target_rate)
+    mask = sample_missingness_mask(x, dataset_cfg=cfg, seed_manager=SeedManager(11), device="cpu")
+    observed_rate = float(mask.float().mean().item())
+    assert abs(observed_rate - target_rate) < 0.03
+
+
+@pytest.mark.parametrize(
+    "mechanism",
+    [MISSINGNESS_MECHANISM_MCAR, MISSINGNESS_MECHANISM_MAR, MISSINGNESS_MECHANISM_MNAR],
+)
+def test_sampler_is_deterministic_for_fixed_seed(mechanism: str) -> None:
+    x = _feature_matrix(257, 13)
+    cfg = _cfg(mechanism, missing_rate=0.35)
+    mask_a = sample_missingness_mask(
+        x, dataset_cfg=cfg, seed_manager=SeedManager(123), device="cpu"
+    )
+    mask_b = sample_missingness_mask(
+        x, dataset_cfg=cfg, seed_manager=SeedManager(123), device="cpu"
+    )
+    assert torch.equal(mask_a, mask_b)
+
+
+@pytest.mark.parametrize(
+    "mechanism",
+    [MISSINGNESS_MECHANISM_MCAR, MISSINGNESS_MECHANISM_MAR, MISSINGNESS_MECHANISM_MNAR],
+)
+def test_sampler_changes_when_seed_changes(mechanism: str) -> None:
+    x = _feature_matrix(257, 13)
+    cfg = _cfg(mechanism, missing_rate=0.35)
+    mask_a = sample_missingness_mask(
+        x, dataset_cfg=cfg, seed_manager=SeedManager(123), device="cpu"
+    )
+    mask_b = sample_missingness_mask(
+        x, dataset_cfg=cfg, seed_manager=SeedManager(124), device="cpu"
+    )
+    assert not torch.equal(mask_a, mask_b)
+
+
+@pytest.mark.parametrize(
+    "mechanism",
+    [MISSINGNESS_MECHANISM_MAR, MISSINGNESS_MECHANISM_MNAR],
+)
+def test_mar_and_mnar_empirical_rate_close_to_target(mechanism: str) -> None:
+    x = _feature_matrix(2048, 16)
+    target_rate = 0.25
+    cfg = _cfg(mechanism, missing_rate=target_rate)
+    mask = sample_missingness_mask(x, dataset_cfg=cfg, seed_manager=SeedManager(19), device="cpu")
+    observed_rate = float(mask.float().mean().item())
+    assert abs(observed_rate - target_rate) < 0.05
+
+
+def test_mar_mask_depends_on_observed_feature_values() -> None:
+    x = _feature_matrix(512, 12)
+    perturb = torch.linspace(-1.5, 1.5, steps=x.shape[0], dtype=torch.float32).unsqueeze(1)
+    scales = torch.arange(1, x.shape[1] + 1, dtype=torch.float32).unsqueeze(0) / float(x.shape[1])
+    x_shifted = x + perturb * scales
+
+    cfg = _cfg(MISSINGNESS_MECHANISM_MAR, missing_rate=0.35)
+    seed = 909
+    mask_a = sample_missingness_mask(
+        x, dataset_cfg=cfg, seed_manager=SeedManager(seed), device="cpu"
+    )
+    mask_b = sample_missingness_mask(
+        x_shifted, dataset_cfg=cfg, seed_manager=SeedManager(seed), device="cpu"
+    )
+    assert not torch.equal(mask_a, mask_b)
+
+
+def test_mnar_mask_depends_on_feature_self_values() -> None:
+    x = _feature_matrix(512, 12)
+    x_mutated = x.clone()
+    x_mutated[:, 0] = x_mutated[:, 0] ** 3 + 0.5 * x_mutated[:, 0]
+
+    cfg = _cfg(MISSINGNESS_MECHANISM_MNAR, missing_rate=0.35)
+    seed = 1201
+    mask_a = sample_missingness_mask(
+        x, dataset_cfg=cfg, seed_manager=SeedManager(seed), device="cpu"
+    )
+    mask_b = sample_missingness_mask(
+        x_mutated, dataset_cfg=cfg, seed_manager=SeedManager(seed), device="cpu"
+    )
+
+    assert int(torch.count_nonzero(mask_a ^ mask_b).item()) > 0
+    assert int(torch.count_nonzero(mask_a[:, 0] ^ mask_b[:, 0]).item()) > 0
+
+
+def test_sampler_rejects_non_2d_input() -> None:
+    x = torch.ones(10)
+    cfg = _cfg(MISSINGNESS_MECHANISM_MCAR, missing_rate=0.2)
+    with pytest.raises(ValueError, match="expects a 2D tensor"):
+        sample_missingness_mask(x, dataset_cfg=cfg, seed_manager=SeedManager(1), device="cpu")

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.13"
 
 [[package]]
 name = "cauchy-generator"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- add deterministic tensor-first missingness mask samplers for MCAR/MAR/MNAR
- export sample_missingness_mask from sampling package for reuse in follow-on integration work
- extend config tests for missingness defaults, normalization, validation bounds, and invalid combinations
- add dedicated missingness sampler tests for shape/rate invariants and seed reproducibility
- bump package version to 0.1.9 and update changelog unreleased notes

## Linked Issues
- Closes #16
- Part of #15

## Validation
- uv run ruff check src tests
- uv run mypy src
- uv run pytest tests -q
