### PR TITLE
feat(missingness): add CLI overrides, presets, docs, and benchmark guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Torch-native steering metric extractor (`core/steering_metrics.py`) — avoids NumPy conversion during candidate scoring
 - Deterministic MCAR/MAR/MNAR missingness mask samplers with typed config validation coverage
 - End-to-end missingness injection in generation/postprocess path with compact metadata summaries for configured and realized rates
+- Missingness CLI overrides for `generate`: `--missing-rate`, `--missing-mechanism`, `--missing-mar-observed-fraction`, `--missing-mar-logit-scale`, `--missing-mnar-logit-scale`
+- Missingness presets: `configs/preset_missingness_mcar.yaml`, `configs/preset_missingness_mar.yaml`, `configs/preset_missingness_mnar.yaml`
+- Missingness wrapper script: `scripts/generate-missingness.sh`
+- Missingness benchmark guardrails (runtime vs missingness-off control + acceptance checks) surfaced in profile summaries and regression issues
 
 ### Changed
 
 - Eliminated NumPy bottlenecks across generation pipeline: `functions/`, `linalg/`, `converters/` now use torch-native implementations
 - Steering candidate scoring uses torch-native metric path and torch softmax selection to avoid CPU/NumPy round trips on accelerator runs
 - Diagnostics coverage aggregation now uses deterministic reservoir sampling per metric with configurable retention cap (`diagnostics.max_values_per_metric`) to bound memory on long runs
+- Root docs and script docs now include recommended missingness generation and benchmark commands
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,26 @@ uv run cauchy-gen generate --config configs/preset_diagnostics_on.yaml --num-dat
 uv run cauchy-gen generate --config configs/preset_steering_conservative.yaml --num-datasets 25 --diagnostics --out data/run_steering
 ```
 
+```bash
+# Missingness presets (MCAR/MAR/MNAR)
+uv run cauchy-gen generate --config configs/preset_missingness_mcar.yaml --num-datasets 25 --out data/run_missing_mcar
+uv run cauchy-gen generate --config configs/preset_missingness_mar.yaml --num-datasets 25 --out data/run_missing_mar
+uv run cauchy-gen generate --config configs/preset_missingness_mnar.yaml --num-datasets 25 --out data/run_missing_mnar
+```
+
+```bash
+# Override missingness controls directly from CLI with strict validation
+uv run cauchy-gen generate \
+  --config configs/default.yaml \
+  --num-datasets 25 \
+  --device cpu \
+  --missing-rate 0.25 \
+  --missing-mechanism mar \
+  --missing-mar-observed-fraction 0.6 \
+  --missing-mar-logit-scale 1.4 \
+  --out data/run_missing_cli_mar
+```
+
 ### Benchmarking Performance
 
 ```bash
@@ -90,6 +110,19 @@ uv run cauchy-gen benchmark \
   --out-dir benchmarks/results/smoke_cpu_diag
 ```
 
+```bash
+# Benchmark a missingness-enabled custom config with runtime + acceptance guardrails
+uv run cauchy-gen benchmark \
+  --config configs/preset_missingness_mar.yaml \
+  --profile custom \
+  --suite smoke \
+  --no-memory \
+  --out-dir benchmarks/results/smoke_missing_mar
+```
+
+When missingness is enabled, benchmark summaries include `missingness_guardrails` per profile,
+and guardrail warnings/failures are reflected in overall regression status.
+
 ______________________________________________________________________
 
 ## Research & Roadmap
@@ -97,7 +130,7 @@ ______________________________________________________________________
 The development of `cauchy-generator` is strictly driven by recent literature in Tabular Deep Learning.
 
 - **Meta-Feature Diagnostics:** A diagnostics module computes 15 structural metrics per dataset and aggregates coverage across generation runs. Soft steering is available to bias selection toward under-represented target bands.
-- **Missingness Generation:** Adding MAR/MCAR/MNAR mechanisms to simulate real-world data corruption.
+- **Missingness Generation:** Configurable MAR/MCAR/MNAR mechanisms with CLI overrides and benchmark guardrails.
 - **Shift-Aware SCMs:** Expanding the graph pipeline to support distribution shift and temporal drift.
 
 See [docs/improvement_ideas.md](docs/improvement_ideas.md) for the prioritized research backlog.

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -11,6 +11,11 @@ dataset:
   categorical_ratio_min: -0.5
   categorical_ratio_max: 1.2
   max_categorical_cardinality: 9
+  missing_rate: 0.0
+  missing_mechanism: none
+  missing_mar_observed_fraction: 0.5
+  missing_mar_logit_scale: 1.0
+  missing_mnar_logit_scale: 1.0
 graph:
   n_nodes_min: 2
   n_nodes_max: 32

--- a/configs/preset_missingness_mar.yaml
+++ b/configs/preset_missingness_mar.yaml
@@ -1,0 +1,20 @@
+seed: 17
+
+dataset:
+  task: classification
+  missing_rate: 0.25
+  missing_mechanism: mar
+  missing_mar_observed_fraction: 0.6
+  missing_mar_logit_scale: 1.4
+
+runtime:
+  device: auto
+
+output:
+  out_dir: data/run_missingness_mar
+
+diagnostics:
+  enabled: false
+
+steering:
+  enabled: false

--- a/configs/preset_missingness_mcar.yaml
+++ b/configs/preset_missingness_mcar.yaml
@@ -1,0 +1,18 @@
+seed: 13
+
+dataset:
+  task: classification
+  missing_rate: 0.2
+  missing_mechanism: mcar
+
+runtime:
+  device: auto
+
+output:
+  out_dir: data/run_missingness_mcar
+
+diagnostics:
+  enabled: false
+
+steering:
+  enabled: false

--- a/configs/preset_missingness_mnar.yaml
+++ b/configs/preset_missingness_mnar.yaml
@@ -1,0 +1,19 @@
+seed: 19
+
+dataset:
+  task: classification
+  missing_rate: 0.25
+  missing_mechanism: mnar
+  missing_mnar_logit_scale: 1.6
+
+runtime:
+  device: auto
+
+output:
+  out_dir: data/run_missingness_mnar
+
+diagnostics:
+  enabled: false
+
+steering:
+  enabled: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cauchy-generator"
-version = "0.1.10"
+version = "0.1.11"
 description = "High-performance synthetic tabular data generator"
 readme = "README.md"
 license = "MIT"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,6 +15,8 @@ These wrappers call `uv run cauchy-gen ...` from the repo root.
 - `scripts/generate-curriculum.sh [num_datasets] [device] [out_dir] [seed] [curriculum]`
   - Runs staged generation using `configs/curriculum_tabiclv2.yaml`.
   - `curriculum` accepts `auto`, `1`, `2`, or `3`.
+- `scripts/generate-missingness.sh [mechanism] [missing_rate] [num_datasets] [device] [out_dir] [seed]`
+  - Runs generation with CLI-level missingness overrides (`mcar`, `mar`, `mnar`).
 - `scripts/fetch-additional-references.sh`
   - Downloads the additional arXiv papers listed in `reference/ADDITIONAL_PAPERS.md`.
 - `scripts/benchmark-suite.sh [suite] [profile] [out_dir] [diagnostics] [diagnostics_out_dir]`
@@ -35,6 +37,8 @@ These wrappers call `uv run cauchy-gen ...` from the repo root.
 ./scripts/generate-curriculum.sh
 ./scripts/generate-curriculum.sh 25 cpu data/run_curriculum 123 auto
 ./scripts/generate-curriculum.sh 5 cpu data/run_stage3 123 3
+./scripts/generate-missingness.sh mcar 0.2 25 cpu data/run_missing_mcar 101
+./scripts/generate-missingness.sh mar 0.25 25 cpu data/run_missing_mar 102
 ./scripts/fetch-additional-references.sh
 ./scripts/benchmark-smoke.sh cpu
 ./scripts/benchmark-smoke.sh cpu on benchmarks/results/smoke_diag
@@ -42,6 +46,8 @@ These wrappers call `uv run cauchy-gen ...` from the repo root.
 ./scripts/benchmark-suite.sh smoke cpu benchmarks/results/smoke_cpu_diag on
 uv run cauchy-gen generate --config configs/preset_diagnostics_on.yaml --num-datasets 25 --diagnostics --out data/run_diag
 uv run cauchy-gen generate --config configs/preset_steering_conservative.yaml --num-datasets 25 --diagnostics --out data/run_steering
+uv run cauchy-gen generate --config configs/preset_missingness_mnar.yaml --num-datasets 25 --out data/run_missing_mnar
+uv run cauchy-gen benchmark --config configs/preset_missingness_mar.yaml --profile custom --suite smoke --no-memory --out-dir benchmarks/results/smoke_missing_mar
 ./scripts/bump-version.sh patch --dry-run
 ./scripts/bump-version.sh minor --tag
 ```
