### PR TITLE
feat: harden many-class converters, postprocess, and class metadata

### DIFF
--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -84,26 +84,27 @@ Each dataset's `metadata.json` contains:
 
 ### Top-level keys
 
-| Key                      | Type        | Description                              |
-| ------------------------ | ----------- | ---------------------------------------- |
-| `backend`                | str         | Always `"torch"`                         |
-| `device`                 | str         | Compute device (e.g., `"cpu"`, `"cuda"`) |
-| `compute_backend`        | str         | Implementation variant identifier        |
-| `n_features`             | int         | Number of features                       |
-| `n_categorical_features` | int         | Number of categorical features           |
-| `n_classes`              | int or null | Number of classes (null for regression)  |
-| `graph_nodes`            | int         | Number of nodes in the DAG               |
-| `graph_edges`            | int         | Number of edges in the DAG               |
-| `graph_depth_nodes`      | int         | Longest path length in the DAG           |
-| `graph_edge_density`     | float       | Edge count / max possible edges          |
-| `seed`                   | int         | Base seed for this dataset               |
-| `attempt_used`           | int         | Generation attempt index (0-based)       |
-| `lineage`                | object      | DAG lineage record (see Lineage below)   |
-| `curriculum`             | object      | Curriculum metadata (see below)          |
-| `config`                 | object      | Full serialized generator configuration  |
-| `filter`                 | object      | Filter results (see below)               |
-| `missingness`            | object      | Present only when missingness is enabled |
-| `steering`               | object      | Present only when steering is enabled    |
+| Key                      | Type        | Description                                                  |
+| ------------------------ | ----------- | ------------------------------------------------------------ |
+| `backend`                | str         | Always `"torch"`                                             |
+| `device`                 | str         | Compute device (e.g., `"cpu"`, `"cuda"`)                     |
+| `compute_backend`        | str         | Implementation variant identifier                            |
+| `n_features`             | int         | Number of features                                           |
+| `n_categorical_features` | int         | Number of categorical features                               |
+| `n_classes`              | int or null | Realized class count in emitted labels (null for regression) |
+| `graph_nodes`            | int         | Number of nodes in the DAG                                   |
+| `graph_edges`            | int         | Number of edges in the DAG                                   |
+| `graph_depth_nodes`      | int         | Longest path length in the DAG                               |
+| `graph_edge_density`     | float       | Edge count / max possible edges                              |
+| `seed`                   | int         | Base seed for this dataset                                   |
+| `attempt_used`           | int         | Generation attempt index (0-based)                           |
+| `lineage`                | object      | DAG lineage record (see Lineage below)                       |
+| `curriculum`             | object      | Curriculum metadata (see below)                              |
+| `config`                 | object      | Full serialized generator configuration                      |
+| `filter`                 | object      | Filter results (see below)                                   |
+| `class_structure`        | object      | Present only for classification (see below)                  |
+| `missingness`            | object      | Present only when missingness is enabled                     |
+| `steering`               | object      | Present only when steering is enabled                        |
 
 ### Curriculum sub-object
 
@@ -136,6 +137,19 @@ The `stage_bounds` object contains nullable min/max pairs:
 | `n_valid_oob` | int   | OOB sample count (when enabled)           |
 | `backend`     | str   | Filter implementation (when enabled)      |
 | `accepted`    | bool  | Whether the dataset passed (when enabled) |
+
+### Class Structure sub-object (classification only)
+
+Present only for classification datasets.
+
+| Key                      | Type        | Description                                        |
+| ------------------------ | ----------- | -------------------------------------------------- |
+| `n_classes_sampled`      | int         | Layout-sampled class count before postprocessing   |
+| `n_classes_realized`     | int         | Unique class count in emitted `y_train` + `y_test` |
+| `labels_contiguous`      | bool        | Whether labels form contiguous range `0..K-1`      |
+| `train_test_class_match` | bool        | Whether train and test class sets are identical    |
+| `min_label`              | int or null | Minimum emitted class label                        |
+| `max_label`              | int or null | Maximum emitted class label                        |
 
 ### Steering sub-object (optional)
 

