### PR TITLE
feat(curriculum): enforce stagewise feature/node-count scaling in runtime

### DIFF
--- a/src/cauchy_generator/core/dataset.py
+++ b/src/cauchy_generator/core/dataset.py
@@ -185,15 +185,17 @@ def _torch_dtype(config: GeneratorConfig) -> torch.dtype:
     return torch.float64 if config.runtime.torch_dtype == "float64" else torch.float32
 
 
-def _sample_node_count(config: GeneratorConfig, generator: torch.Generator, device: str) -> int:
-    """Sample graph node count using log-uniform bounds from config."""
+def _sample_node_count(
+    n_nodes_min: int,
+    n_nodes_max: int,
+    generator: torch.Generator,
+    device: str,
+) -> int:
+    """Sample graph node count using log-uniform bounds."""
 
-    low = max(2.0, float(config.graph.n_nodes_min))
-    high = max(low, float(config.graph.n_nodes_max))
-    log_low = math.log(low)
-    log_high = math.log(high)
-    u = torch.empty(1, device=device).uniform_(log_low, log_high, generator=generator)
-    return max(2, int(math.exp(u.item())))
+    low = max(2, int(n_nodes_min))
+    high = max(low, int(n_nodes_max))
+    return _sample_log_uniform_int(generator, device, low, high)
 
 
 def _sample_assignments(
@@ -209,15 +211,59 @@ def _sample_assignments(
     return eligible_nodes[indices].tolist()
 
 
+def _resolve_stagewise_layout_bounds(
+    config: GeneratorConfig, curriculum: dict[str, Any]
+) -> tuple[int, int, int, int]:
+    """Resolve effective feature/node sampling bounds for a curriculum stage."""
+
+    feature_min = int(config.dataset.n_features_min)
+    feature_max = int(config.dataset.n_features_max)
+    node_min = int(config.graph.n_nodes_min)
+    node_max = int(config.graph.n_nodes_max)
+
+    stage_raw = curriculum.get("stage")
+    if stage_raw is not None:
+        stage = int(stage_raw)
+        stage_cfg = config.curriculum.stages.get(stage)
+        if stage_cfg is not None:
+            if stage_cfg.n_features_min is not None:
+                feature_min = int(stage_cfg.n_features_min)
+            if stage_cfg.n_features_max is not None:
+                feature_max = int(stage_cfg.n_features_max)
+            if stage_cfg.n_nodes_min is not None:
+                node_min = int(stage_cfg.n_nodes_min)
+            if stage_cfg.n_nodes_max is not None:
+                node_max = int(stage_cfg.n_nodes_max)
+
+    if feature_min > feature_max:
+        raise ValueError(
+            "Invalid effective feature bounds after curriculum stage resolution: "
+            f"n_features_min={feature_min} > n_features_max={feature_max}."
+        )
+    if node_min > node_max:
+        raise ValueError(
+            "Invalid effective node bounds after curriculum stage resolution: "
+            f"n_nodes_min={node_min} > n_nodes_max={node_max}."
+        )
+    return feature_min, feature_max, node_min, node_max
+
+
 def _sample_layout(
-    config: GeneratorConfig, generator: torch.Generator, device: str
+    config: GeneratorConfig,
+    generator: torch.Generator,
+    device: str,
+    *,
+    curriculum: dict[str, Any],
 ) -> dict[str, Any]:
     """Sample dataset layout, graph, and node assignments for one dataset instance."""
 
+    feature_min, feature_max, node_min, node_max = _resolve_stagewise_layout_bounds(
+        config, curriculum
+    )
     n_features = int(
         torch.randint(
-            config.dataset.n_features_min,
-            config.dataset.n_features_max + 1,
+            feature_min,
+            feature_max + 1,
             (1,),
             generator=generator,
         ).item()
@@ -262,7 +308,7 @@ def _sample_layout(
     )
     n_classes = max(2, n_classes)
 
-    n_nodes = _sample_node_count(config, generator, device)
+    n_nodes = _sample_node_count(node_min, node_max, generator, device)
     adjacency = sample_cauchy_dag(n_nodes, generator, device)
     feature_node_assignment = _sample_assignments(n_features, n_nodes, generator, device)
     target_node_assignment = _sample_assignments(1, n_nodes, generator, device)[0]
@@ -735,7 +781,7 @@ def _generate_one_seeded(
     manager = SeedManager(seed)
     curriculum = _sample_curriculum(config, manager, auto_stage=auto_stage)
     layout_gen = manager.torch_rng("layout")
-    layout = _sample_layout(config, layout_gen, "cpu")
+    layout = _sample_layout(config, layout_gen, "cpu", curriculum=curriculum)
     data_seed = manager.child("data")
     n_train = int(curriculum["n_train"])
     n_test = int(curriculum["n_test"])

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -2,8 +2,9 @@ import pytest
 import torch
 import numpy as np
 
-from cauchy_generator.config import GeneratorConfig
+from cauchy_generator.config import CurriculumStageConfig, GeneratorConfig
 from cauchy_generator.core.dataset import (
+    _sample_layout,
     _stratified_split_indices,
     generate_batch,
     generate_batch_iter,
@@ -15,6 +16,7 @@ from cauchy_generator.io.lineage_schema import (
     validate_metadata_lineage,
     validate_lineage_payload,
 )
+from cauchy_generator.rng import SeedManager
 from cauchy_generator.types import DatasetBundle
 
 
@@ -318,6 +320,137 @@ def test_fixed_curriculum_stage_ranges(stage: int, low: int, high: int) -> None:
     assert low <= int(curriculum["n_rows_total"]) <= high
     assert float(curriculum["train_fraction"]) == pytest.approx(0.8)
     assert int(curriculum["n_train"]) + int(curriculum["n_test"]) == int(curriculum["n_rows_total"])
+
+
+def test_fixed_curriculum_stage_enforces_feature_and_node_bounds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = _tiny_config()
+    cfg.dataset.task = "regression"
+    cfg.curriculum_stage = 2
+    cfg.filter.enabled = False
+    cfg.dataset.n_features_min = 8
+    cfg.dataset.n_features_max = 64
+    cfg.graph.n_nodes_min = 2
+    cfg.graph.n_nodes_max = 32
+    cfg.curriculum.stages = {
+        2: CurriculumStageConfig(
+            n_features_min=11,
+            n_features_max=11,
+            n_nodes_min=7,
+            n_nodes_max=7,
+        )
+    }
+
+    def _identity_postprocess(
+        x_train,
+        y_train,
+        x_test,
+        y_test,
+        feature_types,
+        _task,
+        _generator,
+        _device,
+        *,
+        return_feature_index_map=False,
+    ):
+        assert return_feature_index_map is True
+        index_map = list(range(int(x_train.shape[1])))
+        return x_train, y_train, x_test, y_test, list(feature_types), index_map
+
+    monkeypatch.setattr(
+        "cauchy_generator.core.dataset.postprocess_dataset",
+        _identity_postprocess,
+    )
+
+    bundle = generate_one(cfg, seed=2026, device="cpu")
+    assert int(bundle.metadata["curriculum"]["stage"]) == 2
+    assert int(bundle.metadata["n_features"]) == 11
+    assert int(bundle.metadata["graph_nodes"]) == 7
+    assert int(bundle.X_train.shape[1]) == 11
+    assert int(bundle.X_test.shape[1]) == 11
+
+
+def test_curriculum_off_ignores_stagewise_feature_and_node_bounds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = _tiny_config()
+    cfg.dataset.task = "regression"
+    cfg.curriculum_stage = "off"
+    cfg.filter.enabled = False
+    cfg.dataset.n_features_min = 6
+    cfg.dataset.n_features_max = 6
+    cfg.graph.n_nodes_min = 4
+    cfg.graph.n_nodes_max = 4
+    cfg.curriculum.stages = {
+        1: CurriculumStageConfig(
+            n_features_min=20,
+            n_features_max=20,
+            n_nodes_min=12,
+            n_nodes_max=12,
+        )
+    }
+
+    def _identity_postprocess(
+        x_train,
+        y_train,
+        x_test,
+        y_test,
+        feature_types,
+        _task,
+        _generator,
+        _device,
+        *,
+        return_feature_index_map=False,
+    ):
+        assert return_feature_index_map is True
+        index_map = list(range(int(x_train.shape[1])))
+        return x_train, y_train, x_test, y_test, list(feature_types), index_map
+
+    monkeypatch.setattr(
+        "cauchy_generator.core.dataset.postprocess_dataset",
+        _identity_postprocess,
+    )
+
+    bundle = generate_one(cfg, seed=2027, device="cpu")
+    assert bundle.metadata["curriculum"]["stage"] is None
+    assert int(bundle.metadata["n_features"]) == 6
+    assert int(bundle.metadata["graph_nodes"]) == 4
+
+
+def test_stagewise_layout_sampling_is_seed_reproducible_for_feature_and_node_bounds() -> None:
+    cfg = _tiny_config()
+    cfg.dataset.n_features_min = 8
+    cfg.dataset.n_features_max = 64
+    cfg.graph.n_nodes_min = 2
+    cfg.graph.n_nodes_max = 32
+    cfg.curriculum.stages = {
+        3: CurriculumStageConfig(
+            n_features_min=13,
+            n_features_max=19,
+            n_nodes_min=5,
+            n_nodes_max=9,
+        )
+    }
+    curriculum = {"stage": 3}
+
+    layout_a = _sample_layout(
+        cfg,
+        SeedManager(909).torch_rng("layout"),
+        "cpu",
+        curriculum=curriculum,
+    )
+    layout_b = _sample_layout(
+        cfg,
+        SeedManager(909).torch_rng("layout"),
+        "cpu",
+        curriculum=curriculum,
+    )
+
+    assert layout_a["n_features"] == layout_b["n_features"]
+    assert layout_a["graph_nodes"] == layout_b["graph_nodes"]
+    assert 13 <= int(layout_a["n_features"]) <= 19
+    assert 5 <= int(layout_a["graph_nodes"]) <= 9
 
 
 def test_auto_curriculum_batch_stage_sequence_reproducible() -> None:


### PR DESCRIPTION
## Summary
- enforce stage-aware feature/node sampling bounds during layout generation
- apply stage-specific curriculum overrides only when a curriculum stage is active
- preserve off-mode behavior and deterministic seed behavior
- add integration/repro tests for stage enforcement and off-mode compatibility

## Linked Issue
Closes #51

## Validation
- `uv run ruff check src/cauchy_generator/core/dataset.py tests/test_generate.py`
- `uv run mypy src/cauchy_generator/core/dataset.py`
- `uv run pytest tests/test_generate.py -q`
- `uv run pytest tests/test_config.py -q`
- `uv run cauchy-gen benchmark --suite standard --profile cpu`
