### PR TITLE
feat(dag-artifacts): define adjacency/assignment schema + config compatibility (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Missingness presets: `configs/preset_missingness_mcar.yaml`, `configs/preset_missingness_mar.yaml`, `configs/preset_missingness_mnar.yaml`
 - Missingness wrapper script: `scripts/generate-missingness.sh`
 - Missingness benchmark guardrails (runtime vs missingness-off control + acceptance checks) surfaced in profile summaries and regression issues
+- Versioned DAG lineage schema validator for `metadata.lineage` (`schema_name=cauchy_generator.dag_lineage`, `schema_version=1.0.0`) with strict adjacency/assignment checks and backward-compatible optional metadata mode
 
 ### Changed
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -71,6 +71,27 @@ Persist generated outputs as Parquet shards with a sidecar metadata JSON per sha
 
 Current metadata includes summary graph stats, config lineage, and optional `missingness` payload fields (configured/realized rates and per-split counts). Full DAG artifact export is tracked under RD-001.
 
+#### DAG Lineage Schema (v1)
+
+RD-001 issue #45 defines the versioned lineage schema and validator API, without changing current emission defaults.
+
+- Location: `metadata.lineage`
+- Envelope:
+  - `schema_name`: must equal `cauchy_generator.dag_lineage`
+  - `schema_version`: must equal `1.0.0`
+- Graph payload:
+  - `graph.n_nodes`: integer, `>= 2`
+  - `graph.adjacency`: dense square `n_nodes x n_nodes` matrix of integer `0/1` values
+  - Validation enforces diagonal zeros and upper-triangular encoding (topological-order DAG form)
+- Assignment payload:
+  - `assignments.feature_to_node`: list of node indices in `[0, n_nodes - 1]`
+  - `assignments.target_to_node`: node index in `[0, n_nodes - 1]`
+
+Compatibility contract:
+
+- Validation accepts metadata without `lineage` by default (`required=False`) so existing configs/runs stay valid.
+- Consumers can require lineage explicitly (`required=True`) when later rollout phases make emission mandatory.
+
 ## Runtime Profiles
 
 - `configs/default.yaml`: balanced local development profile.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cauchy-generator"
-version = "0.1.11"
+version = "0.1.12"
 description = "High-performance synthetic tabular data generator"
 readme = "README.md"
 license = "MIT"

--- a/src/cauchy_generator/io/__init__.py
+++ b/src/cauchy_generator/io/__init__.py
@@ -1,5 +1,20 @@
 """Storage helpers."""
 
+from .lineage_schema import (
+    LINEAGE_SCHEMA_NAME,
+    LINEAGE_SCHEMA_VERSION,
+    LineageValidationError,
+    validate_lineage_payload,
+    validate_metadata_lineage,
+)
 from .parquet_writer import write_parquet_shards, write_parquet_shards_stream
 
-__all__ = ["write_parquet_shards", "write_parquet_shards_stream"]
+__all__ = [
+    "LINEAGE_SCHEMA_NAME",
+    "LINEAGE_SCHEMA_VERSION",
+    "LineageValidationError",
+    "validate_lineage_payload",
+    "validate_metadata_lineage",
+    "write_parquet_shards",
+    "write_parquet_shards_stream",
+]

--- a/src/cauchy_generator/io/lineage_schema.py
+++ b/src/cauchy_generator/io/lineage_schema.py
@@ -1,0 +1,194 @@
+"""Validation helpers for DAG lineage metadata schema."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, NoReturn, TypeGuard, cast
+
+LINEAGE_SCHEMA_NAME = "cauchy_generator.dag_lineage"
+LINEAGE_SCHEMA_VERSION = "1.0.0"
+
+_LINEAGE_REQUIRED_KEYS = frozenset({"schema_name", "schema_version", "graph", "assignments"})
+_GRAPH_REQUIRED_KEYS = frozenset({"n_nodes", "adjacency"})
+_ASSIGNMENTS_REQUIRED_KEYS = frozenset({"feature_to_node", "target_to_node"})
+
+
+class LineageValidationError(ValueError):
+    """Raised when a lineage payload fails schema validation."""
+
+
+def _is_int(value: object) -> TypeGuard[int]:
+    """Return True for int values excluding bool."""
+
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _raise(path: str, message: str) -> NoReturn:
+    """Raise a schema validation error with a field path."""
+
+    raise LineageValidationError(f"{path}: {message}")
+
+
+def _as_mapping(value: object, *, path: str) -> Mapping[str, Any]:
+    """Validate and return a mapping payload."""
+
+    if not isinstance(value, Mapping):
+        _raise(path, "must be an object")
+    return cast(Mapping[str, Any], value)
+
+
+def _validate_required_and_unknown_keys(
+    payload: Mapping[str, Any],
+    *,
+    path: str,
+    required_keys: frozenset[str],
+) -> None:
+    """Validate required keys are present and reject unknown keys."""
+
+    raw_keys = list(payload.keys())
+    non_string_keys = [key for key in raw_keys if not isinstance(key, str)]
+    if non_string_keys:
+        formatted = ", ".join(repr(key) for key in non_string_keys)
+        _raise(path, f"contains non-string key(s): {formatted}")
+
+    keys = {str(key) for key in raw_keys}
+    missing = sorted(required_keys - keys)
+    if missing:
+        _raise(path, f"missing required key(s): {', '.join(missing)}")
+
+    unknown = sorted(keys - required_keys)
+    if unknown:
+        _raise(path, f"unknown key(s): {', '.join(unknown)}")
+
+
+def _validate_assignment_node_index(value: object, *, n_nodes: int, path: str) -> None:
+    """Validate one assignment node index with bound checks."""
+
+    if not _is_int(value):
+        _raise(path, "must be an integer node index")
+    if value < 0 or value >= n_nodes:
+        _raise(path, f"must be in range [0, {n_nodes - 1}]")
+
+
+def _validate_lineage_payload(payload: object, *, root_path: str) -> None:
+    """Validate the DAG lineage payload rooted at a given path."""
+
+    lineage = _as_mapping(payload, path=root_path)
+    _validate_required_and_unknown_keys(
+        lineage,
+        path=root_path,
+        required_keys=_LINEAGE_REQUIRED_KEYS,
+    )
+
+    schema_name = lineage["schema_name"]
+    schema_name_path = f"{root_path}.schema_name"
+    if not isinstance(schema_name, str):
+        _raise(schema_name_path, "must be a string")
+    if schema_name != LINEAGE_SCHEMA_NAME:
+        _raise(
+            schema_name_path,
+            f"must equal '{LINEAGE_SCHEMA_NAME}' (got '{schema_name}')",
+        )
+
+    schema_version = lineage["schema_version"]
+    schema_version_path = f"{root_path}.schema_version"
+    if not isinstance(schema_version, str):
+        _raise(schema_version_path, "must be a string")
+    if schema_version != LINEAGE_SCHEMA_VERSION:
+        _raise(
+            schema_version_path,
+            f"must equal '{LINEAGE_SCHEMA_VERSION}' (got '{schema_version}')",
+        )
+
+    graph_path = f"{root_path}.graph"
+    graph = _as_mapping(lineage["graph"], path=graph_path)
+    _validate_required_and_unknown_keys(
+        graph,
+        path=graph_path,
+        required_keys=_GRAPH_REQUIRED_KEYS,
+    )
+
+    n_nodes = graph["n_nodes"]
+    n_nodes_path = f"{graph_path}.n_nodes"
+    if not _is_int(n_nodes):
+        _raise(n_nodes_path, "must be an integer >= 2")
+    if n_nodes < 2:
+        _raise(n_nodes_path, "must be >= 2")
+
+    adjacency = graph["adjacency"]
+    adjacency_path = f"{graph_path}.adjacency"
+    if not isinstance(adjacency, list):
+        _raise(adjacency_path, "must be a list of rows")
+    if len(adjacency) != n_nodes:
+        _raise(adjacency_path, f"must have {n_nodes} rows (got {len(adjacency)})")
+
+    for row_idx, row in enumerate(adjacency):
+        row_path = f"{adjacency_path}[{row_idx}]"
+        if not isinstance(row, list):
+            _raise(row_path, "must be a list")
+        if len(row) != n_nodes:
+            _raise(row_path, f"must have {n_nodes} columns (got {len(row)})")
+        for col_idx, value in enumerate(row):
+            value_path = f"{row_path}[{col_idx}]"
+            if not _is_int(value):
+                _raise(value_path, "must be integer 0 or 1")
+            if value not in (0, 1):
+                _raise(value_path, "must be 0 or 1")
+            if row_idx == col_idx and value != 0:
+                _raise(value_path, "must be 0 on the diagonal")
+            if row_idx > col_idx and value != 0:
+                _raise(value_path, "must be 0 for upper-triangular DAG encoding")
+
+    assignments_path = f"{root_path}.assignments"
+    assignments = _as_mapping(lineage["assignments"], path=assignments_path)
+    _validate_required_and_unknown_keys(
+        assignments,
+        path=assignments_path,
+        required_keys=_ASSIGNMENTS_REQUIRED_KEYS,
+    )
+
+    feature_to_node = assignments["feature_to_node"]
+    feature_to_node_path = f"{assignments_path}.feature_to_node"
+    if not isinstance(feature_to_node, list):
+        _raise(feature_to_node_path, "must be a list of node indices")
+    for idx, node_index in enumerate(feature_to_node):
+        _validate_assignment_node_index(
+            node_index,
+            n_nodes=n_nodes,
+            path=f"{feature_to_node_path}[{idx}]",
+        )
+
+    _validate_assignment_node_index(
+        assignments["target_to_node"],
+        n_nodes=n_nodes,
+        path=f"{assignments_path}.target_to_node",
+    )
+
+
+def validate_lineage_payload(payload: Mapping[str, Any]) -> None:
+    """Validate a lineage payload object rooted at `lineage`."""
+
+    _validate_lineage_payload(payload, root_path="lineage")
+
+
+def validate_metadata_lineage(metadata: Mapping[str, Any], *, required: bool = False) -> None:
+    """Validate `metadata.lineage` when present.
+
+    When `required` is False (default), missing lineage is accepted for backward compatibility.
+    """
+
+    metadata_payload = _as_mapping(metadata, path="metadata")
+    if "lineage" not in metadata_payload:
+        if required:
+            _raise("metadata.lineage", "is required")
+        return
+    _validate_lineage_payload(metadata_payload["lineage"], root_path="metadata.lineage")
+
+
+__all__ = [
+    "LINEAGE_SCHEMA_NAME",
+    "LINEAGE_SCHEMA_VERSION",
+    "LineageValidationError",
+    "validate_lineage_payload",
+    "validate_metadata_lineage",
+]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,7 @@ from cauchy_generator.config import (
     MISSINGNESS_MECHANISM_NONE,
     GeneratorConfig,
 )
+from cauchy_generator.io.lineage_schema import validate_metadata_lineage
 
 
 def test_load_default_config() -> None:
@@ -37,6 +38,15 @@ def test_load_default_config() -> None:
     assert cfg.dataset.missing_mar_observed_fraction == 0.5
     assert cfg.dataset.missing_mar_logit_scale == 1.0
     assert cfg.dataset.missing_mnar_logit_scale == 1.0
+
+
+def test_default_config_metadata_is_compatible_with_optional_lineage() -> None:
+    cfg = GeneratorConfig.from_yaml("configs/default.yaml")
+    metadata = {
+        "seed": int(cfg.seed),
+        "config": cfg.to_dict(),
+    }
+    validate_metadata_lineage(metadata, required=False)
 
 
 def test_load_cuda_presets() -> None:

--- a/tests/test_lineage_schema.py
+++ b/tests/test_lineage_schema.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import pytest
+
+from cauchy_generator.io.lineage_schema import (
+    LINEAGE_SCHEMA_NAME,
+    LINEAGE_SCHEMA_VERSION,
+    LineageValidationError,
+    validate_lineage_payload,
+    validate_metadata_lineage,
+)
+
+
+def _valid_lineage_payload() -> dict[str, Any]:
+    return {
+        "schema_name": LINEAGE_SCHEMA_NAME,
+        "schema_version": LINEAGE_SCHEMA_VERSION,
+        "graph": {
+            "n_nodes": 4,
+            "adjacency": [
+                [0, 1, 1, 0],
+                [0, 0, 1, 1],
+                [0, 0, 0, 1],
+                [0, 0, 0, 0],
+            ],
+        },
+        "assignments": {
+            "feature_to_node": [0, 1, 1, 2, 3],
+            "target_to_node": 2,
+        },
+    }
+
+
+def test_validate_lineage_payload_accepts_valid_payload() -> None:
+    validate_lineage_payload(_valid_lineage_payload())
+
+
+def test_validate_metadata_lineage_accepts_absent_payload_when_optional() -> None:
+    validate_metadata_lineage({"seed": 1}, required=False)
+
+
+def test_validate_metadata_lineage_rejects_missing_payload_when_required() -> None:
+    with pytest.raises(LineageValidationError, match=r"metadata\.lineage: is required"):
+        validate_metadata_lineage({"seed": 1}, required=True)
+
+
+def test_validate_lineage_payload_rejects_wrong_schema_name() -> None:
+    payload = _valid_lineage_payload()
+    payload["schema_name"] = "other.schema"
+    with pytest.raises(
+        LineageValidationError,
+        match=r"lineage\.schema_name: must equal 'cauchy_generator\.dag_lineage'",
+    ):
+        validate_lineage_payload(payload)
+
+
+def test_validate_lineage_payload_rejects_unknown_root_keys() -> None:
+    payload = _valid_lineage_payload()
+    payload["extra"] = True
+    with pytest.raises(LineageValidationError, match=r"lineage: unknown key\(s\): extra"):
+        validate_lineage_payload(payload)
+
+
+def test_validate_lineage_payload_rejects_non_square_adjacency() -> None:
+    payload = _valid_lineage_payload()
+    graph = deepcopy(payload["graph"])
+    assert isinstance(graph, dict)
+    graph["adjacency"] = [[0, 1], [0, 0]]
+    payload["graph"] = graph
+    with pytest.raises(
+        LineageValidationError,
+        match=r"lineage\.graph\.adjacency: must have 4 rows \(got 2\)",
+    ):
+        validate_lineage_payload(payload)
+
+
+def test_validate_lineage_payload_rejects_non_binary_adjacency_values() -> None:
+    payload = _valid_lineage_payload()
+    graph = deepcopy(payload["graph"])
+    assert isinstance(graph, dict)
+    adjacency = deepcopy(graph["adjacency"])
+    assert isinstance(adjacency, list)
+    adjacency[0][1] = 2
+    graph["adjacency"] = adjacency
+    payload["graph"] = graph
+    with pytest.raises(
+        LineageValidationError, match=r"lineage\.graph\.adjacency\[0\]\[1\]: must be 0 or 1"
+    ):
+        validate_lineage_payload(payload)
+
+
+def test_validate_lineage_payload_rejects_bool_adjacency_values() -> None:
+    payload = _valid_lineage_payload()
+    graph = deepcopy(payload["graph"])
+    assert isinstance(graph, dict)
+    adjacency = deepcopy(graph["adjacency"])
+    assert isinstance(adjacency, list)
+    adjacency[0][1] = True
+    graph["adjacency"] = adjacency
+    payload["graph"] = graph
+    with pytest.raises(
+        LineageValidationError,
+        match=r"lineage\.graph\.adjacency\[0\]\[1\]: must be integer 0 or 1",
+    ):
+        validate_lineage_payload(payload)
+
+
+def test_validate_lineage_payload_rejects_diagonal_edges() -> None:
+    payload = _valid_lineage_payload()
+    graph = deepcopy(payload["graph"])
+    assert isinstance(graph, dict)
+    adjacency = deepcopy(graph["adjacency"])
+    assert isinstance(adjacency, list)
+    adjacency[2][2] = 1
+    graph["adjacency"] = adjacency
+    payload["graph"] = graph
+    with pytest.raises(
+        LineageValidationError,
+        match=r"lineage\.graph\.adjacency\[2\]\[2\]: must be 0 on the diagonal",
+    ):
+        validate_lineage_payload(payload)
+
+
+def test_validate_lineage_payload_rejects_lower_triangle_edges() -> None:
+    payload = _valid_lineage_payload()
+    graph = deepcopy(payload["graph"])
+    assert isinstance(graph, dict)
+    adjacency = deepcopy(graph["adjacency"])
+    assert isinstance(adjacency, list)
+    adjacency[3][1] = 1
+    graph["adjacency"] = adjacency
+    payload["graph"] = graph
+    with pytest.raises(
+        LineageValidationError,
+        match=r"lineage\.graph\.adjacency\[3\]\[1\]: must be 0 for upper-triangular DAG encoding",
+    ):
+        validate_lineage_payload(payload)
+
+
+def test_validate_lineage_payload_rejects_feature_assignment_out_of_range() -> None:
+    payload = _valid_lineage_payload()
+    assignments = deepcopy(payload["assignments"])
+    assert isinstance(assignments, dict)
+    assignments["feature_to_node"] = [0, 1, 4]
+    payload["assignments"] = assignments
+    with pytest.raises(
+        LineageValidationError,
+        match=r"lineage\.assignments\.feature_to_node\[2\]: must be in range \[0, 3\]",
+    ):
+        validate_lineage_payload(payload)
+
+
+def test_validate_lineage_payload_rejects_target_assignment_out_of_range() -> None:
+    payload = _valid_lineage_payload()
+    assignments = deepcopy(payload["assignments"])
+    assert isinstance(assignments, dict)
+    assignments["target_to_node"] = -1
+    payload["assignments"] = assignments
+    with pytest.raises(
+        LineageValidationError,
+        match=r"lineage\.assignments\.target_to_node: must be in range \[0, 3\]",
+    ):
+        validate_lineage_payload(payload)
+
+
+def test_validate_metadata_lineage_rejects_non_object_payload() -> None:
+    with pytest.raises(LineageValidationError, match=r"metadata\.lineage: must be an object"):
+        validate_metadata_lineage({"lineage": 42}, required=False)

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.13"
 
 [[package]]
 name = "cauchy-generator"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary
Parent epic: #44

Implements #45 by defining and validating a stable, versioned DAG lineage schema for adjacency and assignment payloads, while keeping current generation/config behavior backward-compatible.

## What Changed
- Added metadata.lineage schema validator API in src/cauchy_generator/io/lineage_schema.py
  - schema_name = cauchy_generator.dag_lineage
  - schema_version = 1.0.0
  - strict validation for graph adjacency + assignment lineage
  - clear, path-specific validation errors via LineageValidationError
- Exported validator/types from cauchy_generator.io
- Added unit tests for valid payloads and malformed cases
- Added config compatibility regression test (lineage remains optional by default)
- Documented schema + compatibility contract in docs/implementation.md
- Added changelog entry under Unreleased
- Bumped patch version 0.1.11 -> 0.1.12

## Compatibility
- No new config keys introduced in this PR
- Existing configs remain valid without modification
- validate_metadata_lineage(..., required=False) preserves backward compatibility

## Validation
- uv run mypy src
- uv run ruff check src/cauchy_generator/io/lineage_schema.py tests/test_lineage_schema.py tests/test_config.py
- uv run pytest -q tests/test_lineage_schema.py tests/test_config.py tests/test_parquet_writer.py

## Acceptance Criteria Mapping
- Schema documented and versioned: ✅
- Validation rejects malformed lineage payloads with clear errors: ✅
- Existing configs remain valid without modification: ✅

Closes #45
