### PR TITLE
feat(many-class): add presets/docs and benchmark validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ cauchy-gen generate \
 cauchy-gen benchmark --suite smoke --profile cpu --out-dir benchmarks/results/smoke_cpu
 ```
 
+### Many-Class Workflows
+
+```bash
+# Generate many-class datasets within the current rollout envelope (<=32 classes)
+cauchy-gen generate --config configs/preset_many_class_generate_smoke.yaml --num-datasets 10 --out data/run_many_class
+
+# Benchmark many-class smoke performance and guardrails
+cauchy-gen benchmark --config configs/preset_many_class_benchmark_smoke.yaml --profile custom --suite smoke --no-memory --out-dir benchmarks/results/smoke_many_class
+```
+
 ### Inspect Hardware
 
 ```bash
@@ -151,13 +161,14 @@ ______________________________________________________________________
 
 ## Configuration Presets
 
-| Category    | Example file                                 | What it controls                                 |
-| ----------- | -------------------------------------------- | ------------------------------------------------ |
-| Default     | `configs/default.yaml`                       | Balanced baseline for classification             |
-| Curriculum  | `configs/preset_curriculum_auto_staged.yaml` | Staged difficulty (features, nodes, depth)       |
-| Missingness | `configs/preset_missingness_mcar.yaml`       | Synthetic missing-data injection (MCAR/MAR/MNAR) |
-| Steering    | `configs/preset_steering_conservative.yaml`  | Soft selection toward meta-feature target bands  |
-| Benchmark   | `configs/benchmark_cpu.yaml`                 | Hardware-specific benchmark parameters           |
+| Category    | Example file                                    | What it controls                                     |
+| ----------- | ----------------------------------------------- | ---------------------------------------------------- |
+| Default     | `configs/default.yaml`                          | Balanced baseline for classification                 |
+| Curriculum  | `configs/preset_curriculum_auto_staged.yaml`    | Staged difficulty (features, nodes, depth)           |
+| Missingness | `configs/preset_missingness_mcar.yaml`          | Synthetic missing-data injection (MCAR/MAR/MNAR)     |
+| Steering    | `configs/preset_steering_conservative.yaml`     | Soft selection toward meta-feature target bands      |
+| Many-class  | `configs/preset_many_class_generate_smoke.yaml` | High-class-count generation within 32-class envelope |
+| Benchmark   | `configs/benchmark_cpu.yaml`                    | Hardware-specific benchmark parameters               |
 
 Presets follow the `preset_<category>_<variant>.yaml` naming convention. You can compose presets by layering CLI `--config` with flag overrides.
 

--- a/configs/preset_many_class_benchmark_smoke.yaml
+++ b/configs/preset_many_class_benchmark_smoke.yaml
@@ -1,0 +1,48 @@
+seed: 53
+
+dataset:
+  task: classification
+  n_train: 256
+  n_test: 256
+  n_features_min: 8
+  n_features_max: 24
+  n_classes_min: 24
+  n_classes_max: 24
+
+graph:
+  n_nodes_min: 2
+  n_nodes_max: 12
+
+runtime:
+  device: cpu
+
+output:
+  out_dir: benchmarks/results/smoke_many_class
+  shard_size: 16
+  compression: zstd
+
+diagnostics:
+  enabled: false
+
+steering:
+  enabled: false
+
+benchmark:
+  profile_name: many_class_smoke
+  suite: smoke
+  num_datasets: 10
+  warmup_datasets: 0
+  warn_threshold_pct: 10.0
+  fail_threshold_pct: 20.0
+  collect_memory: false
+  collect_reproducibility: false
+  reproducibility_num_datasets: 1
+  latency_num_samples: 5
+  profiles:
+    many_class_smoke:
+      device: cpu
+      num_datasets: 10
+      warmup_datasets: 0
+
+filter:
+  enabled: false

