### PR TITLE
feat(missingness): integrate MCAR/MAR/MNAR injection into generation pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Architecture documentation with mermaid diagrams (`docs/architecture.md`)
 - Torch-native steering metric extractor (`core/steering_metrics.py`) — avoids NumPy conversion during candidate scoring
 - Deterministic MCAR/MAR/MNAR missingness mask samplers with typed config validation coverage
+- End-to-end missingness injection in generation/postprocess path with compact metadata summaries for configured and realized rates
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cauchy-generator"
-version = "0.1.9"
+version = "0.1.10"
 description = "High-performance synthetic tabular data generator"
 readme = "README.md"
 license = "MIT"

--- a/src/cauchy_generator/core/dataset.py
+++ b/src/cauchy_generator/core/dataset.py
@@ -24,7 +24,7 @@ from cauchy_generator.core.steering_metrics import extract_steering_metrics
 from cauchy_generator.diagnostics.types import DatasetMetrics
 from cauchy_generator.filtering import apply_torch_rf_filter
 from cauchy_generator.graph import sample_cauchy_dag
-from cauchy_generator.postprocess import postprocess_dataset
+from cauchy_generator.postprocess import inject_missingness, postprocess_dataset
 from cauchy_generator.rng import SeedManager
 from cauchy_generator.sampling import CorrelatedSampler
 from cauchy_generator.types import DatasetBundle
@@ -450,6 +450,14 @@ def _generate_torch(
             generator,
             device,
         )
