### PR TITLE
docs: align roadmap prioritization with mission and right-size epic chains

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,13 +7,14 @@ It maps the mission and strategic pillars in `README.md` to:
 - current implemented capabilities
 - known gaps
 - prioritized roadmap items with explicit exit criteria
+- canonical status/rank sequencing and GitHub issue tracking
 
 Related docs:
 
-- Prioritized queue: `docs/improvement_ideas.md`
 - Decision rubric and go/no-go gates: `docs/backlog_decision_rules.md`
 - Evidence appendix: `docs/literature_evidence_2026.md`
 - Current implementation details: `docs/implementation.md`
+- Historical pointer only (non-canonical): `docs/improvement_ideas.md`
 
 ## Status Labels
 
@@ -22,18 +23,48 @@ Related docs:
 - `planned`: scoped and prioritized, not implemented.
 - `research`: exploratory with higher uncertainty or risk.
 
+## Canonical Planning Metadata
+
+`docs/roadmap.md` is the single source of truth for planning state. Every active item is tracked here with:
+
+- status and milestone lane
+- priority rank
+- GitHub epic/issue mapping
+- dependencies and exit criteria
+
+If any other document disagrees with this file, this file is authoritative.
+
+## Canonical Priority Queue
+
+Lower rank means higher priority. Rank `0` is reserved for completed items retained for traceability.
+
+| Rank | Roadmap ID | Item                                                         | Status      | Milestone | GitHub Tracking                                 |
+| ---- | ---------- | ------------------------------------------------------------ | ----------- | --------- | ----------------------------------------------- |
+| 0    | RD-001     | Ground-truth DAG artifact export                             | implemented | Now       | `#44 -> #45 -> #46 -> #47 -> #48` (completed)   |
+| 0    | RD-003     | Missingness generation (MCAR/MAR/MNAR)                       | implemented | Now       | `#15 -> #17 -> #18` (completed)                 |
+| 0    | RD-008     | Meta-feature coverage steering                               | implemented | Now       | `#9` (completed epic)                           |
+| 1    | RD-006     | Curriculum complexity scaling (features + graph)             | planned     | Now       | `#49 -> #50 -> #51 -> #52 -> #53`               |
+| 2    | RD-004     | Shift-aware SCM generation                                   | planned     | Next      | `#64 -> #72 -> #73 -> #74 -> #75`               |
+| 3    | RD-012     | Noise family diversification for synthetic generation        | planned     | Next      | `#24 -> #25 -> #26 -> #27`                      |
+| 4    | RD-010     | Hardware-adaptive autotuning beyond coarse FLOPs tiers       | planned     | Next      | `#54 -> #55 -> #56 -> #70 -> #57 -> #71 -> #58` |
+| 5    | RD-011     | Mechanism family mix expansion (BNN/GP kernels/interactions) | planned     | Next      | `#28 -> #29 -> #30 -> #68 -> #69 -> #31 -> #32` |
+| 6    | RD-007     | Many-class and high-cardinality expansion                    | research    | Next      | `#19 -> #43 -> (#20 -> #21 -> #22 -> #23)`      |
+| 7    | RD-005     | Robustness stress profiles (hard-task/adversarial regimes)   | research    | Next      | `#65 -> #76 -> #79 -> #78 -> #77`               |
+| 8    | RD-009     | Parallel/distributed generation and writing                  | research    | Next      | `#66 -> #80 -> #81 -> #82 -> #83`               |
+| 9    | RD-002     | Interventional and counterfactual generation modes           | research    | Later     | `#67 -> #84 -> #85 -> #86 -> #87`               |
+
 ## Current Capability Matrix
 