--- a/configs/preset_many_class_generate_smoke.yaml
+++ b/configs/preset_many_class_generate_smoke.yaml
@@ -1,0 +1,29 @@
+seed: 47
+
+dataset:
+  task: classification
+  n_train: 256
+  n_test: 256
+  n_features_min: 8
+  n_features_max: 24
+  n_classes_min: 24
+  n_classes_max: 24
+
+graph:
+  n_nodes_min: 2
+  n_nodes_max: 12
+
+runtime:
+  device: cpu
+
+output:
+  out_dir: data/run_many_class_smoke
+
+diagnostics:
+  enabled: false
+
+steering:
+  enabled: false
+
+filter:
+  enabled: false

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -97,7 +97,26 @@ cauchy-gen generate --config configs/preset_curriculum_auto_staged.yaml --num-da
 
 ______________________________________________________________________
 
-## 5. Benchmark workflows and guardrails
+## 5. Many-class workflows
+
+Use many-class presets to exercise the current rollout envelope (`n_classes_max <= 32`) with smoke-stable defaults.
+
+```bash
+cauchy-gen generate --config configs/preset_many_class_generate_smoke.yaml --num-datasets 25 --out data/run_many_class_smoke
+
+cauchy-gen benchmark \
+  --config configs/preset_many_class_benchmark_smoke.yaml \
+  --profile custom \
+  --suite smoke \
+  --no-memory \
+  --out-dir benchmarks/results/smoke_many_class
+```
+
+The benchmark summary includes throughput/latency plus standard guardrail payloads (for example, `lineage_guardrails`).
+
+______________________________________________________________________
+
+## 6. Benchmark workflows and guardrails
 
 Use smoke benchmarks for quick validation and standard benchmarks for broader
 performance checks.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,6 +10,8 @@ These wrappers call `uv run cauchy-gen ...` from the repo root.
   - Uses `configs/default.yaml`.
 - `scripts/generate-h100.sh [num_datasets] [device] [out_dir] [seed]`
   - Uses `configs/preset_cuda_h100.yaml`.
+- `scripts/generate-many-class.sh [num_datasets] [device] [out_dir] [seed]`
+  - Uses `configs/preset_many_class_generate_smoke.yaml`.
 - `scripts/generate-smoke.sh [config] [num_datasets] [device]`
   - Runs quick in-memory generation with `--no-write`.
 - `scripts/generate-curriculum.sh [num_datasets] [device] [out_dir] [seed] [curriculum]`
@@ -32,6 +34,7 @@ These wrappers call `uv run cauchy-gen ...` from the repo root.
 ./scripts/generate-default.sh
 ./scripts/generate-default.sh 50 cpu data/run_cpu_50
 ./scripts/generate-h100.sh 500 cuda data/run_h100_500 123
+./scripts/generate-many-class.sh 25 cpu data/run_many_class 123
 ./scripts/generate-from-config.sh configs/benchmark_medium_cuda.yaml 100 cuda data/run_medium 42
 ./scripts/generate-smoke.sh configs/default.yaml 3 cpu
 ./scripts/generate-curriculum.sh

--- a/scripts/generate-many-class.sh
+++ b/scripts/generate-many-class.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/generate-from-config.sh" \
+  "configs/preset_many_class_generate_smoke.yaml" \
+  "${1:-10}" \
+  "${2:-cpu}" \
+  "${3:-data/run_many_class_$(date +%Y%m%d_%H%M%S)}" \
+  "${4:-}"

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -283,3 +283,36 @@ def test_benchmark_cli_curriculum_stage1_smoke_preset_does_not_crash(tmp_path) -
     profile = payload["profile_results"][0]
     guardrails = profile["curriculum_guardrails"]
     assert guardrails["enabled"] is True