@@ -52,3 +58,6 @@ When diagnostics is enabled for benchmark scripts, coverage artifacts are writte
 
 - `<out_dir>/diagnostics/<profile>/coverage_summary.json`
 - `<out_dir>/diagnostics/<profile>/coverage_summary.md`
+
+When missingness is enabled in benchmark configs, summary JSON includes
+`profile_results[*].missingness_guardrails` and may escalate regression status via runtime or acceptance issues.

--- a/scripts/generate-missingness.sh
+++ b/scripts/generate-missingness.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "Error: uv is not installed. Install it from https://docs.astral.sh/uv/" >&2
+  exit 1
+fi
+
+MECHANISM="${1:-mcar}"
+MISSING_RATE="${2:-0.2}"
+NUM_DATASETS="${3:-10}"
+DEVICE="${4:-auto}"
+OUT_DIR="${5:-data/run_missing_${MECHANISM}_$(date +%Y%m%d_%H%M%S)}"
+SEED_ARG="${6:-}"
+
+case "$MECHANISM" in
+  mcar|mar|mnar) ;;
+  *)
+    echo "Error: mechanism must be one of: mcar, mar, mnar" >&2
+    exit 1
+    ;;
+esac
+
+CMD=(
+  uv run cauchy-gen generate
+  --config "configs/default.yaml"
+  --num-datasets "$NUM_DATASETS"
+  --device "$DEVICE"
+  --out "$OUT_DIR"
+  --missing-rate "$MISSING_RATE"
+  --missing-mechanism "$MECHANISM"
+)
+
+if [[ -n "$SEED_ARG" ]]; then
+  CMD+=(--seed "$SEED_ARG")
+fi
+
+echo "Running: ${CMD[*]}"
+"${CMD[@]}"

--- a/src/cauchy_generator/bench/report.py
+++ b/src/cauchy_generator/bench/report.py
@@ -34,11 +34,15 @@ def _build_profile_table(profile_results: list[dict[str, Any]]) -> list[str]:
     """Create a markdown table summarizing per-profile performance metrics."""
 
     lines = [
-        "| Profile | Device | Backend | Datasets/min | Elapsed (s) | Latency p95 (ms) | Peak RSS (MB) | Diagnostics |",
-        "|---|---|---:|---:|---:|---:|---:|---|",
+        "| Profile | Device | Backend | Datasets/min | Elapsed (s) | Latency p95 (ms) | Peak RSS (MB) | Diagnostics | Missingness |",
+        "|---|---|---:|---:|---:|---:|---:|---|---|",
     ]
     for result in profile_results:
         diagnostics_state = "on" if bool(result.get("diagnostics_enabled")) else "off"
+        missingness_state = "off"
+        guardrails = result.get("missingness_guardrails")
+        if isinstance(guardrails, dict) and bool(guardrails.get("enabled")):
+            missingness_state = str(guardrails.get("status", "pass"))
         lines.append(
             "| "
             f"{result.get('profile_key', '-')} | "
@@ -49,6 +53,7 @@ def _build_profile_table(profile_results: list[dict[str, Any]]) -> list[str]:
             f"{_format_float(result.get('latency_p95_ms'), 2)} | "
             f"{_format_float(result.get('peak_rss_mb'), 2)} | "
             f"{diagnostics_state} |"
+            f" {missingness_state} |"
         )
     return lines
 

--- a/src/cauchy_generator/bench/suite.py
+++ b/src/cauchy_generator/bench/suite.py
@@ -18,11 +18,12 @@ import torch
 from cauchy_generator.bench.baseline import compare_summary_to_baseline
 from cauchy_generator.bench.micro import run_microbenchmarks
 from cauchy_generator.bench.metrics import (
+    degradation_percent,
     reproducibility_signature,
     summarize_latencies,
 )
 from cauchy_generator.bench.throughput import run_throughput_benchmark
