### PR TITLE
feat(many-class): add class-aware filter thresholds and diagnostics

### DIFF
--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -130,13 +130,19 @@ The `stage_bounds` object contains nullable min/max pairs:
 
 ### Filter sub-object
 
-| Key           | Type  | Description                               |
-| ------------- | ----- | ----------------------------------------- |
-| `enabled`     | bool  | Whether filtering was active              |
-| `wins_ratio`  | float | Bootstrap wins ratio (when enabled)       |
-| `n_valid_oob` | int   | OOB sample count (when enabled)           |
-| `backend`     | str   | Filter implementation (when enabled)      |
-| `accepted`    | bool  | Whether the dataset passed (when enabled) |
+| Key                   | Type        | Description                                                                                 |
+| --------------------- | ----------- | ------------------------------------------------------------------------------------------- |
+| `enabled`             | bool        | Whether filtering was active                                                                |
+| `wins_ratio`          | float       | Bootstrap wins ratio (when enabled)                                                         |
+| `n_valid_oob`         | int         | OOB sample count (when enabled)                                                             |
+| `backend`             | str         | Filter implementation (when enabled)                                                        |
+| `accepted`            | bool        | Whether the dataset passed (when enabled)                                                   |
+| `threshold_requested` | float       | Requested filter threshold before class-aware adjustment                                    |
+| `threshold_effective` | float       | Effective threshold used in acceptance decision                                             |
+| `threshold_policy`    | str         | Threshold policy identifier (`class_aware_piecewise_v1`)                                    |
+| `class_count`         | int or null | Realized class count used by filter (`null` for regression)                                 |
+| `class_bucket`        | str         | Class-count bucket for policy lookup (`<=8`, `9-16`, `17-24`, `25-32`, or `not_applicable`) |
+| `threshold_delta`     | float       | Difference between requested and effective threshold                                        |
 
 ### Class Structure sub-object (classification only)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -307,6 +307,7 @@ metadata JSON contract, and DAG lineage schema.
 - Pillar alignment: tabular realism, causal structural integrity
 - Goal: assess feasibility and, only if viable, raise practical class/cardinality limits while preserving filter quality.
 - Current rollout envelope (`#20`): enforce `dataset.n_classes_max <= 32` as the narrow-go safety cap until follow-on hardening (`#21`-`#23`) lands.
+- `#22` scope: class-aware RF filter thresholding plus metadata diagnostics so many-class accept/reject behavior remains interpretable.
 - GitHub tracking: epic `#19`; research gate `#43`; conditional chain `#20 -> #21 -> #22 -> #23`
 - Repo touchpoints: `src/cauchy_generator/config.py`, `src/cauchy_generator/converters/categorical.py`, `src/cauchy_generator/filtering/torch_rf_filter.py`
 - Exit criteria:

--- a/src/cauchy_generator/filtering/torch_rf_filter.py
+++ b/src/cauchy_generator/filtering/torch_rf_filter.py
@@ -9,6 +9,10 @@ from typing import Any
 import torch
 
 
+_CLASS_AWARE_THRESHOLD_POLICY = "class_aware_piecewise_v1"
+_CLASS_AWARE_THRESHOLD_FLOOR = 0.80
+
+
 @dataclass(slots=True)
 class _TreeModel:
     split_feature: list[int]
@@ -273,6 +277,52 @@ def _predict_tree(tree: _TreeModel, x: torch.Tensor) -> torch.Tensor:
     return leaf_values[node_ids]
 
 