-| README Mission/Pillar Claim                                         | Current State | Evidence in Repo                                                                                                                                         | Gap                                                                                                 | Roadmap IDs            |
-| ------------------------------------------------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------- |
-| Foundation model pretraining with diverse structural priors         | `partial`     | DAG-based generation, mixed-type conversion, diagnostics extraction/coverage aggregation, soft steering, configurable missingness, throughput benchmarks | Shift/hard-task regimes and many-class expansion are not implemented end-to-end                     | RD-004, RD-005, RD-007 |
-| Causal discovery with ground-truth DAGs and interventional datasets | `partial`     | DAG lineage metadata is emitted per dataset and persisted as compact shard-level artifacts with schema validation and benchmark guardrails               | Interventional/counterfactual generation semantics are not implemented                              | RD-002                 |
-| Robustness testing with hard tasks, shifts, adversarial regimes     | `partial`     | Basic filtering and diagnostics proxies exist; missingness mechanisms are implemented with deterministic controls and benchmark guardrails               | No explicit robustness profiles or shift/drift controls                                             | RD-004, RD-005         |
-| Causal structural integrity (hierarchical dependencies)             | `implemented` | Graph-driven node pipeline and multi-family function composition                                                                                         | Deeper mechanism controls are not user-configurable                                                 | RD-007                 |
-| Tabular realism (mixed type + postprocess hooks)                    | `partial`     | Numeric/categorical converters, E.13 postprocessing, and configurable missingness mechanisms are implemented                                             | High-cardinality/many-class limits remain conservative                                              | RD-006, RD-007         |
-| Complexity curriculum scales features/nodes/samples                 | `partial`     | Curriculum mode stages row/split regime                                                                                                                  | Curriculum does not yet stage feature count or graph complexity                                     | RD-006                 |
-| Hardware-native performance (Torch + hardware-aware tuning)         | `partial`     | Torch CPU/CUDA/MPS path, hardware detection, coarse profile-based tuning, and benchmark suite                                                            | Hardware-adaptive autotuning is not implemented; parallel/distributed generation is not implemented | RD-010, RD-009         |
-| Parallel streaming Parquet sharding                                 | `partial`     | Streaming Parquet writing exists                                                                                                                         | Writing is currently single-process sequential                                                      | RD-009                 |
+| README Mission/Pillar Claim                                         | Current State | Evidence in Repo                                                                                                                                         | Gap                                                                                                               | Roadmap IDs                            |
+| ------------------------------------------------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| Foundation model pretraining with diverse structural priors         | `partial`     | DAG-based generation, mixed-type conversion, diagnostics extraction/coverage aggregation, soft steering, configurable missingness, throughput benchmarks | Shift/hard-task regimes, mechanism/noise-family controls, and many-class expansion are not implemented end-to-end | RD-004, RD-005, RD-007, RD-011, RD-012 |
+| Causal discovery with ground-truth DAGs and interventional datasets | `partial`     | DAG lineage metadata is emitted per dataset and persisted as compact shard-level artifacts with schema validation and benchmark guardrails               | Interventional/counterfactual generation semantics are not implemented                                            | RD-002                                 |
+| Robustness testing with hard tasks, shifts, adversarial regimes     | `partial`     | Basic filtering and diagnostics proxies exist; missingness mechanisms are implemented with deterministic controls and benchmark guardrails               | No explicit robustness profiles or shift/drift/noise-diversity controls                                           | RD-004, RD-005, RD-012                 |
+| Causal structural integrity (hierarchical dependencies)             | `implemented` | Graph-driven node pipeline and multi-family function composition                                                                                         | Deeper mechanism-family controls are not user-configurable                                                        | RD-007, RD-011                         |
+| Tabular realism (mixed type + postprocess hooks)                    | `partial`     | Numeric/categorical converters, E.13 postprocessing, and configurable missingness mechanisms are implemented                                             | High-cardinality/many-class limits and noise-family diversity remain conservative                                 | RD-006, RD-007, RD-012                 |
+| Complexity curriculum scales features/nodes/samples                 | `partial`     | Curriculum mode stages row/split regime                                                                                                                  | Curriculum does not yet stage feature count or graph complexity                                                   | RD-006                                 |
+| Hardware-native performance (Torch + hardware-aware tuning)         | `partial`     | Torch CPU/CUDA/MPS path, hardware detection, coarse profile-based tuning, and benchmark suite                                                            | Hardware-adaptive autotuning is not implemented; parallel/distributed generation is not implemented               | RD-010, RD-009                         |
+| Parallel streaming Parquet sharding                                 | `partial`     | Streaming Parquet writing exists                                                                                                                         | Writing is currently single-process sequential                                                                    | RD-009                                 |
 
 ## Roadmap Items
 
@@ -62,6 +93,7 @@ Related docs:
 - Mission alignment: causal discovery
 - Pillar alignment: causal structural integrity
 - Goal: support observational + interventional sampling tracks with explicit intervention specs.
+- GitHub tracking: epic `#67`; dependency chain `#84 -> #85 -> #86 -> #87`
 - Repo touchpoints: `src/cauchy_generator/config.py`, `src/cauchy_generator/core/dataset.py`, `src/cauchy_generator/core/node_pipeline.py`, `src/cauchy_generator/cli.py`
 - Exit criteria:
   - Config supports opt-in intervention mode with safe default (`off`).
@@ -93,6 +125,7 @@ Related docs:
 - Mission alignment: robustness testing, causal discovery
 - Pillar alignment: causal structural integrity, tabular realism
 - Goal: introduce controlled distribution-shift/drift modes in graph and mechanism sampling.
+- GitHub tracking: epic `#64`; dependency chain `#72 -> #73 -> #74 -> #75`
 - Repo touchpoints: `src/cauchy_generator/config.py`, `src/cauchy_generator/core/dataset.py`, `src/cauchy_generator/sampling/random_weights.py`
 - Exit criteria:
   - Shift profiles are opt-in and backward-compatible.