--- a/src/cauchy_generator/converters/categorical.py
+++ b/src/cauchy_generator/converters/categorical.py
@@ -41,7 +41,9 @@ def apply_categorical_converter(
     idx_joint = torch.randint(0, len(_JOINT_VARIANTS), (1,), generator=generator).item()
     selected_method, variant = _JOINT_VARIANTS[int(idx_joint)]
     if method is not None:
-        selected_method = method
+        selected_method = str(method).strip().lower()
+    if selected_method not in {"neighbor", "softmax"}:
+        raise ValueError(f"Unsupported categorical converter method: {selected_method!r}.")
 
     centers = None
     if selected_method == "neighbor":
@@ -95,4 +97,12 @@ def apply_categorical_converter(
     else:
         out = y
 
+    if out.shape[1] != d:
+        if out.shape[1] > d:
+            out = out[:, :d]
+        else:
+            out = torch.nn.functional.pad(out, (0, d - out.shape[1]))
+    out = torch.nan_to_num(out.to(torch.float32), nan=0.0, posinf=1e6, neginf=-1e6)
+
+    labels = torch.remainder(labels.to(torch.int64), c)
     return out, labels

--- a/src/cauchy_generator/core/dataset.py
+++ b/src/cauchy_generator/core/dataset.py
@@ -69,6 +69,38 @@ def _torch_dtype(config: GeneratorConfig) -> torch.dtype:
     return torch.float64 if config.runtime.torch_dtype == "float64" else torch.float32
 
 
+def _classification_class_structure(
+    *,
+    y_train: torch.Tensor,
+    y_test: torch.Tensor,
+    n_classes_sampled: int,
+) -> dict[str, Any]:
+    """Build classification label-structure metadata for one emitted bundle."""
+
+    y_train_i64 = y_train.to(torch.int64)
+    y_test_i64 = y_test.to(torch.int64)
+    y_all = torch.cat([y_train_i64, y_test_i64], dim=0)
+    unique_all = torch.unique(y_all, sorted=True)
+    n_classes_realized = int(unique_all.numel())
+    labels_contiguous = bool(
+        torch.equal(
+            unique_all,
+            torch.arange(n_classes_realized, dtype=unique_all.dtype, device=unique_all.device),
+        )
+    )
+    train_classes = torch.unique(y_train_i64, sorted=True)
+    test_classes = torch.unique(y_test_i64, sorted=True)
+
+    return {
+        "n_classes_sampled": int(n_classes_sampled),
+        "n_classes_realized": int(n_classes_realized),
+        "labels_contiguous": bool(labels_contiguous),
+        "train_test_class_match": bool(torch.equal(train_classes, test_classes)),
+        "min_label": int(unique_all[0].item()) if n_classes_realized > 0 else None,
+        "max_label": int(unique_all[-1].item()) if n_classes_realized > 0 else None,
+    }
+
+
 def _generate_graph_dataset_torch(
     config: GeneratorConfig,
     layout: dict[str, Any],
@@ -225,6 +257,15 @@ def _generate_torch(
         y_dtype = torch.int64 if config.dataset.task == "classification" else dtype
         y_train = y_train.to(y_dtype)
         y_test = y_test.to(y_dtype)
+        class_structure: dict[str, Any] | None = None
+        n_classes: int | None = None
+        if config.dataset.task == "classification":
+            class_structure = _classification_class_structure(
+                y_train=y_train,
+                y_test=y_test,
+                n_classes_sampled=int(layout["n_classes"]),
+            )
+            n_classes = int(class_structure["n_classes_realized"])
         curriculum_metadata = _build_curriculum_metadata(
             curriculum,
             layout=layout,
@@ -239,9 +280,7 @@ def _generate_torch(
             "compute_backend": "torch_appendix_full",
             "n_features": int(x_train.shape[1]),
             "n_categorical_features": int(sum(1 for t in feature_types if t == "cat")),
-            "n_classes": (
-                int(layout["n_classes"]) if config.dataset.task == "classification" else None
-            ),
+            "n_classes": n_classes,
             "graph_nodes": int(layout["graph_nodes"]),
             "graph_edges": int(layout["graph_edges"]),
             "graph_depth_nodes": int(layout["graph_depth_nodes"]),
@@ -255,6 +294,8 @@ def _generate_torch(
         }
         if missingness_summary is not None:
             metadata["missingness"] = missingness_summary
+        if class_structure is not None:
+            metadata["class_structure"] = class_structure
         return DatasetBundle(
             X_train=x_train,
             y_train=y_train,

--- a/src/cauchy_generator/postprocess/postprocess.py
+++ b/src/cauchy_generator/postprocess/postprocess.py
@@ -56,6 +56,13 @@ def _permute_classes(y: torch.Tensor, generator: torch.Generator, device: str) -
     return remapped
 
 
+def _remap_classes_to_contiguous(y: torch.Tensor) -> torch.Tensor:
+    """Map arbitrary class ids to contiguous 0..K-1 labels (sorted by original id)."""
+
+    _, inverse = torch.unique(y.to(torch.int64), sorted=True, return_inverse=True)
+    return inverse.to(torch.int64)
+
+
 @overload
 def postprocess_dataset(
     x_train: torch.Tensor,
@@ -143,15 +150,19 @@ def postprocess_dataset(
             )
         return x_train_p, y_all[:n_train], x_test_p, y_all[n_train:], feature_types
 
-    y_all = torch.cat([y_train, y_test], dim=0).to(torch.int64)
-    y_all = _permute_classes(y_all, generator, device)
+    y_all_original = torch.cat([y_train, y_test], dim=0).to(torch.int64)
+    y_all_permuted = _permute_classes(y_all_original, generator, device)
+    y_train_candidate = y_all_permuted[:n_train]
+    y_test_candidate = y_all_permuted[n_train:]
+
+    if torch.unique(y_train_candidate).numel() < 2 or torch.unique(y_test_candidate).numel() < 2:
+        # Fall back to original labels if permutation collapses effective class diversity.
+        y_all = y_all_original
+    else:
+        y_all = y_all_permuted
+    y_all = _remap_classes_to_contiguous(y_all)
     y_train_p = y_all[:n_train]
     y_test_p = y_all[n_train:]
-
-    if torch.unique(y_train_p).numel() < 2 or torch.unique(y_test_p).numel() < 2:
-        # Fall back to original labels if permutation collapses effective class diversity.
-        y_train_p = y_train.to(torch.int64)
-        y_test_p = y_test.to(torch.int64)
 
     if return_feature_index_map:
         return x_train_p, y_train_p, x_test_p, y_test_p, feature_types, feature_index_map

--- a/tests/test_categorical_converter.py
+++ b/tests/test_categorical_converter.py
@@ -1,5 +1,6 @@
 """Tests for converters/categorical.py categorical path."""
 
+import pytest
 import torch
 
 from cauchy_generator.converters.categorical import apply_categorical_converter
@@ -23,6 +24,16 @@ def test_labels_in_range() -> None:
     assert torch.all(labels < n_cat)
 
 
+@pytest.mark.parametrize("n_cat", [10, 16, 24, 32])
+def test_labels_in_range_many_class(n_cat: int) -> None:
+    g = _make_generator(11 + n_cat)
+    x = torch.randn(96, 8, generator=g)
+    _, labels = apply_categorical_converter(x, g, n_categories=n_cat)
+    assert labels.dtype == torch.int64
+    assert torch.all(labels >= 0)
+    assert torch.all(labels < n_cat)
+
+
 def test_deterministic() -> None:
     x = torch.randn(32, 3, generator=_make_generator(99))
     xp1, l1 = apply_categorical_converter(x.clone(), _make_generator(0), n_categories=4)
@@ -36,3 +47,19 @@ def test_finite_outputs() -> None:
     x = torch.randn(64, 5, generator=g)
     x_prime, _ = apply_categorical_converter(x, g, n_categories=3)
     assert torch.all(torch.isfinite(x_prime))
+
+
+@pytest.mark.parametrize("method", ["neighbor", "softmax"])
+def test_method_override_is_supported(method: str) -> None:
+    g = _make_generator(21)
+    x = torch.randn(48, 6, generator=g)
+    x_prime, labels = apply_categorical_converter(x, g, n_categories=32, method=method)
+    assert x_prime.shape == x.shape
+    assert labels.shape == (x.shape[0],)
+
+
+def test_unknown_method_raises() -> None:
+    g = _make_generator(22)
+    x = torch.randn(32, 4, generator=g)
+    with pytest.raises(ValueError, match=r"Unsupported categorical converter method"):
+        apply_categorical_converter(x, g, n_categories=8, method="unknown")

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -953,8 +953,35 @@ def test_stratified_split_ensures_valid_class_split_with_many_classes() -> None:
     bundle = generate_one(cfg, seed=42, device="cpu")
     train_classes = set(torch.unique(bundle.y_train).tolist())
     test_classes = set(torch.unique(bundle.y_test).tolist())
+    all_classes = torch.unique(torch.cat([bundle.y_train, bundle.y_test], dim=0), sorted=True)
+    expected = torch.arange(all_classes.numel(), dtype=all_classes.dtype)
     assert len(train_classes) >= 2
     assert train_classes == test_classes
+    assert torch.equal(all_classes, expected)
+
+    class_structure = bundle.metadata["class_structure"]
+    assert bundle.metadata["n_classes"] == int(class_structure["n_classes_realized"])
+    assert int(class_structure["n_classes_sampled"]) == 10
+    assert bool(class_structure["labels_contiguous"]) is True
+    assert bool(class_structure["train_test_class_match"]) is True
+    assert int(class_structure["min_label"]) == 0
+    assert int(class_structure["max_label"]) == int(all_classes.numel() - 1)
+
+
+def test_metadata_n_classes_uses_realized_class_count_for_classification() -> None:
+    cfg = _tiny_config()
+    cfg.dataset.task = "classification"
+    cfg.dataset.n_classes_min = 32
+    cfg.dataset.n_classes_max = 32
+    cfg.dataset.n_train = 256
+    cfg.dataset.n_test = 256
+    cfg.filter.max_attempts = 3
+
+    bundle = generate_one(cfg, seed=52, device="cpu")
+    all_classes = torch.unique(torch.cat([bundle.y_train, bundle.y_test], dim=0), sorted=True)
+    assert bundle.metadata["n_classes"] == int(all_classes.numel())
+    assert int(bundle.metadata["class_structure"]["n_classes_sampled"]) == 32
+    assert int(bundle.metadata["class_structure"]["n_classes_realized"]) == int(all_classes.numel())
 
 
 def test_stratified_split_indices_returns_exact_requested_sizes() -> None:

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -62,6 +62,50 @@ def test_preserves_class_counts() -> None:
     assert before_counts == after_counts
 
 
+def test_classification_labels_are_remapped_to_contiguous_indices() -> None:
+    g = _make_generator(12)
+    x_train = torch.randn(40, 4, generator=g)
+    x_test = torch.randn(20, 4, generator=g)
+    y_train = torch.tensor([0, 2, 5, 9] * 10, dtype=torch.int64)
+    y_test = torch.tensor([0, 2, 5, 9] * 5, dtype=torch.int64)
+    feature_types = ["num", "num", "num", "num"]
+
+    _, y_train_p, _, y_test_p, _ = postprocess_dataset(
+        x_train,
+        y_train,
+        x_test,
+        y_test,
+        feature_types,
+        "classification",
+        _make_generator(13),
+        "cpu",
+    )
+
+    y_all_after = torch.cat([y_train_p, y_test_p], dim=0)
+    unique_after = torch.unique(y_all_after, sorted=True)
+    expected = torch.arange(unique_after.numel(), dtype=unique_after.dtype)
+    assert torch.equal(unique_after, expected)
+
+    _, before_counts_raw = torch.unique(torch.cat([y_train, y_test], dim=0), return_counts=True)
+    _, after_counts_raw = torch.unique(y_all_after, return_counts=True)
+    before_counts = sorted(before_counts_raw.tolist())
+    after_counts = sorted(after_counts_raw.tolist())
+    assert before_counts == after_counts
+
+
+def test_many_class_postprocess_outputs_contiguous_labels() -> None:
+    g = _make_generator(14)
+    xt, yt, xte, yte, ft, task = _make_data(g, n_classes=32, n_train=256, n_test=256)
+    _, ytp, _, ytep, _ = postprocess_dataset(xt, yt, xte, yte, ft, task, _make_generator(15), "cpu")
+
+    y_all = torch.cat([ytp, ytep], dim=0)
+    unique_after = torch.unique(y_all, sorted=True)
+    expected = torch.arange(unique_after.numel(), dtype=unique_after.dtype)
+    assert torch.equal(unique_after, expected)
+    assert torch.all(y_all >= 0)
+    assert int(unique_after[-1].item()) == int(unique_after.numel() - 1)
+
+
 def test_regression_clips_targets() -> None:
     g = _make_generator(3)
     xt, yt, xte, yte, ft, task = _make_data(g, task="regression")


### PR DESCRIPTION
## Summary
- harden categorical converter behavior for many-class settings (method validation, shape/range safety)
- remap classification labels to contiguous `0..K-1` in postprocessing
- report realized class structure in metadata via `class_structure`
- update output format docs for realized `n_classes` semantics and `class_structure`
- add/extend many-class converter, postprocess, and end-to-end generation tests

## Validation
- uv run pytest tests/test_categorical_converter.py tests/test_postprocess.py tests/test_generate.py -q
- uv run pytest -q
- uv run ruff check src/cauchy_generator/converters/categorical.py src/cauchy_generator/postprocess/postprocess.py src/cauchy_generator/core/dataset.py tests/test_categorical_converter.py tests/test_postprocess.py tests/test_generate.py
- uv run mypy src/cauchy_generator/converters/categorical.py src/cauchy_generator/postprocess/postprocess.py src/cauchy_generator/core/dataset.py

Closes #21