+
+
+def test_benchmark_cli_many_class_smoke_preset_emits_runtime_metrics(tmp_path) -> None:
+    out = tmp_path / "summary_many_class_smoke.json"
+    code = main(
+        [
+            "benchmark",
+            "--config",
+            "configs/preset_many_class_benchmark_smoke.yaml",
+            "--profile",
+            "custom",
+            "--suite",
+            "smoke",
+            "--num-datasets",
+            "2",
+            "--warmup",
+            "0",
+            "--no-hardware-aware",
+            "--no-memory",
+            "--json-out",
+            str(out),
+        ]
+    )
+    assert code == 0
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    profile = payload["profile_results"][0]
+    assert float(profile["datasets_per_minute"]) > 0.0
+    assert float(profile["latency_p95_ms"]) >= 0.0
+    regression = payload["regression"]
+    assert regression["status"] in {"pass", "warn", "fail"}
+    guardrails = profile["lineage_guardrails"]
+    assert isinstance(guardrails, dict)
+    assert isinstance(guardrails["enabled"], bool)

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -234,6 +234,61 @@ def test_generate_cli_curriculum_fixed_stage_preset_end_to_end_no_write(
         assert int(payload["stage"]) == 2
 
 
+def test_generate_cli_many_class_preset_end_to_end_no_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from cauchy_generator.core import dataset as dataset_mod
+
+    captured_metadata: list[dict[str, object]] = []
+    original_generate_batch_iter = dataset_mod.generate_batch_iter
+
+    def _capture_generate_batch_iter(
+        config,
+        *,
+        num_datasets: int,
+        seed: int | None = None,
+        device: str | None = None,
+    ):
+        for bundle in original_generate_batch_iter(
+            config,
+            num_datasets=num_datasets,
+            seed=seed,
+            device=device,
+        ):
+            captured_metadata.append(bundle.metadata)
+            yield bundle
+
+    monkeypatch.setattr(
+        "cauchy_generator.cli.generate_batch_iter",
+        _capture_generate_batch_iter,
+    )
+
+    code = main(
+        [
+            "generate",
+            "--config",
+            "configs/preset_many_class_generate_smoke.yaml",
+            "--num-datasets",
+            "2",
+            "--device",
+            "cpu",
+            "--no-hardware-aware",
+            "--no-write",
+        ]
+    )
+
+    assert code == 0
+    assert len(captured_metadata) == 2
+    for metadata in captured_metadata:
+        class_structure = metadata["class_structure"]
+        assert isinstance(class_structure, dict)
+        assert 2 <= int(class_structure["n_classes_realized"]) <= 32
+        filter_metadata = metadata["filter"]
+        assert isinstance(filter_metadata, dict)
+        assert filter_metadata["enabled"] is False
+        assert "accepted" not in filter_metadata
+
+
 def test_benchmark_cli_rejects_negative_warmup() -> None:
     with pytest.raises(SystemExit) as exc:
         main(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -209,6 +209,23 @@ def test_load_curriculum_stage_presets() -> None:
     assert "curriculum_smoke" in cfg_benchmark.benchmark.profiles
 
 
+def test_load_many_class_presets() -> None:
+    cfg_generate = GeneratorConfig.from_yaml("configs/preset_many_class_generate_smoke.yaml")
+    cfg_benchmark = GeneratorConfig.from_yaml("configs/preset_many_class_benchmark_smoke.yaml")
+
+    assert cfg_generate.dataset.task == "classification"
+    assert cfg_generate.dataset.n_classes_min >= 24
+    assert cfg_generate.dataset.n_classes_max <= MAX_SUPPORTED_CLASS_COUNT
+    assert cfg_generate.filter.enabled is False
+
+    assert cfg_benchmark.dataset.task == "classification"
+    assert cfg_benchmark.dataset.n_classes_min >= 24
+    assert cfg_benchmark.dataset.n_classes_max <= MAX_SUPPORTED_CLASS_COUNT
+    assert cfg_benchmark.filter.enabled is False
+    assert cfg_benchmark.benchmark.profile_name == "many_class_smoke"
+    assert "many_class_smoke" in cfg_benchmark.benchmark.profiles
+
+
 def test_curriculum_stage_schema_parses_with_string_stage_keys() -> None:
     cfg = GeneratorConfig.from_dict(
         {


### PR DESCRIPTION
## Summary
- add many-class smoke presets for generation and benchmark workflows
- add a dedicated many-class generation wrapper script
- document many-class generation and benchmark usage in README, usage guide, and scripts docs
- add config-load tests for many-class presets
- add CLI integration tests for many-class generate and benchmark invocation paths

## Validation
- uv run ruff check tests/test_config.py tests/test_cli_validation.py tests/test_benchmark_cli.py
- uv run pytest -q tests/test_config.py tests/test_cli_validation.py tests/test_benchmark_cli.py

Closes #23