+        x_train, x_test, missingness_summary = inject_missingness(
+            x_train,
+            x_test,
+            dataset_cfg=config.dataset,
+            seed=seed,
+            attempt=attempt,
+            device=device,
+        )
 
         if config.dataset.task == "classification" and not _classification_split_valid(
             y_train, y_test
@@ -480,6 +488,8 @@ def _generate_torch(
             "curriculum": curriculum,
             "config": asdict(config),
         }
+        if missingness_summary is not None:
+            metadata["missingness"] = missingness_summary
         return DatasetBundle(
             X_train=x_train,
             y_train=y_train,

--- a/src/cauchy_generator/postprocess/__init__.py
+++ b/src/cauchy_generator/postprocess/__init__.py
@@ -1,5 +1,5 @@
 """Dataset postprocessing."""
 
-from .postprocess import postprocess_dataset
+from .postprocess import inject_missingness, postprocess_dataset
 
-__all__ = ["postprocess_dataset"]
+__all__ = ["inject_missingness", "postprocess_dataset"]

--- a/src/cauchy_generator/postprocess/postprocess.py
+++ b/src/cauchy_generator/postprocess/postprocess.py
@@ -2,7 +2,17 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import torch
+
+from cauchy_generator.config import (
+    DatasetConfig,
+    MISSINGNESS_MECHANISM_NONE,
+    normalize_missing_mechanism,
+)
+from cauchy_generator.rng import SeedManager
+from cauchy_generator.sampling import sample_missingness_mask
 
 
 def _remove_constant_columns(
@@ -97,3 +107,65 @@ def postprocess_dataset(
         y_test_p = y_test.to(torch.int64)
 
     return x_train_p, y_train_p, x_test_p, y_test_p, feature_types
+
+
+def inject_missingness(
+    x_train: torch.Tensor,
+    x_test: torch.Tensor,
+    *,
+    dataset_cfg: DatasetConfig,
+    seed: int,
+    attempt: int,
+    device: str,
+) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any] | None]:
+    """
+    Inject configured missingness into train/test feature tensors.
+
+    Missing values are encoded as NaN and summary stats are returned for metadata.
+    """
+
+    missing_rate = float(dataset_cfg.missing_rate)
+    mechanism = normalize_missing_mechanism(dataset_cfg.missing_mechanism)
+    enabled = missing_rate > 0.0 and mechanism != MISSINGNESS_MECHANISM_NONE
+    if not enabled:
+        return x_train, x_test, None
+
+    run_manager = SeedManager(seed)
+    train_manager = SeedManager(run_manager.child("missingness", attempt, "train"))
+    test_manager = SeedManager(run_manager.child("missingness", attempt, "test"))
+
+    train_mask = sample_missingness_mask(
+        x_train,
+        dataset_cfg=dataset_cfg,
+        seed_manager=train_manager,
+        device=device,
+    )
+    test_mask = sample_missingness_mask(
+        x_test,
+        dataset_cfg=dataset_cfg,
+        seed_manager=test_manager,
+        device=device,
+    )
+
+    x_train_missing = x_train.masked_fill(train_mask, float("nan"))
+    x_test_missing = x_test.masked_fill(test_mask, float("nan"))
+
+    missing_count_train = int(train_mask.sum().item())
+    missing_count_test = int(test_mask.sum().item())
+    train_total = max(1, int(train_mask.numel()))
+    test_total = max(1, int(test_mask.numel()))
+    total = train_total + test_total
+    missing_count_overall = missing_count_train + missing_count_test
+
+    summary: dict[str, Any] = {
+        "enabled": True,
+        "mechanism": mechanism,
+        "target_rate": float(missing_rate),
+        "realized_rate_train": float(missing_count_train / train_total),
+        "realized_rate_test": float(missing_count_test / test_total),
+        "realized_rate_overall": float(missing_count_overall / total),
+        "missing_count_train": missing_count_train,
+        "missing_count_test": missing_count_test,
+        "missing_count_overall": missing_count_overall,
+    }
+    return x_train_missing, x_test_missing, summary

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -272,3 +272,70 @@ def test_invalid_class_split_raises_after_attempts(monkeypatch: pytest.MonkeyPat
 
     with pytest.raises(ValueError, match="Failed to generate a valid dataset"):
         generate_one(cfg, seed=99, device="cpu")
+
+
+def _tiny_missingness_config(
+    *,
+    task: str,
+    mechanism: str,
+    missing_rate: float = 0.25,
+) -> GeneratorConfig:
+    cfg = _tiny_config()
+    cfg.dataset.task = task
+    cfg.dataset.n_train = 320
+    cfg.dataset.n_test = 160
+    cfg.dataset.missing_rate = missing_rate
+    cfg.dataset.missing_mechanism = mechanism  # type: ignore[assignment]
+    return cfg
+
+
+@pytest.mark.parametrize("mechanism", ["mcar", "mar", "mnar"])
+@pytest.mark.parametrize("task", ["classification", "regression"])
+def test_generate_one_applies_missingness_and_emits_summary(task: str, mechanism: str) -> None:
+    cfg = _tiny_missingness_config(task=task, mechanism=mechanism, missing_rate=0.25)
+    bundle = generate_one(cfg, seed=2718, device="cpu")
+
+    assert bundle.X_train.shape[0] == cfg.dataset.n_train
+    assert bundle.X_test.shape[0] == cfg.dataset.n_test
+    assert bundle.X_train.shape[1] == bundle.X_test.shape[1]
+    assert len(bundle.feature_types) == bundle.X_train.shape[1]
+
+    assert torch.isnan(bundle.X_train).any()
+    assert torch.isnan(bundle.X_test).any()
+
+    payload = bundle.metadata["missingness"]
+    assert payload["enabled"] is True
+    assert payload["mechanism"] == mechanism
+    assert payload["target_rate"] == pytest.approx(0.25)
+    assert payload["missing_count_overall"] == (
+        payload["missing_count_train"] + payload["missing_count_test"]
+    )
+    assert 0.0 <= float(payload["realized_rate_train"]) <= 1.0
+    assert 0.0 <= float(payload["realized_rate_test"]) <= 1.0
+    assert 0.0 <= float(payload["realized_rate_overall"]) <= 1.0
+    assert abs(float(payload["realized_rate_overall"]) - 0.25) <= 0.05
+
+    if task == "classification":
+        assert bundle.y_train.dtype == torch.int64
+        assert bundle.y_test.dtype == torch.int64
+    else:
+        assert torch.isfinite(bundle.y_train).all()
+        assert torch.isfinite(bundle.y_test).all()
+
+
+def test_generate_one_missingness_disabled_preserves_default_behavior() -> None:
+    cfg = _tiny_missingness_config(task="classification", mechanism="none", missing_rate=0.0)
+    bundle = generate_one(cfg, seed=31415, device="cpu")
+    assert "missingness" not in bundle.metadata
+    assert not torch.isnan(bundle.X_train).any()
+    assert not torch.isnan(bundle.X_test).any()
+
+
+def test_generate_one_missingness_mask_is_reproducible_for_fixed_seed() -> None:
+    cfg = _tiny_missingness_config(task="classification", mechanism="mar", missing_rate=0.3)
+    a = generate_one(cfg, seed=12345, device="cpu")
+    b = generate_one(cfg, seed=12345, device="cpu")
+
+    assert torch.equal(torch.isnan(a.X_train), torch.isnan(b.X_train))
+    assert torch.equal(torch.isnan(a.X_test), torch.isnan(b.X_test))
+    assert a.metadata["missingness"] == b.metadata["missingness"]

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -2,7 +2,8 @@
 
 import torch
 
-from cauchy_generator.postprocess.postprocess import postprocess_dataset
+from cauchy_generator.config import DatasetConfig
+from cauchy_generator.postprocess.postprocess import inject_missingness, postprocess_dataset
 from conftest import make_generator as _make_generator
 
 
@@ -81,3 +82,72 @@ def test_deterministic() -> None:
     )
     torch.testing.assert_close(out1[0], out2[0])
     torch.testing.assert_close(out1[1], out2[1])
+
+
+def test_inject_missingness_disabled_noop() -> None:
+    g = _make_generator(5)
+    x_train = torch.randn(16, 4, generator=g)
+    x_test = torch.randn(8, 4, generator=g)
+    cfg = DatasetConfig(missing_rate=0.0, missing_mechanism="none")
+
+    out_train, out_test, summary = inject_missingness(
+        x_train, x_test, dataset_cfg=cfg, seed=77, attempt=0, device="cpu"
+    )
+
+    torch.testing.assert_close(out_train, x_train)
+    torch.testing.assert_close(out_test, x_test)
+    assert summary is None
+
+
+def test_inject_missingness_adds_nans_and_preserves_shape() -> None:
+    g = _make_generator(6)
+    x_train = torch.randn(64, 6, generator=g)
+    x_test = torch.randn(32, 6, generator=g)
+    cfg = DatasetConfig(missing_rate=0.3, missing_mechanism="mcar")
+
+    out_train, out_test, summary = inject_missingness(
+        x_train, x_test, dataset_cfg=cfg, seed=88, attempt=1, device="cpu"
+    )
+
+    assert out_train.shape == x_train.shape
+    assert out_test.shape == x_test.shape
+    assert torch.isnan(out_train).any()
+    assert torch.isnan(out_test).any()
+    assert summary is not None
+    assert summary["mechanism"] == "mcar"
+    assert summary["target_rate"] == 0.3
+    assert 0.0 <= float(summary["realized_rate_overall"]) <= 1.0
+
+
+def test_inject_missingness_deterministic_for_fixed_seed_and_attempt() -> None:
+    g = _make_generator(7)
+    x_train = torch.randn(96, 5, generator=g)
+    x_test = torch.randn(48, 5, generator=g)
+    cfg = DatasetConfig(missing_rate=0.35, missing_mechanism="mar")
+
+    a_train, a_test, _ = inject_missingness(
+        x_train, x_test, dataset_cfg=cfg, seed=101, attempt=2, device="cpu"
+    )
+    b_train, b_test, _ = inject_missingness(
+        x_train, x_test, dataset_cfg=cfg, seed=101, attempt=2, device="cpu"
+    )
+
+    assert torch.equal(torch.isnan(a_train), torch.isnan(b_train))
+    assert torch.equal(torch.isnan(a_test), torch.isnan(b_test))
+
+
+def test_inject_missingness_changes_for_different_seed() -> None:
+    g = _make_generator(8)
+    x_train = torch.randn(96, 5, generator=g)
+    x_test = torch.randn(48, 5, generator=g)
+    cfg = DatasetConfig(missing_rate=0.35, missing_mechanism="mnar")
+
+    a_train, a_test, _ = inject_missingness(
+        x_train, x_test, dataset_cfg=cfg, seed=202, attempt=0, device="cpu"
+    )
+    b_train, b_test, _ = inject_missingness(
+        x_train, x_test, dataset_cfg=cfg, seed=203, attempt=0, device="cpu"
+    )
+
+    assert not torch.equal(torch.isnan(a_train), torch.isnan(b_train))
+    assert not torch.equal(torch.isnan(a_test), torch.isnan(b_test))

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.13"
 
 [[package]]
 name = "cauchy-generator"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- integrate missingness injection into the generation/postprocess path after filtering
- apply deterministic MCAR/MAR/MNAR masks to X_train and X_test using NaN encoding
- add compact missingness metadata summary with mechanism, target rate, realized rates, and missing counts
- export postprocess inject_missingness helper and wire it from core/dataset.py
- add postprocess and generation integration tests for enabled/disabled behavior, shape invariants, and reproducibility
- bump package version to 0.1.10

## Linked Issues
- Closes #17
- Part of #15

## Validation
- uv run ruff check src tests
- uv run mypy src
- uv run pytest tests -q