+def _resolve_threshold_diagnostics(
+    *,
+    task: str,
+    requested_threshold: float,
+    class_count: int | None,
+) -> dict[str, Any]:
+    """Return class-aware threshold diagnostics and effective threshold."""
+
+    if task != "classification" or class_count is None:
+        effective_threshold = float(requested_threshold)
+        return {
+            "threshold_requested": float(requested_threshold),
+            "threshold_effective": effective_threshold,
+            "threshold_policy": _CLASS_AWARE_THRESHOLD_POLICY,
+            "class_count": None,
+            "class_bucket": "not_applicable",
+            "threshold_delta": float(requested_threshold) - effective_threshold,
+        }
+
+    if class_count <= 8:
+        class_bucket = "<=8"
+        threshold_delta = 0.00
+    elif class_count <= 16:
+        class_bucket = "9-16"
+        threshold_delta = 0.05
+    elif class_count <= 24:
+        class_bucket = "17-24"
+        threshold_delta = 0.10
+    else:
+        class_bucket = "25-32"
+        threshold_delta = 0.15
+
+    relaxed_threshold = max(
+        _CLASS_AWARE_THRESHOLD_FLOOR, float(requested_threshold) - threshold_delta
+    )
+    effective_threshold = min(float(requested_threshold), relaxed_threshold)
+    return {
+        "threshold_requested": float(requested_threshold),
+        "threshold_effective": float(effective_threshold),
+        "threshold_policy": _CLASS_AWARE_THRESHOLD_POLICY,
+        "class_count": int(class_count),
+        "class_bucket": class_bucket,
+        "threshold_delta": float(requested_threshold) - float(effective_threshold),
+    }
+
+
 def apply_torch_rf_filter(
     x: torch.Tensor,
     y: torch.Tensor,
@@ -310,15 +360,25 @@ def apply_torch_rf_filter(
     m_try = _resolve_max_features(max_features, n_features, task)
 
     if task == "classification":
-        y_cls = y.to(torch.int64).view(-1)
-        n_classes = int(torch.max(y_cls).item()) + 1
+        y_raw = y.to(torch.int64).view(-1)
+        unique_labels, y_cls = torch.unique(y_raw, sorted=True, return_inverse=True)
+        n_classes = int(unique_labels.numel())
+        class_count: int | None = n_classes
         y_target = torch.nn.functional.one_hot(y_cls, num_classes=n_classes).to(torch.float32)
     else:
         y_cls = None
         n_classes = 0
+        class_count = None
         y_target = y.to(torch.float32)
         if y_target.dim() == 1:
             y_target = y_target.unsqueeze(1)
+
+    threshold_details = _resolve_threshold_diagnostics(
+        task=task,
+        requested_threshold=float(threshold),
+        class_count=class_count,
+    )
+    effective_threshold = float(threshold_details["threshold_effective"])
 
     gen = torch.Generator(device=device)
     gen.manual_seed(seed)
@@ -361,6 +421,7 @@ def apply_torch_rf_filter(
             "reason": "insufficient_oob_predictions",
             "n_valid_oob": n_valid,
             "backend": "torch_rf",
+            **threshold_details,
         }
 
     pred = oob_pred_sum[valid_oob] / oob_count[valid_oob]
@@ -379,8 +440,9 @@ def apply_torch_rf_filter(
         wins += int((mse_pred < mse_base).sum().item())
 
     wins_ratio = wins / float(n_bootstrap)
-    return bool(wins_ratio >= threshold), {
+    return bool(wins_ratio >= effective_threshold), {
         "wins_ratio": float(wins_ratio),
         "n_valid_oob": n_valid,
         "backend": "torch_rf",
+        **threshold_details,
     }

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -271,7 +271,16 @@ def test_torch_path_applies_filter_when_enabled(monkeypatch: pytest.MonkeyPatch)
 
     def _stub_filter(*_args, **_kwargs):
         called["count"] += 1
-        return True, {"wins_ratio": 1.0, "n_valid_oob": 128}
+        return True, {
+            "wins_ratio": 1.0,
+            "n_valid_oob": 128,
+            "threshold_requested": 0.95,
+            "threshold_effective": 0.80,
+            "threshold_policy": "class_aware_piecewise_v1",
+            "class_count": 32,
+            "class_bucket": "25-32",
+            "threshold_delta": 0.15,
+        }
 
     monkeypatch.setattr("cauchy_generator.core.dataset.apply_torch_rf_filter", _stub_filter)
     cfg = _tiny_config()
@@ -282,6 +291,9 @@ def test_torch_path_applies_filter_when_enabled(monkeypatch: pytest.MonkeyPatch)
     assert bundle.metadata["backend"] == "torch"
     assert bundle.metadata["filter"]["enabled"] is True
     assert bundle.metadata["filter"]["accepted"] is True
+    assert bundle.metadata["filter"]["threshold_policy"] == "class_aware_piecewise_v1"
+    assert bundle.metadata["filter"]["class_bucket"] == "25-32"
+    assert float(bundle.metadata["filter"]["threshold_effective"]) == pytest.approx(0.80)
     assert "reason" not in bundle.metadata["filter"]
 
 

--- a/tests/test_torch_rf_filter.py
+++ b/tests/test_torch_rf_filter.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from cauchy_generator.filtering import apply_torch_rf_filter
@@ -23,9 +24,28 @@ def _make_classification_data(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     g = torch.Generator(device="cpu")
     g.manual_seed(seed)
-    x = torch.randn(n_rows, n_features, generator=g)
-    logits = x[:, :n_classes] + 0.1 * torch.randn(n_rows, n_classes, generator=g)
-    y = torch.argmax(logits, dim=1)
+    y = torch.arange(n_rows, dtype=torch.int64) % int(n_classes)
+    y = y[torch.randperm(n_rows, generator=g)]
+    centroids = torch.randn(n_classes, n_features, generator=g)
+    x = centroids[y] + 0.25 * torch.randn(n_rows, n_features, generator=g)
+    return x, y
+
+
+def _make_sparse_label_classification_data(
+    *,
+    seed: int = 91,
+    n_rows: int = 256,
+    n_features: int = 10,
+    labels: tuple[int, ...] = (10, 20, 30, 40),
+) -> tuple[torch.Tensor, torch.Tensor]:
+    g = torch.Generator(device="cpu")
+    g.manual_seed(seed)
+    class_ids = torch.arange(n_rows, dtype=torch.int64) % int(len(labels))
+    class_ids = class_ids[torch.randperm(n_rows, generator=g)]
+    label_values = torch.tensor(labels, dtype=torch.int64)
+    y = label_values[class_ids]
+    centroids = torch.randn(len(labels), n_features, generator=g)
+    x = centroids[class_ids] + 0.25 * torch.randn(n_rows, n_features, generator=g)
     return x, y
 
 
@@ -112,6 +132,12 @@ def test_torch_rf_filter_can_report_insufficient_oob_predictions() -> None:
     assert accepted is False
     assert details["reason"] == "insufficient_oob_predictions"
     assert details["backend"] == "torch_rf"
+    assert details["threshold_requested"] == pytest.approx(0.5)
+    assert details["threshold_effective"] == pytest.approx(0.5)
+    assert details["threshold_policy"] == "class_aware_piecewise_v1"
+    assert details["class_count"] is None
+    assert details["class_bucket"] == "not_applicable"
+    assert details["threshold_delta"] == pytest.approx(0.0)
 
 
 def test_torch_rf_filter_classification_smoke() -> None:
@@ -132,6 +158,162 @@ def test_torch_rf_filter_classification_smoke() -> None:
     assert "wins_ratio" in details
     assert "n_valid_oob" in details
     assert details["backend"] == "torch_rf"
+    assert details["threshold_requested"] == pytest.approx(0.5)
+    assert details["threshold_effective"] == pytest.approx(0.5)
+    assert details["threshold_policy"] == "class_aware_piecewise_v1"
+    assert int(details["class_count"]) >= 2
+    assert details["class_bucket"] == "<=8"
+    assert details["threshold_delta"] == pytest.approx(0.0)
+
+
+@pytest.mark.parametrize(
+    ("n_classes", "expected_bucket", "expected_effective"),
+    [
+        (4, "<=8", 0.95),
+        (10, "9-16", 0.90),
+        (18, "17-24", 0.85),
+        (28, "25-32", 0.80),
+        (32, "25-32", 0.80),
+    ],
+)
+def test_torch_rf_filter_class_aware_threshold_sweep(
+    n_classes: int,
+    expected_bucket: str,
+    expected_effective: float,
+) -> None:
+    x, y = _make_classification_data(
+        seed=211 + n_classes,
+        n_rows=512,
+        n_features=12,
+        n_classes=n_classes,
+    )
+    _, details = apply_torch_rf_filter(
+        x,
+        y,
+        task="classification",
+        seed=17,
+        n_trees=6,
+        depth=4,
+        min_samples_leaf=2,
+        n_bootstrap=16,
+        threshold=0.95,
+    )
+
+    assert details["class_bucket"] == expected_bucket
+    assert details["threshold_requested"] == pytest.approx(0.95)
+    assert details["threshold_effective"] == pytest.approx(expected_effective)
+    assert details["threshold_policy"] == "class_aware_piecewise_v1"
+    assert int(details["class_count"]) == n_classes
+    assert details["threshold_delta"] == pytest.approx(0.95 - expected_effective)
+
+
+def test_torch_rf_filter_regression_threshold_diagnostics_are_not_applicable() -> None:
+    x, y = _make_regression_data(seed=123)
+    _, details = apply_torch_rf_filter(
+        x,
+        y,
+        task="regression",
+        seed=88,
+        n_trees=6,
+        depth=4,
+        n_bootstrap=16,
+        threshold=0.75,
+    )
+
+    assert details["threshold_requested"] == pytest.approx(0.75)
+    assert details["threshold_effective"] == pytest.approx(0.75)
+    assert details["threshold_policy"] == "class_aware_piecewise_v1"
+    assert details["class_count"] is None
+    assert details["class_bucket"] == "not_applicable"
+    assert details["threshold_delta"] == pytest.approx(0.0)
+
+
+def test_torch_rf_filter_rejected_scored_run_keeps_threshold_diagnostics() -> None:
+    x, y = _make_classification_data(seed=77, n_rows=384, n_features=12, n_classes=32)
+    accepted, details = apply_torch_rf_filter(
+        x,
+        y,
+        task="classification",
+        seed=31,
+        n_trees=6,
+        depth=4,
+        min_samples_leaf=2,
+        n_bootstrap=16,
+        threshold=2.0,
+    )
+
+    assert accepted is False
+    assert "wins_ratio" in details
+    assert details["threshold_requested"] == pytest.approx(2.0)
+    assert details["threshold_effective"] == pytest.approx(1.85)
+    assert details["threshold_policy"] == "class_aware_piecewise_v1"
+    assert details["class_bucket"] == "25-32"
+    assert int(details["class_count"]) == 32
+    assert details["threshold_delta"] == pytest.approx(0.15)
+
+
+def test_torch_rf_filter_many_class_acceptance_rate_is_not_pathological() -> None:
+    seeds = [1701, 1702, 1703, 1704, 1705, 1706]
+    acceptance_rates: dict[int, float] = {}
+
+    for n_classes in (8, 16, 24, 32):
+        accepted = 0
+        for seed in seeds:
+            x, y = _make_classification_data(
+                seed=seed + (n_classes * 100),
+                n_rows=512,
+                n_features=12,
+                n_classes=n_classes,
+            )
+            is_accepted, _details = apply_torch_rf_filter(
+                x,
+                y,
+                task="classification",
+                seed=seed,
+                n_trees=6,
+                depth=4,
+                min_samples_leaf=2,
+                n_bootstrap=16,
+                threshold=0.95,
+            )
+            if is_accepted:
+                accepted += 1
+        acceptance_rates[n_classes] = accepted / float(len(seeds))
+
+    assert acceptance_rates[32] >= (acceptance_rates[8] - 0.25)
+
+
+@pytest.mark.parametrize(
+    ("labels", "expected_class_count", "expected_bucket", "expected_effective"),
+    [
+        ((10, 11), 2, "<=8", 0.95),
+        ((10, 20, 30, 40), 4, "<=8", 0.95),
+    ],
+)
+def test_torch_rf_filter_sparse_labels_use_realized_class_count(
+    labels: tuple[int, ...],
+    expected_class_count: int,
+    expected_bucket: str,
+    expected_effective: float,
+) -> None:
+    x, y = _make_sparse_label_classification_data(labels=labels)
+    _, details = apply_torch_rf_filter(
+        x,
+        y,
+        task="classification",
+        seed=123,
+        n_trees=6,
+        depth=4,
+        min_samples_leaf=2,
+        n_bootstrap=16,
+        threshold=0.95,
+    )
+
+    assert int(details["class_count"]) == expected_class_count
+    assert details["class_bucket"] == expected_bucket
+    assert details["threshold_requested"] == pytest.approx(0.95)
+    assert details["threshold_effective"] == pytest.approx(expected_effective)
+    assert details["threshold_delta"] == pytest.approx(0.95 - expected_effective)
 
 
 def test_predict_tree_returns_correct_leaf_values() -> None:


### PR DESCRIPTION
## Summary
- add class-aware threshold resolution and diagnostics to the Torch RF filter for many-class classification
- keep filter metadata interpretable for accepted/rejected runs by emitting requested/effective threshold details
- count realized classes using dense remapping via torch.unique return_inverse so sparse labels do not over-relax thresholds
- add and extend filter tests for class-bucket sweep, sparse-label correctness, and many-class acceptance-rate guard
- document the new filter diagnostics fields and RD-007 issue #22 scope

## Validation
- uv run ruff check src/cauchy_generator/filtering/torch_rf_filter.py tests/test_torch_rf_filter.py tests/test_generate.py docs/output-format.md docs/roadmap.md
- uv run pytest -q tests/test_torch_rf_filter.py tests/test_generate.py

Closes #22