-from cauchy_generator.config import GeneratorConfig
+from cauchy_generator.config import GeneratorConfig, MISSINGNESS_MECHANISM_NONE
 from cauchy_generator.core.dataset import generate_batch_iter, generate_one
 from cauchy_generator.diagnostics import (
     CoverageAggregationConfig,
@@ -36,6 +37,7 @@ from cauchy_generator.hardware import (
     detect_hardware,
 )
 from cauchy_generator.rng import SeedManager
+from cauchy_generator.types import DatasetBundle
 
 
 DEFAULT_PROFILE_CONFIGS: dict[str, str] = {
@@ -43,6 +45,8 @@ DEFAULT_PROFILE_CONFIGS: dict[str, str] = {
     "cuda_desktop": "configs/benchmark_cuda_desktop.yaml",
     "cuda_h100": "configs/benchmark_cuda_h100.yaml",
 }
+MISSINGNESS_RATE_WARN_ABS_ERROR = 0.03
+MISSINGNESS_RATE_FAIL_ABS_ERROR = 0.05
 
 
 @dataclass(slots=True)
@@ -234,6 +238,211 @@ def _artifact_pointer(path: Path) -> str:
     return str(path.resolve())
 
 
+def _build_diagnostics_aggregator(config: GeneratorConfig) -> CoverageAggregator:
+    """Create a diagnostics coverage aggregator from config."""
+
+    return CoverageAggregator(
+        CoverageAggregationConfig(
+            include_spearman=bool(config.diagnostics.include_spearman),
+            histogram_bins=max(1, int(config.diagnostics.histogram_bins)),
+            quantiles=_coerce_quantiles(config.diagnostics.quantiles),
+            underrepresented_threshold=float(config.diagnostics.underrepresented_threshold),
+            max_values_per_metric=config.diagnostics.max_values_per_metric,
+            target_bands=_resolve_target_bands(config),
+        )
+    )
+
+
+def _is_missingness_enabled(config: GeneratorConfig) -> bool:
+    """Return whether missingness is enabled in config."""
+
+    return bool(
+        float(config.dataset.missing_rate) > 0.0
+        and str(config.dataset.missing_mechanism).strip().lower() != MISSINGNESS_MECHANISM_NONE
+    )
+
+
+def _matrix_cell_count(matrix: Any) -> int:
+    """Return cell count for a rank-2 matrix-like payload."""
+
+    shape = getattr(matrix, "shape", None)
+    if shape is None or len(shape) < 2:
+        return 0
+    try:
+        n_rows = max(0, int(shape[0]))
+        n_cols = max(0, int(shape[1]))
+    except (TypeError, ValueError):
+        return 0
+    return n_rows * n_cols
+
+
+def _severity_from_thresholds(value: float, *, warn: float, fail: float) -> str:
+    """Map a numeric value to pass/warn/fail severity."""
+
+    if value >= fail:
+        return "fail"
+    if value >= warn:
+        return "warn"
+    return "pass"
+
+
+def _status_from_issues(issues: list[dict[str, Any]]) -> str:
+    """Collapse per-metric issues into an overall status."""
+
+    severities = {str(issue.get("severity", "pass")) for issue in issues}
+    if "fail" in severities:
+        return "fail"
+    if "warn" in severities:
+        return "warn"
+    return "pass"
+
+
+@dataclass(slots=True)
+class _MissingnessAcceptanceCollector:
+    """Collect per-bundle missingness metadata for acceptance guardrails."""
+
+    target_rate: float
+    bundles_seen: int = 0
+    bundles_with_metadata: int = 0
+    missing_cells: int = 0
+    total_cells: int = 0
+
+    def update(self, bundle: DatasetBundle) -> None:
+        """Collect missingness counters for one generated bundle."""
+
+        self.bundles_seen += 1
+        payload = bundle.metadata.get("missingness")
+        if not isinstance(payload, dict):
+            return
+
+        total_cells = _matrix_cell_count(bundle.X_train) + _matrix_cell_count(bundle.X_test)
+        if total_cells <= 0:
+            return
+
+        missing_count_raw = payload.get("missing_count_overall")
+        if isinstance(missing_count_raw, bool) or not isinstance(missing_count_raw, (int, float)):
+            return
+        missing_count = int(max(0, min(total_cells, int(missing_count_raw))))
+
+        self.bundles_with_metadata += 1
+        self.total_cells += total_cells
+        self.missing_cells += missing_count
+
+    def build_summary(self) -> dict[str, Any]:
+        """Build acceptance guardrail metrics and issues."""
+
+        coverage_rate = (
+            float(self.bundles_with_metadata) / float(self.bundles_seen)
+            if self.bundles_seen > 0
+            else 0.0
+        )
+        realized_rate = (
+            float(self.missing_cells) / float(self.total_cells) if self.total_cells > 0 else 0.0
+        )
+        rate_abs_error = abs(realized_rate - float(self.target_rate))
+
+        issues: list[dict[str, Any]] = []
+        if self.bundles_with_metadata != self.bundles_seen:
+            issues.append(
+                {
+                    "metric": "missingness_metadata_coverage",
+                    "severity": "fail",
+                    "current": float(coverage_rate),
+                    "baseline": 1.0,
+                    "degradation_pct": float(max(0.0, (1.0 - coverage_rate) * 100.0)),
+                    "detail": "Missingness metadata must be present for all generated bundles.",
+                }
+            )
+
+        rate_error_pp = rate_abs_error * 100.0
+        rate_severity = _severity_from_thresholds(
+            rate_abs_error,
+            warn=MISSINGNESS_RATE_WARN_ABS_ERROR,
+            fail=MISSINGNESS_RATE_FAIL_ABS_ERROR,
+        )
+        if rate_severity != "pass":
+            threshold_pp = (
+                MISSINGNESS_RATE_FAIL_ABS_ERROR * 100.0
+                if rate_severity == "fail"
+                else MISSINGNESS_RATE_WARN_ABS_ERROR * 100.0
+            )
+            issues.append(
+                {
+                    "metric": "missingness_realized_rate_error_pp",
+                    "severity": rate_severity,
+                    "current": float(rate_error_pp),
+                    "baseline": float(threshold_pp),
+                    "degradation_pct": float(rate_error_pp),
+                    "detail": "Realized missing rate drifted from configured target.",
+                }
+            )
+
+        return {
+            "metadata_coverage_rate": float(coverage_rate),
+            "realized_rate_overall": float(realized_rate),
+            "rate_abs_error": float(rate_abs_error),
+            "issues": issues,
+            "status": _status_from_issues(issues),
+        }
+
+
+def _build_missingness_guardrail_issue(
+    *,
+    metric: str,
+    severity: str,
+    current: float | None,
+    baseline: float | None,
+    degradation_pct: float | None,
+    detail: str,
+) -> dict[str, Any]:
+    """Create a normalized guardrail issue payload."""
+
+    return {
+        "metric": metric,
+        "severity": severity,
+        "current": current,
+        "baseline": baseline,
+        "degradation_pct": degradation_pct,
+        "detail": detail,
+    }
+
+
+def _issue_sort_key(issue: dict[str, Any]) -> tuple[int, float]:
+    """Sort regression issues by severity then descending degradation percentage."""
+
+    severity = str(issue.get("severity", "warn"))
+    rank = 0 if severity == "fail" else 1 if severity == "warn" else 2
+    raw_degradation = issue.get("degradation_pct")
+    if isinstance(raw_degradation, bool) or not isinstance(raw_degradation, (int, float)):
+        return (rank, 0.0)
+    degradation = float(raw_degradation)
+    if not math.isfinite(degradation):
+        return (rank, 0.0)
+    return (rank, -degradation)
+
+
+def _collect_missingness_regression_issues(
+    profile_results: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Flatten per-profile missingness guardrail issues into regression issue payloads."""
+
+    issues: list[dict[str, Any]] = []
+    for result in profile_results:
+        guardrails = result.get("missingness_guardrails")
+        if not isinstance(guardrails, dict) or not bool(guardrails.get("enabled")):
+            continue
+        raw_issues = guardrails.get("issues")
+        if not isinstance(raw_issues, list):
+            continue
+        for issue in raw_issues:
+            if not isinstance(issue, dict):
+                continue
+            merged = dict(issue)
+            merged["profile"] = str(result.get("profile_key"))
+            issues.append(merged)
+    return issues
+
+
 def run_profile_benchmark(
     spec: ProfileRunSpec,
     *,
@@ -246,6 +455,8 @@ def run_profile_benchmark(
     no_hardware_aware: bool,
     collect_diagnostics: bool,
     diagnostics_root_dir: Path | None,
+    warn_threshold_pct: float,
+    fail_threshold_pct: float,
     diagnostics_occurrence_index: int,
     diagnostics_occurrence_total: int,
 ) -> dict[str, Any]:
@@ -275,25 +486,32 @@ def run_profile_benchmark(
     diagnostics_enabled = bool(collect_diagnostics and diagnostics_root_dir is not None)
     diagnostics_aggregator: CoverageAggregator | None = None
     if diagnostics_enabled:
-        diagnostics_aggregator = CoverageAggregator(
-            CoverageAggregationConfig(
-                include_spearman=bool(config.diagnostics.include_spearman),
-                histogram_bins=max(1, int(config.diagnostics.histogram_bins)),
-                quantiles=_coerce_quantiles(config.diagnostics.quantiles),
-                underrepresented_threshold=float(config.diagnostics.underrepresented_threshold),
-                max_values_per_metric=config.diagnostics.max_values_per_metric,
-                target_bands=_resolve_target_bands(config),
-            )
-        )
+        diagnostics_aggregator = _build_diagnostics_aggregator(config)
+
+    missingness_enabled = _is_missingness_enabled(config)
+    missingness_acceptance = (
+        _MissingnessAcceptanceCollector(target_rate=float(config.dataset.missing_rate))
+        if missingness_enabled
+        else None
+    )
+
+    on_bundle_callback = None
+    if diagnostics_aggregator is not None or missingness_acceptance is not None:
+
+        def _on_bundle(bundle: DatasetBundle) -> None:
+            if diagnostics_aggregator is not None:
+                diagnostics_aggregator.update_bundle(bundle)
+            if missingness_acceptance is not None:
+                missingness_acceptance.update(bundle)
+
+        on_bundle_callback = _on_bundle
 
     result = run_throughput_benchmark(
         config,
         num_datasets=num_datasets,
         warmup_datasets=warmup,
         device=requested_device,
-        on_bundle=(
-            diagnostics_aggregator.update_bundle if diagnostics_aggregator is not None else None
-        ),
+        on_bundle=on_bundle_callback,
     )
     result["profile_key"] = spec.key
     result["suite"] = suite
@@ -305,6 +523,7 @@ def run_profile_benchmark(
     result["hardware_profile"] = hw.profile
     result["diagnostics_enabled"] = diagnostics_enabled
     result["diagnostics_artifacts"] = None
+    result["missingness_guardrails"] = {"enabled": False}
 
     latency_stats = _collect_latency(
         config,
@@ -335,6 +554,87 @@ def run_profile_benchmark(
 
     if include_micro:
         result.update(run_microbenchmarks(config, device=requested_device, repeats=3))
+
+    if missingness_enabled and missingness_acceptance is not None:
+        baseline_config = _clone_config(config)
+        baseline_config.dataset.missing_rate = 0.0
+        baseline_config.dataset.missing_mechanism = MISSINGNESS_MECHANISM_NONE
+        baseline_diagnostics_aggregator: CoverageAggregator | None = None
+        if diagnostics_aggregator is not None:
+            baseline_diagnostics_aggregator = _build_diagnostics_aggregator(baseline_config)
+        baseline_missingness_acceptance = _MissingnessAcceptanceCollector(
+            target_rate=float(config.dataset.missing_rate)
+        )
+
+        baseline_on_bundle_callback = None
+        if baseline_diagnostics_aggregator is not None:
+
+            def _baseline_on_bundle(bundle: DatasetBundle) -> None:
+                baseline_diagnostics_aggregator.update_bundle(bundle)
+                baseline_missingness_acceptance.update(bundle)
+
+            baseline_on_bundle_callback = _baseline_on_bundle
+        else:
+
+            def _baseline_on_bundle(bundle: DatasetBundle) -> None:
+                baseline_missingness_acceptance.update(bundle)
+
+            baseline_on_bundle_callback = _baseline_on_bundle
+
+        baseline_throughput = run_throughput_benchmark(
+            baseline_config,
+            num_datasets=num_datasets,
+            warmup_datasets=warmup,
+            device=requested_device,
+            on_bundle=baseline_on_bundle_callback,
+        )
+        baseline_dpm = float(baseline_throughput.get("datasets_per_minute", 0.0))
+        current_dpm = float(result.get("datasets_per_minute", 0.0))
+        runtime_degradation = degradation_percent("datasets_per_minute", current_dpm, baseline_dpm)
+        runtime_degradation_value = (
+            float(runtime_degradation) if runtime_degradation is not None else 0.0
+        )
+        runtime_severity = _severity_from_thresholds(
+            runtime_degradation_value,
+            warn=float(warn_threshold_pct),
+            fail=float(fail_threshold_pct),
+        )
+
+        acceptance_summary = missingness_acceptance.build_summary()
+        issues = list(acceptance_summary["issues"])
+        if runtime_severity != "pass":
+            issues.append(
+                _build_missingness_guardrail_issue(
+                    metric="missingness_runtime_degradation_pct",
+                    severity=runtime_severity,
+                    current=current_dpm,
+                    baseline=baseline_dpm,
+                    degradation_pct=runtime_degradation_value,
+                    detail=(
+                        "Missingness-enabled throughput regressed versus an equivalent "
+                        "missingness-disabled control run."
+                    ),
+                )
+            )
+
+        result["missingness_guardrails"] = {
+            "enabled": True,
+            "mechanism": str(config.dataset.missing_mechanism),
+            "target_rate": float(config.dataset.missing_rate),
+            "metadata_coverage_rate": float(acceptance_summary["metadata_coverage_rate"]),
+            "realized_rate_overall": float(acceptance_summary["realized_rate_overall"]),
+            "rate_abs_error": float(acceptance_summary["rate_abs_error"]),
+            "rate_warn_abs_error": float(MISSINGNESS_RATE_WARN_ABS_ERROR),
+            "rate_fail_abs_error": float(MISSINGNESS_RATE_FAIL_ABS_ERROR),
+            "runtime_baseline_datasets_per_minute": baseline_dpm,
+            "runtime_degradation_pct": (
+                float(runtime_degradation) if runtime_degradation is not None else None
+            ),
+            "runtime_warn_threshold_pct": float(warn_threshold_pct),
+            "runtime_fail_threshold_pct": float(fail_threshold_pct),
+            "issues": issues,
+            "status": _status_from_issues(issues),
+        }
 
     if (
         diagnostics_enabled
@@ -450,6 +750,8 @@ def run_benchmark_suite(
                 collect_reproducibility=enable_repro,
                 collect_diagnostics=collect_diagnostics,
                 diagnostics_root_dir=diagnostics_root_dir,
+                warn_threshold_pct=float(warn_threshold_pct),
+                fail_threshold_pct=float(fail_threshold_pct),
                 include_micro=include_micro,
                 no_hardware_aware=no_hardware_aware,
                 diagnostics_occurrence_index=occurrence_index,
@@ -478,6 +780,15 @@ def run_benchmark_suite(
             "fail_threshold_pct": float(fail_threshold_pct),
             "issues": [],
         }
+
+    missingness_issues = _collect_missingness_regression_issues(profile_results)
+    if missingness_issues:
+        existing_issues = regression.get("issues", [])
+        if not isinstance(existing_issues, list):
+            existing_issues = []
+        all_issues = [*existing_issues, *missingness_issues]
+        regression["issues"] = sorted(all_issues, key=_issue_sort_key)
+        regression["status"] = _status_from_issues(regression["issues"])
 
     regression["fail_on_regression"] = bool(fail_on_regression)
     regression["hard_fail"] = bool(fail_on_regression and regression.get("status") == "fail")

--- a/src/cauchy_generator/cli.py
+++ b/src/cauchy_generator/cli.py
@@ -6,7 +6,7 @@ import argparse
 import datetime as dt
 import math
 import sys
-from dataclasses import fields
+from dataclasses import asdict, fields
 from pathlib import Path
 from typing import Any
 
@@ -16,7 +16,13 @@ from cauchy_generator.bench.suite import resolve_profile_run_specs, run_benchmar
 from cauchy_generator.config import (
     CURRICULUM_STAGE_AUTO,
     CURRICULUM_STAGE_CLI_CHOICES,
+    DatasetConfig,
     GeneratorConfig,
+    MISSINGNESS_MECHANISM_MAR,
+    MISSINGNESS_MECHANISM_MCAR,
+    MISSINGNESS_MECHANISM_MNAR,
+    MISSINGNESS_MECHANISM_NONE,
+    normalize_missing_mechanism,
 )
 from cauchy_generator.core.dataset import generate_batch_iter
 from cauchy_generator.diagnostics import (
@@ -34,6 +40,12 @@ from cauchy_generator.hardware import (
 from cauchy_generator.io.parquet_writer import write_parquet_shards_stream
 
 DEVICE_CHOICES = ("auto", "cpu", "cuda", "mps")
+MISSINGNESS_MECHANISM_CLI_CHOICES = (
+    MISSINGNESS_MECHANISM_NONE,
+    MISSINGNESS_MECHANISM_MCAR,
+    MISSINGNESS_MECHANISM_MAR,
+    MISSINGNESS_MECHANISM_MNAR,
+)
 META_TARGET_SUPPORTED_METRICS = frozenset(
     field_info.name for field_info in fields(DatasetMetrics) if field_info.name != "task"
 )
@@ -56,6 +68,75 @@ def _non_negative_int(value: str) -> int:
     if parsed < 0:
         raise argparse.ArgumentTypeError(f"Expected a non-negative integer, got {value}.")
     return parsed
+
+
+def _parse_finite_float(raw: str, *, flag: str) -> float:
+    """argparse helper: parse a finite float."""
+
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"Invalid {flag} value '{raw}'. Expected a number."
+        ) from exc
+    if not math.isfinite(value):
+        raise argparse.ArgumentTypeError(f"Invalid {flag} value '{raw}'. Expected a finite number.")
+    return value
+
+
+def _parse_missing_rate_arg(raw: str) -> float:
+    """argparse type: parse missing rate in [0, 1]."""
+
+    value = _parse_finite_float(raw, flag="--missing-rate")
+    if not (0.0 <= value <= 1.0):
+        raise argparse.ArgumentTypeError(
+            f"Invalid --missing-rate value '{raw}'. Expected a finite value in [0, 1]."
+        )
+    return value
+
+
+def _parse_missing_positive_scale_arg(raw: str, *, flag: str) -> float:
+    """argparse helper: parse positive finite missingness scale."""
+
+    value = _parse_finite_float(raw, flag=flag)
+    if value <= 0.0:
+        raise argparse.ArgumentTypeError(
+            f"Invalid {flag} value '{raw}'. Expected a finite value > 0."
+        )
+    return value
+
+
+def _parse_missing_mar_observed_fraction_arg(raw: str) -> float:
+    """argparse type: parse MAR observed-feature fraction in (0, 1]."""
+
+    value = _parse_finite_float(raw, flag="--missing-mar-observed-fraction")
+    if not (0.0 < value <= 1.0):
+        raise argparse.ArgumentTypeError(
+            "Invalid --missing-mar-observed-fraction value "
+            f"'{raw}'. Expected a finite value in (0, 1]."
+        )
+    return value
+
+
+def _parse_missing_mar_logit_scale_arg(raw: str) -> float:
+    """argparse type: parse MAR logit scale > 0."""
+
+    return _parse_missing_positive_scale_arg(raw, flag="--missing-mar-logit-scale")
+
+
+def _parse_missing_mnar_logit_scale_arg(raw: str) -> float:
+    """argparse type: parse MNAR logit scale > 0."""
+
+    return _parse_missing_positive_scale_arg(raw, flag="--missing-mnar-logit-scale")
+
+
+def _parse_missing_mechanism_arg(raw: str) -> str:
+    """argparse type: normalize missingness mechanism values."""
+
+    try:
+        return normalize_missing_mechanism(raw)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
 
 
 def _parse_meta_target_arg(raw: str) -> tuple[str, tuple[float, float, float]]:
@@ -259,6 +340,37 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     g.add_argument(
+        "--missing-rate",
+        type=_parse_missing_rate_arg,
+        default=None,
+        help="Override dataset missing rate in [0, 1].",
+    )
+    g.add_argument(
+        "--missing-mechanism",
+        type=_parse_missing_mechanism_arg,
+        choices=MISSINGNESS_MECHANISM_CLI_CHOICES,
+        default=None,
+        help="Override missingness mechanism (none/mcar/mar/mnar).",
+    )
+    g.add_argument(
+        "--missing-mar-observed-fraction",
+        type=_parse_missing_mar_observed_fraction_arg,
+        default=None,
+        help="Override MAR observed-feature fraction in (0, 1].",
+    )
+    g.add_argument(
+        "--missing-mar-logit-scale",
+        type=_parse_missing_mar_logit_scale_arg,
+        default=None,
+        help="Override MAR logit scale (> 0).",
+    )
+    g.add_argument(
+        "--missing-mnar-logit-scale",
+        type=_parse_missing_mnar_logit_scale_arg,
+        default=None,
+        help="Override MNAR logit scale (> 0).",
+    )
+    g.add_argument(
         "--curriculum",
         default=None,
         choices=CURRICULUM_STAGE_CLI_CHOICES,
@@ -375,6 +487,39 @@ def _resolve_config_with_hardware(
     return config, hw
 
 
+def _apply_missingness_cli_overrides(config: GeneratorConfig, args: argparse.Namespace) -> None:
+    """Apply and validate missingness overrides from CLI arguments."""
+
+    has_missingness_override = any(
+        value is not None
+        for value in (
+            args.missing_rate,
+            args.missing_mechanism,
+            args.missing_mar_observed_fraction,
+            args.missing_mar_logit_scale,
+            args.missing_mnar_logit_scale,
+        )
+    )
+    if not has_missingness_override:
+        return
+
+    if args.missing_rate is not None:
+        config.dataset.missing_rate = float(args.missing_rate)
+    if args.missing_mechanism is not None:
+        config.dataset.missing_mechanism = args.missing_mechanism
+    if args.missing_mar_observed_fraction is not None:
+        config.dataset.missing_mar_observed_fraction = float(args.missing_mar_observed_fraction)
+    if args.missing_mar_logit_scale is not None:
+        config.dataset.missing_mar_logit_scale = float(args.missing_mar_logit_scale)
+    if args.missing_mnar_logit_scale is not None:
+        config.dataset.missing_mnar_logit_scale = float(args.missing_mnar_logit_scale)
+
+    try:
+        config.dataset = DatasetConfig(**asdict(config.dataset))
+    except ValueError as exc:
+        _raise_usage_error(str(exc))
+
+
 def _run_generate(args: argparse.Namespace) -> int:
     """Execute the ``generate`` command."""
 
@@ -390,6 +535,7 @@ def _run_generate(args: argparse.Namespace) -> int:
             if args.curriculum == CURRICULUM_STAGE_AUTO
             else int(args.curriculum)
         )
+    _apply_missingness_cli_overrides(config, args)
     steering_requested = bool(config.steering.enabled or args.steer_meta or bool(args.meta_target))
     resolved_target_specs = _resolve_meta_target_specs(config, args.meta_target)
     if steering_requested:
@@ -556,12 +702,17 @@ def _print_profile_result_line(result: dict[str, Any]) -> None:
         if isinstance(json_pointer, str) and json_pointer:
             diagnostics_hint = f" diagnostics={json_pointer}"
 
+    missingness_hint = ""
+    guardrails = result.get("missingness_guardrails")
+    if isinstance(guardrails, dict) and bool(guardrails.get("enabled")):
+        missingness_hint = f" missingness={guardrails.get('status', 'pass')}"
+
     print(
         f"[{result.get('profile_key')}] device={result.get('device')} "
         f"backend={result.get('hardware_backend')} "
         f"datasets/min={float(result.get('datasets_per_minute', 0.0)):.2f} "
         f"latency_p95_ms={float(result.get('latency_p95_ms', 0.0)):.2f}"
-        f"{diagnostics_hint}"
+        f"{diagnostics_hint}{missingness_hint}"
     )
 
 

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -186,3 +186,32 @@ def test_benchmark_cli_diagnostics_pointers_resolve_when_roots_differ(tmp_path) 
     assert md_path.exists()
     assert json_path.resolve().is_relative_to(diagnostics_out.resolve())
     assert md_path.resolve().is_relative_to(diagnostics_out.resolve())
+
+
+def test_benchmark_cli_missingness_guardrails_are_emitted(tmp_path) -> None:
+    out = tmp_path / "summary_missingness.json"
+    code = main(
+        [
+            "benchmark",
+            "--config",
+            "configs/preset_missingness_mcar.yaml",
+            "--profile",
+            "custom",
+            "--suite",
+            "smoke",
+            "--num-datasets",
+            "2",
+            "--warmup",
+            "0",
+            "--no-hardware-aware",
+            "--no-memory",
+            "--json-out",
+            str(out),
+        ]
+    )
+    assert code == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    profile = payload["profile_results"][0]
+    guardrails = profile["missingness_guardrails"]
+    assert guardrails["enabled"] is True
+    assert guardrails["status"] in {"pass", "warn", "fail"}

--- a/tests/test_benchmark_suite.py
+++ b/tests/test_benchmark_suite.py
@@ -1,6 +1,8 @@
 import numpy as np
 from pathlib import Path
 
+import pytest
+
 import cauchy_generator.bench.suite as suite_mod
 from cauchy_generator.bench.micro import run_microbenchmarks
 from cauchy_generator.bench.suite import ProfileRunSpec, run_benchmark_suite
@@ -28,6 +30,13 @@ def _tiny_cpu_config() -> GeneratorConfig:
         "num_datasets": 2,
         "warmup_datasets": 0,
     }
+    return cfg
+
+
+def _tiny_missingness_cpu_config() -> GeneratorConfig:
+    cfg = _tiny_cpu_config()
+    cfg.dataset.missing_rate = 0.25
+    cfg.dataset.missing_mechanism = "mcar"  # type: ignore[assignment]
     return cfg
 
 
@@ -59,6 +68,134 @@ def test_run_benchmark_suite_smoke_single_profile() -> None:
     assert result["profile_key"] == "cpu_test"
     assert result["datasets_per_minute"] > 0
     assert result["latency_p95_ms"] >= 0
+
+
+def test_run_benchmark_suite_missingness_guardrails_emit_metrics() -> None:
+    cfg = _tiny_missingness_cpu_config()
+    spec = ProfileRunSpec(key="cpu_test", config=cfg, device="cpu")
+
+    summary = run_benchmark_suite(
+        [spec],
+        suite="smoke",
+        warn_threshold_pct=100.0,
+        fail_threshold_pct=200.0,
+        baseline_payload=None,
+        num_datasets_override=4,
+        warmup_override=0,
+        collect_memory=False,
+        collect_reproducibility=False,
+        collect_diagnostics=False,
+        diagnostics_root_dir=None,
+        fail_on_regression=False,
+        no_hardware_aware=True,
+    )
+
+    result = summary["profile_results"][0]
+    guardrails = result["missingness_guardrails"]
+    assert guardrails["enabled"] is True
+    assert guardrails["status"] == "pass"
+    assert guardrails["metadata_coverage_rate"] == pytest.approx(1.0)
+    assert 0.0 <= guardrails["realized_rate_overall"] <= 1.0
+    assert guardrails["runtime_baseline_datasets_per_minute"] > 0.0
+
+
+def test_run_benchmark_suite_missingness_runtime_guardrail_updates_regression_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = _tiny_missingness_cpu_config()
+    spec = ProfileRunSpec(key="cpu_test", config=cfg, device="cpu")
+    calls: list[dict[str, bool]] = []
+
+    def _stub_throughput(
+        config,
+        *,
+        num_datasets: int,
+        warmup_datasets: int = 10,
+        device: str | None = None,
+        on_bundle=None,
+    ):
+        _ = warmup_datasets
+        _ = device
+        missing_enabled = float(config.dataset.missing_rate) > 0.0
+        calls.append(
+            {
+                "missing_enabled": missing_enabled,
+                "has_callback": on_bundle is not None,
+            }
+        )
+        dpm = 80.0 if missing_enabled else 100.0
+        dps = dpm / 60.0
+        elapsed = (float(num_datasets) / dps) if dps > 0 else 0.0
+        if on_bundle is not None and missing_enabled:
+            for i in range(num_datasets):
+                on_bundle(
+                    DatasetBundle(
+                        X_train=np.zeros((3, 4), dtype=np.float32),
+                        y_train=np.zeros(3, dtype=np.int64),
+                        X_test=np.zeros((1, 4), dtype=np.float32),
+                        y_test=np.zeros(1, dtype=np.int64),
+                        feature_types=["num", "num", "num", "num"],
+                        metadata={
+                            "seed": i,
+                            "attempt_used": 0,
+                            "missingness": {"missing_count_overall": 4},
+                        },
+                    )
+                )
+        return {
+            "profile": config.benchmark.profile_name,
+            "num_datasets": num_datasets,
+            "warmup_datasets": warmup_datasets,
+            "elapsed_seconds": elapsed,
+            "datasets_per_second": dps,
+            "datasets_per_minute": dpm,
+            "slo_pass_100_datasets_per_min": dpm >= 100.0,
+        }
+
+    monkeypatch.setattr("cauchy_generator.bench.suite.run_throughput_benchmark", _stub_throughput)
+    monkeypatch.setattr(
+        "cauchy_generator.bench.suite._collect_latency",
+        lambda _cfg, *, device, num_samples: {
+            "latency_samples": float(num_samples),
+            "latency_mean_ms": 1.0,
+            "latency_p95_ms": 1.0,
+            "latency_min_ms": 1.0,
+            "latency_max_ms": 1.0,
+        },
+    )
+
+    summary = run_benchmark_suite(
+        [spec],
+        suite="smoke",
+        warn_threshold_pct=10.0,
+        fail_threshold_pct=20.0,
+        baseline_payload=None,
+        num_datasets_override=1,
+        warmup_override=0,
+        collect_memory=False,
+        collect_reproducibility=False,
+        collect_diagnostics=False,
+        diagnostics_root_dir=None,
+        fail_on_regression=False,
+        no_hardware_aware=True,
+    )
+
+    result = summary["profile_results"][0]
+    guardrails = result["missingness_guardrails"]
+    assert guardrails["enabled"] is True
+    assert guardrails["status"] == "fail"
+    assert any(
+        issue["metric"] == "missingness_runtime_degradation_pct" and issue["severity"] == "fail"
+        for issue in guardrails["issues"]
+    )
+    assert summary["regression"]["status"] == "fail"
+    assert any(
+        issue["metric"] == "missingness_runtime_degradation_pct"
+        for issue in summary["regression"]["issues"]
+    )
+    baseline_calls = [call for call in calls if not call["missing_enabled"]]
+    assert baseline_calls
+    assert all(call["has_callback"] for call in baseline_calls)
 
 
 def test_run_microbenchmarks_returns_expected_keys() -> None:

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -280,6 +280,111 @@ def test_generate_cli_enables_diagnostics_flag(
     assert captured["diagnostics_enabled"] is True
 
 
+def test_generate_cli_applies_missingness_overrides_no_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _stub_generate_batch_iter(
+        config,
+        *,
+        num_datasets: int,
+        seed: int | None = None,
+        device: str | None = None,
+    ):
+        captured["missing_rate"] = config.dataset.missing_rate
+        captured["missing_mechanism"] = config.dataset.missing_mechanism
+        captured["missing_mar_observed_fraction"] = config.dataset.missing_mar_observed_fraction
+        captured["missing_mar_logit_scale"] = config.dataset.missing_mar_logit_scale
+        captured["missing_mnar_logit_scale"] = config.dataset.missing_mnar_logit_scale
+        _ = seed
+        _ = device
+        for _ in range(num_datasets):
+            yield object()
+
+    monkeypatch.setattr("cauchy_generator.cli.generate_batch_iter", _stub_generate_batch_iter)
+
+    code = main(
+        [
+            "generate",
+            "--config",
+            "configs/default.yaml",
+            "--num-datasets",
+            "1",
+            "--device",
+            "cpu",
+            "--missing-rate",
+            "0.3",
+            "--missing-mechanism",
+            "mar",
+            "--missing-mar-observed-fraction",
+            "0.7",
+            "--missing-mar-logit-scale",
+            "1.8",
+            "--missing-mnar-logit-scale",
+            "2.2",
+            "--no-hardware-aware",
+            "--no-write",
+        ]
+    )
+    assert code == 0
+    assert captured["missing_rate"] == pytest.approx(0.3)
+    assert captured["missing_mechanism"] == "mar"
+    assert captured["missing_mar_observed_fraction"] == pytest.approx(0.7)
+    assert captured["missing_mar_logit_scale"] == pytest.approx(1.8)
+    assert captured["missing_mnar_logit_scale"] == pytest.approx(2.2)
+
+
+def test_generate_cli_rejects_invalid_missingness_combination() -> None:
+    with pytest.raises(SystemExit) as exc:
+        main(
+            [
+                "generate",
+                "--config",
+                "configs/default.yaml",
+                "--num-datasets",
+                "1",
+                "--device",
+                "cpu",
+                "--missing-rate",
+                "0.2",
+                "--missing-mechanism",
+                "none",
+                "--no-hardware-aware",
+                "--no-write",
+            ]
+        )
+    assert int(exc.value.code) == 2
+
+
+@pytest.mark.parametrize(
+    ("flag", "value"),
+    [
+        ("--missing-rate", "1.1"),
+        ("--missing-rate", "-0.1"),
+        ("--missing-mar-observed-fraction", "0"),
+        ("--missing-mar-observed-fraction", "1.1"),
+        ("--missing-mar-logit-scale", "0"),
+        ("--missing-mnar-logit-scale", "-1"),
+    ],
+)
+def test_generate_cli_rejects_invalid_missingness_scalar(flag: str, value: str) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main(
+            [
+                "generate",
+                "--config",
+                "configs/default.yaml",
+                "--num-datasets",
+                "1",
+                flag,
+                value,
+                "--no-write",
+            ]
+        )
+    assert int(exc.value.code) == 2
+
+
 def test_generate_cli_applies_meta_target_override_and_enables_steering(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -403,3 +508,40 @@ def test_generate_cli_rejects_unknown_config_target_key_when_steering_enabled(
             ]
         )
     assert int(exc.value.code) == 2
+
+
+def test_generate_cli_missingness_no_write_end_to_end(tmp_path) -> None:
+    cfg = GeneratorConfig.from_yaml("configs/default.yaml")
+    cfg.runtime.device = "cpu"
+    cfg.dataset.task = "classification"
+    cfg.dataset.n_train = 32
+    cfg.dataset.n_test = 8
+    cfg.dataset.n_features_min = 8
+    cfg.dataset.n_features_max = 8
+    cfg.graph.n_nodes_min = 2
+    cfg.graph.n_nodes_max = 4
+    cfg.output.out_dir = str(tmp_path / "run")
+    cfg.diagnostics.enabled = False
+    config_path = tmp_path / "missingness_e2e.yaml"
+    config_path.write_text(yaml.safe_dump(cfg.to_dict()), encoding="utf-8")
+
+    code = main(
+        [
+            "generate",
+            "--config",
+            str(config_path),
+            "--num-datasets",
+            "1",
+            "--device",
+            "cpu",
+            "--missing-rate",
+            "0.2",
+            "--missing-mechanism",
+            "mnar",
+            "--missing-mnar-logit-scale",
+            "1.5",
+            "--no-hardware-aware",
+            "--no-write",
+        ]
+    )
+    assert code == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,9 @@
 import pytest
 
 from cauchy_generator.config import (
+    MISSINGNESS_MECHANISM_MAR,
     MISSINGNESS_MECHANISM_MCAR,
+    MISSINGNESS_MECHANISM_MNAR,
     MISSINGNESS_MECHANISM_NONE,
     GeneratorConfig,
 )
@@ -57,6 +59,22 @@ def test_load_diagnostics_and_steering_presets() -> None:
     assert cfg_steering.meta_feature_targets
     for band in cfg_steering.meta_feature_targets.values():
         assert len(band) in {2, 3}
+
+
+def test_load_missingness_presets() -> None:
+    cfg_mcar = GeneratorConfig.from_yaml("configs/preset_missingness_mcar.yaml")
+    assert cfg_mcar.dataset.missing_mechanism == MISSINGNESS_MECHANISM_MCAR
+    assert cfg_mcar.dataset.missing_rate > 0.0
+
+    cfg_mar = GeneratorConfig.from_yaml("configs/preset_missingness_mar.yaml")
+    assert cfg_mar.dataset.missing_mechanism == MISSINGNESS_MECHANISM_MAR
+    assert cfg_mar.dataset.missing_rate > 0.0
+    assert cfg_mar.dataset.missing_mar_observed_fraction > 0.0
+
+    cfg_mnar = GeneratorConfig.from_yaml("configs/preset_missingness_mnar.yaml")
+    assert cfg_mnar.dataset.missing_mechanism == MISSINGNESS_MECHANISM_MNAR
+    assert cfg_mnar.dataset.missing_rate > 0.0
+    assert cfg_mnar.dataset.missing_mnar_logit_scale > 0.0
 
 
 def test_load_benchmark_profiles() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.13"
 
 [[package]]
 name = "cauchy-generator"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- add strict missingness CLI overrides for `cauchy-gen generate` (`--missing-rate`, mechanism, MAR/MNAR controls) with validation and config re-validation
- add missingness presets for MCAR/MAR/MNAR plus a `scripts/generate-missingness.sh` helper and docs updates
- add missingness benchmark guardrails for runtime impact and acceptance metadata/rate checks, and merge guardrail outcomes into benchmark regression status
- ensure baseline runtime comparison uses equivalent callback overhead to avoid false warn/fail outcomes
- bump project version to `0.1.11`

## Validation
- `uv run ruff check src tests`
- `uv run mypy src`
- `uv run pytest -q`

Closes #18