@@ -106,6 +139,7 @@ Related docs:
 - Mission alignment: robustness testing
 - Pillar alignment: tabular realism
 - Goal: define reproducible stress presets (low-SNR, class imbalance, harder interactions).
+- GitHub tracking: epic `#65`; dependency chain `#76 -> #79 -> #78 -> #77`
 - Repo touchpoints: `src/cauchy_generator/config.py`, `src/cauchy_generator/functions/random_functions.py`, `src/cauchy_generator/postprocess/postprocess.py`, `src/cauchy_generator/bench/`
 - Exit criteria:
   - Presets are selectable via config/CLI and remain opt-in.
@@ -119,6 +153,7 @@ Related docs:
 - Mission alignment: foundation model pretraining
 - Pillar alignment: tabular realism
 - Goal: extend curriculum stages beyond row count to feature/node/depth complexity.
+- GitHub tracking: epic `#49`; dependency chain `#50 -> #51 -> #52 -> #53`
 - Repo touchpoints: `src/cauchy_generator/config.py`, `src/cauchy_generator/core/dataset.py`, `configs/curriculum_tabiclv2.yaml`
 - Exit criteria:
   - Stage definitions include row, feature, and graph complexity controls.
@@ -127,16 +162,17 @@ Related docs:
 
 ### RD-007: Many-Class and High-Cardinality Expansion
 
-- Status: `planned`
-- Milestone: `Now`
+- Status: `research`
+- Milestone: `Next`
 - Mission alignment: foundation model pretraining
 - Pillar alignment: tabular realism, causal structural integrity
-- Goal: raise practical class/cardinality limits while preserving filter quality.
+- Goal: assess feasibility and, only if viable, raise practical class/cardinality limits while preserving filter quality.
+- GitHub tracking: epic `#19`; research gate `#43`; conditional chain `#20 -> #21 -> #22 -> #23`
 - Repo touchpoints: `src/cauchy_generator/config.py`, `src/cauchy_generator/converters/categorical.py`, `src/cauchy_generator/filtering/torch_rf_filter.py`
 - Exit criteria:
-  - Config supports expanded ranges with safe defaults preserving current behavior.
-  - Integration tests cover high-class-count generation success and label validity.
-  - Filter rejection rates remain within defined guardrails on benchmark profiles.
+  - Feasibility report produces explicit `go` / `narrow-go` / `no-go` decision under predefined thresholds.
+  - If `go` or `narrow-go`: implementation chain (`#20`-`#23`) lands with backward-compatible defaults.
+  - If `no-go`: roadmap records deferral or narrowed scope with rationale.
 
 ### RD-008: Meta-Feature Coverage Steering
 
@@ -158,6 +194,7 @@ Related docs:
 - Mission alignment: foundation model pretraining
 - Pillar alignment: hardware-native performance
 - Goal: support multi-worker generation and shard writing with deterministic seed partitioning.
+- GitHub tracking: epic `#66`; dependency chain `#80 -> #81 -> #82 -> #83`
 - Repo touchpoints: `src/cauchy_generator/core/dataset.py`, `src/cauchy_generator/io/parquet_writer.py`, `src/cauchy_generator/cli.py`
 - Exit criteria:
   - Worker-aware config/API is backward-compatible and opt-in.
@@ -171,12 +208,43 @@ Related docs:
 - Mission alignment: foundation model pretraining
 - Pillar alignment: hardware-native performance
 - Goal: evolve hardware-aware scaling from static coarse profile tiers to bounded adaptive tuning based on observed throughput/memory behavior.
+- GitHub tracking: epic `#54`; dependency chain `#55 -> #56 -> #70 -> #57 -> #71 -> #58`
 - Repo touchpoints: `src/cauchy_generator/hardware.py`, `src/cauchy_generator/config.py`, `src/cauchy_generator/cli.py`, `src/cauchy_generator/bench/suite.py`, `src/cauchy_generator/bench/report.py`
 - Exit criteria:
   - Adaptive mode improves throughput versus profile baseline on at least one CUDA hardware class without violating memory guardrails.
   - Unknown CUDA devices can run adaptive tuning without relying only on static fallback tiers.
   - Fixed seed + fixed hardware signature reproduces selected tuning settings within declared deterministic behavior.
   - Opt-out mode preserves current profile-only behavior.
+
+### RD-011: Mechanism Family Mix Expansion (BNN/GP Kernels/Interactions)
+
+- Status: `planned`
+- Milestone: `Next`
+- Mission alignment: foundation model pretraining, robustness testing
+- Pillar alignment: causal structural integrity, tabular realism
+- Goal: add explicit mechanism-family mix controls and broaden function families (including BNN/GP-kernel/interactions) with observable lineage metadata.
+- GitHub tracking: epic `#28`; dependency chain `#29 -> #30 -> #68 -> #69 -> #31 -> #32`
+- Repo touchpoints: `src/cauchy_generator/config.py`, `src/cauchy_generator/functions/random_functions.py`, `src/cauchy_generator/core/node_pipeline.py`, `src/cauchy_generator/core/dataset.py`, `src/cauchy_generator/bench/suite.py`
+- Exit criteria:
+  - Config supports explicit mechanism-family mix controls with backward-compatible defaults.
+  - Expanded mechanism families are selectable and covered by unit/integration tests.
+  - Metadata/diagnostics expose effective family mix in generated bundles.
+  - Presets/docs/bench guardrails exist for contributors.
+
+### RD-012: Noise Family Diversification for Synthetic Generation
+
+- Status: `planned`
+- Milestone: `Next`
+- Mission alignment: foundation model pretraining, robustness testing
+- Pillar alignment: tabular realism
+- Goal: add explicit noise-family controls and support multiple noise families/mixtures beyond current implicit behavior.
+- GitHub tracking: epic `#24`; dependency chain `#25 -> #26 -> #27`
+- Repo touchpoints: `src/cauchy_generator/config.py`, `src/cauchy_generator/sampling/`, `src/cauchy_generator/core/dataset.py`, `src/cauchy_generator/bench/suite.py`
+- Exit criteria:
+  - Multiple noise families are supported and test-covered.
+  - Default behavior remains stable when not enabled.
+  - Selection and metadata/reporting integration are available.
+  - Docs and presets make workflow discoverable.
 
 ## Milestone Board
 
@@ -189,14 +257,16 @@ Related docs:
 ### Now
 
 - RD-006 curriculum complexity scaling
-- RD-007 many-class/high-cardinality expansion
 
 ### Next
 
 - RD-004 shift-aware SCM generation
+- RD-012 noise family diversification
+- RD-010 hardware-adaptive autotuning
+- RD-011 mechanism family mix expansion
+- RD-007 many-class/high-cardinality expansion (research-gated)
 - RD-005 robustness stress profiles
 - RD-009 parallel/distributed generation
-- RD-010 hardware-adaptive autotuning
 
 ### Later
 
@@ -205,7 +275,12 @@ Related docs:
 ## Dependencies and Sequencing
 
 - RD-003 and RD-008 are implemented and provide a stronger baseline for remaining realism and robustness roadmap work.
+- RD-007 is explicitly research-gated by `#19/#43` before conditional rollout issues (`#20`-`#23`) proceed.
+- RD-011 formalizes mechanism-family diversification controls tracked in epic `#28`.
+- RD-012 formalizes noise-family diversification controls tracked in epic `#24`.
 - RD-005 now primarily depends on RD-004 for shift/drift controls, and can build on existing RD-003 missingness infrastructure.
+- RD-005 can additionally consume RD-011 mechanism-family controls and RD-012 noise-family controls for stress-profile composition.
+- RD-004/RD-005/RD-009/RD-002 now have explicit epic trackers and PR-scoped delivery chains.
 - RD-002 builds on completed RD-001 lineage artifacts for intervention metadata extensions.
 - RD-009 should land after interface contracts for RD-001/RD-006 are stable to avoid repeated parallelism refactors.
 - RD-010 can build on the current detection/profile baseline while remaining opt-in and benchmark-guarded.


### PR DESCRIPTION
## Summary
This PR updates `docs/roadmap.md` to align prioritization and execution sequencing with the README mission/use-cases and the current GitHub epic structure.

## What Changed
- Re-ranked the canonical priority queue to reflect mission-aligned execution order and tracker reality.
- Reclassified RD-007 as research-gated (`#19/#43`) and moved it out of `Now`.
- Added concrete GitHub tracking chains for previously unmapped roadmap items:
  - RD-004: `#64 -> #72 -> #73 -> #74 -> #75`
  - RD-005: `#65 -> #76 -> #79 -> #78 -> #77`
  - RD-009: `#66 -> #80 -> #81 -> #82 -> #83`
  - RD-002: `#67 -> #84 -> #85 -> #86 -> #87`
- Updated mechanism and autotune chains to right-sized PR sequencing:
  - RD-011 chain now includes `#68/#69`
  - RD-010 chain now includes `#70/#71`
- Updated milestone/dependency notes to reflect research gating and explicit epic coverage.

## Why
- Avoids roadmap-vs-issue drift.
- Makes sizing/chunking explicit for reviewable PRs.
- Ensures each mission pillar has actionable, correctly-scoped tracker coverage.

## Validation
- Verified open epic coverage now includes `#19, #24, #28, #49, #54, #64, #65, #66, #67`.
- Verified roadmap queue entries reference concrete epic/dependency chains rather than placeholders.

