### PR TITLE
feat(shift): shift-profile config schema + validation

### DIFF
--- a/src/cauchy_generator/config.py
+++ b/src/cauchy_generator/config.py
@@ -39,6 +39,30 @@ _MISSINGNESS_MECHANISM_VALUE_MAP: dict[str, MissingnessMechanism] = {
     MISSINGNESS_MECHANISM_MNAR: MISSINGNESS_MECHANISM_MNAR,
 }
 
+ShiftProfile = Literal[
+    "off",
+    "graph_drift",
+    "mechanism_drift",
+    "noise_drift",
+    "mixed",
+    "custom",
+]
+SHIFT_PROFILE_OFF: Literal["off"] = "off"
+SHIFT_PROFILE_GRAPH_DRIFT: Literal["graph_drift"] = "graph_drift"
+SHIFT_PROFILE_MECHANISM_DRIFT: Literal["mechanism_drift"] = "mechanism_drift"
+SHIFT_PROFILE_NOISE_DRIFT: Literal["noise_drift"] = "noise_drift"
+SHIFT_PROFILE_MIXED: Literal["mixed"] = "mixed"
+SHIFT_PROFILE_CUSTOM: Literal["custom"] = "custom"
+
+_SHIFT_PROFILE_VALUE_MAP: dict[str, ShiftProfile] = {
+    SHIFT_PROFILE_OFF: SHIFT_PROFILE_OFF,
+    SHIFT_PROFILE_GRAPH_DRIFT: SHIFT_PROFILE_GRAPH_DRIFT,
+    SHIFT_PROFILE_MECHANISM_DRIFT: SHIFT_PROFILE_MECHANISM_DRIFT,
+    SHIFT_PROFILE_NOISE_DRIFT: SHIFT_PROFILE_NOISE_DRIFT,
+    SHIFT_PROFILE_MIXED: SHIFT_PROFILE_MIXED,
+    SHIFT_PROFILE_CUSTOM: SHIFT_PROFILE_CUSTOM,
+}
+
 MAX_SUPPORTED_CLASS_COUNT = 32
 
 
@@ -71,6 +95,26 @@ def normalize_missing_mechanism(value: str) -> MissingnessMechanism:
     return result
 
 
+def normalize_shift_profile(value: object) -> ShiftProfile:
+    """Normalize shift profile into a validated internal value."""
+
+    if value is False:
+        return SHIFT_PROFILE_OFF
+    if isinstance(value, bool) or not isinstance(value, str):
+        raise ValueError(
+            "Unsupported shift.profile "
+            f"'{value}'. Expected off, graph_drift, mechanism_drift, noise_drift, mixed, or custom."
+        )
+    normalized = value.strip().lower()
+    result = _SHIFT_PROFILE_VALUE_MAP.get(normalized)
+    if result is None:
+        raise ValueError(
+            "Unsupported shift.profile "
+            f"'{value}'. Expected off, graph_drift, mechanism_drift, noise_drift, mixed, or custom."
+        )
+    return result
+
+
 def _validate_finite_float_field(
     *,
     field_name: str,
@@ -96,6 +140,31 @@ def _validate_finite_float_field(
     if not math.isfinite(parsed) or not (lo_ok and hi_ok):
         raise ValueError(f"{field_name} must be {expectation}, got {parsed!r}.")
     return parsed
+
+
+def _validate_optional_finite_float_field(
+    *,
+    field_name: str,
+    value: Any,
+    lo: float,
+    hi: float | None,
+    lo_inclusive: bool,
+    hi_inclusive: bool,
+    expectation: str,
+) -> float | None:
+    """Validate an optional float field against finite bounds and normalize it."""
+
+    if value is None:
+        return None
+    return _validate_finite_float_field(
+        field_name=field_name,
+        value=value,
+        lo=lo,
+        hi=hi,
+        lo_inclusive=lo_inclusive,
+        hi_inclusive=hi_inclusive,
+        expectation=expectation,
+    )
 
 
 def _validate_int_field(
@@ -408,6 +477,79 @@ class CurriculumConfig:
 
 
 @dataclass(slots=True)
+class ShiftConfig:
+    enabled: bool = False
+    profile: ShiftProfile = SHIFT_PROFILE_OFF
+    graph_scale: float | None = None
+    mechanism_scale: float | None = None
+    noise_scale: float | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.enabled, bool):
+            raise ValueError(f"shift.enabled must be a boolean, got {self.enabled!r}.")
+        self.profile = normalize_shift_profile(self.profile)
+        self.graph_scale = _validate_optional_finite_float_field(
+            field_name="shift.graph_scale",
+            value=self.graph_scale,
+            lo=0.0,
+            hi=1.0,
+            lo_inclusive=True,
+            hi_inclusive=True,
+            expectation="a finite value in [0, 1]",
+        )
+        self.mechanism_scale = _validate_optional_finite_float_field(
+            field_name="shift.mechanism_scale",
+            value=self.mechanism_scale,
+            lo=0.0,
+            hi=1.0,
+            lo_inclusive=True,
+            hi_inclusive=True,
+            expectation="a finite value in [0, 1]",
+        )
+        self.noise_scale = _validate_optional_finite_float_field(
+            field_name="shift.noise_scale",
+            value=self.noise_scale,
+            lo=0.0,
+            hi=1.0,
+            lo_inclusive=True,
+            hi_inclusive=True,
+            expectation="a finite value in [0, 1]",
+        )
+
+        has_overrides = any(
+            scale is not None
+            for scale in (self.graph_scale, self.mechanism_scale, self.noise_scale)
+        )
+        if not self.enabled:
+            if self.profile != SHIFT_PROFILE_OFF:
+                raise ValueError("shift.profile must be 'off' when shift.enabled is false.")
+            if has_overrides:
+                raise ValueError("shift override scales must be unset when shift.enabled is false.")
+            return
+
+        if self.profile == SHIFT_PROFILE_OFF:
+            raise ValueError("shift.profile must not be 'off' when shift.enabled is true.")
+
+        if self.profile == SHIFT_PROFILE_CUSTOM and not has_overrides:
+            raise ValueError("shift.profile 'custom' requires at least one override scale.")
+
+        if self.profile == SHIFT_PROFILE_GRAPH_DRIFT and (
+            self.mechanism_scale is not None or self.noise_scale is not None
+        ):
+            raise ValueError("shift.profile 'graph_drift' only allows shift.graph_scale override.")
+        if self.profile == SHIFT_PROFILE_MECHANISM_DRIFT and (
+            self.graph_scale is not None or self.noise_scale is not None
+        ):
+            raise ValueError(
+                "shift.profile 'mechanism_drift' only allows shift.mechanism_scale override."
+            )
+        if self.profile == SHIFT_PROFILE_NOISE_DRIFT and (
+            self.graph_scale is not None or self.mechanism_scale is not None
+        ):
+            raise ValueError("shift.profile 'noise_drift' only allows shift.noise_scale override.")
+
+
+@dataclass(slots=True)
 class RuntimeConfig:
     device: str = "auto"
     torch_dtype: str = "float32"
@@ -483,6 +625,7 @@ class GeneratorConfig:
     dataset: DatasetConfig = field(default_factory=DatasetConfig)
     graph: GraphConfig = field(default_factory=GraphConfig)
     curriculum: CurriculumConfig = field(default_factory=CurriculumConfig)
+    shift: ShiftConfig = field(default_factory=ShiftConfig)
     runtime: RuntimeConfig = field(default_factory=RuntimeConfig)
     output: OutputConfig = field(default_factory=OutputConfig)
     diagnostics: DiagnosticsConfig = field(default_factory=DiagnosticsConfig)
@@ -503,6 +646,7 @@ class GeneratorConfig:
             graph_data["n_nodes_max"] = graph_data.pop("n_nodes_log2_max")
         graph = GraphConfig(**graph_data)
         curriculum = CurriculumConfig.from_dict(data.get("curriculum"))
+        shift = ShiftConfig(**(data.get("shift") or {}))
         runtime = RuntimeConfig(**(data.get("runtime") or {}))
         output = OutputConfig(**(data.get("output") or {}))
         diagnostics = DiagnosticsConfig(**(data.get("diagnostics") or {}))
@@ -520,6 +664,7 @@ class GeneratorConfig:
             dataset=dataset,
             graph=graph,
             curriculum=curriculum,
+            shift=shift,
             runtime=runtime,
             output=output,
             diagnostics=diagnostics,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -528,3 +528,209 @@ def test_unused_missingness_parameters_are_allowed_with_disabled_mechanism() -> 
     assert cfg.dataset.missing_mar_observed_fraction == 0.8
     assert cfg.dataset.missing_mar_logit_scale == 2.5
     assert cfg.dataset.missing_mnar_logit_scale == 3.5
+
+
+def test_shift_defaults_are_backward_compatible_when_shift_block_is_absent() -> None:
+    cfg = GeneratorConfig.from_yaml("configs/default.yaml")
+    assert cfg.shift.enabled is False
+    assert cfg.shift.profile == "off"
+    assert cfg.shift.graph_scale is None
+    assert cfg.shift.mechanism_scale is None
+    assert cfg.shift.noise_scale is None
+
+
+@pytest.mark.parametrize("config_path", ("configs/default.yaml", "configs/benchmark_cpu.yaml"))
+def test_existing_config_files_parse_with_shift_schema(config_path: str) -> None:
+    cfg = GeneratorConfig.from_yaml(config_path)
+    assert cfg.shift.enabled is False
+    assert cfg.shift.profile == "off"
+
+
+def test_shift_schema_accepts_profile_with_optional_override() -> None:
+    cfg = GeneratorConfig.from_dict(
+        {
+            "shift": {
+                "enabled": True,
+                "profile": "Graph_Drift",
+                "graph_scale": "0.75",
+            }
+        }
+    )
+    assert cfg.shift.enabled is True
+    assert cfg.shift.profile == "graph_drift"
+    assert cfg.shift.graph_scale == 0.75
+    assert cfg.shift.mechanism_scale is None
+    assert cfg.shift.noise_scale is None
+
+
+def test_shift_schema_accepts_mixed_profile_with_multiple_overrides() -> None:
+    cfg = GeneratorConfig.from_dict(
+        {
+            "shift": {
+                "enabled": True,
+                "profile": "mixed",
+                "graph_scale": 0.2,
+                "mechanism_scale": 0.4,
+                "noise_scale": 0.6,
+            }
+        }
+    )
+    assert cfg.shift.profile == "mixed"
+    assert cfg.shift.graph_scale == 0.2
+    assert cfg.shift.mechanism_scale == 0.4
+    assert cfg.shift.noise_scale == 0.6
+
+
+def test_shift_schema_accepts_custom_profile_with_at_least_one_override() -> None:
+    cfg = GeneratorConfig.from_dict(
+        {
+            "shift": {
+                "enabled": True,
+                "profile": "custom",
+                "mechanism_scale": 0.35,
+            }
+        }
+    )
+    assert cfg.shift.profile == "custom"
+    assert cfg.shift.mechanism_scale == 0.35
+
+
+def test_shift_schema_rejects_invalid_profile_value() -> None:
+    with pytest.raises(ValueError, match="Unsupported shift.profile"):
+        GeneratorConfig.from_dict({"shift": {"enabled": True, "profile": "unknown_mode"}})
+
+
+def test_shift_schema_accepts_boolean_false_alias_for_off_profile() -> None:
+    cfg = GeneratorConfig.from_dict({"shift": {"enabled": False, "profile": False}})
+    assert cfg.shift.profile == "off"
+
+
+def test_shift_schema_rejects_boolean_true_profile_alias() -> None:
+    with pytest.raises(ValueError, match="Unsupported shift.profile"):
+        GeneratorConfig.from_dict({"shift": {"enabled": False, "profile": True}})
+
+
+def test_shift_schema_from_yaml_accepts_unquoted_off_profile(tmp_path) -> None:
+    cfg_path = tmp_path / "shift_off.yaml"
+    cfg_path.write_text(
+        "shift:\n  enabled: false\n  profile: off\n",
+        encoding="utf-8",
+    )
+    cfg = GeneratorConfig.from_yaml(cfg_path)
+    assert cfg.shift.enabled is False
+    assert cfg.shift.profile == "off"
+
+
+def test_shift_schema_rejects_non_boolean_enabled_value() -> None:
+    with pytest.raises(ValueError, match="shift.enabled must be a boolean"):
+        GeneratorConfig.from_dict({"shift": {"enabled": "true", "profile": "off"}})
+
+
+@pytest.mark.parametrize(
+    ("field_name", "bad_value"),
+    [
+        ("graph_scale", -0.1),
+        ("graph_scale", 1.1),
+        ("graph_scale", float("inf")),
+        ("graph_scale", float("nan")),
+        ("graph_scale", True),
+        ("mechanism_scale", -0.1),
+        ("mechanism_scale", 1.1),
+        ("mechanism_scale", float("inf")),
+        ("mechanism_scale", float("nan")),
+        ("mechanism_scale", True),
+        ("noise_scale", -0.1),
+        ("noise_scale", 1.1),
+        ("noise_scale", float("inf")),
+        ("noise_scale", float("nan")),
+        ("noise_scale", True),
+    ],
+)
+def test_shift_override_scales_enforce_finite_unit_interval_bounds(
+    field_name: str, bad_value: float | bool
+) -> None:
+    with pytest.raises(
+        ValueError, match=rf"shift\.{field_name} must be a finite value in \[0, 1\]"
+    ):
+        GeneratorConfig.from_dict(
+            {
+                "shift": {
+                    "enabled": True,
+                    "profile": "mixed",
+                    field_name: bad_value,
+                }
+            }
+        )
+
+
+def test_shift_schema_rejects_non_off_profile_when_disabled() -> None:
+    with pytest.raises(
+        ValueError, match=r"shift\.profile must be 'off' when shift\.enabled is false"
+    ):
+        GeneratorConfig.from_dict({"shift": {"enabled": False, "profile": "mixed"}})
+
+
+def test_shift_schema_rejects_overrides_when_disabled() -> None:
+    with pytest.raises(
+        ValueError, match=r"shift override scales must be unset when shift\.enabled is false"
+    ):
+        GeneratorConfig.from_dict(
+            {
+                "shift": {
+                    "enabled": False,
+                    "profile": "off",
+                    "graph_scale": 0.2,
+                }
+            }
+        )
+
+
+def test_shift_schema_rejects_off_profile_when_enabled() -> None:
+    with pytest.raises(
+        ValueError, match=r"shift\.profile must not be 'off' when shift\.enabled is true"
+    ):
+        GeneratorConfig.from_dict({"shift": {"enabled": True, "profile": "off"}})
+
+
+def test_shift_schema_requires_custom_profile_to_set_at_least_one_override() -> None:
+    with pytest.raises(
+        ValueError, match=r"shift\.profile 'custom' requires at least one override scale"
+    ):
+        GeneratorConfig.from_dict({"shift": {"enabled": True, "profile": "custom"}})
+
+
+@pytest.mark.parametrize(
+    ("profile", "payload", "error_pattern"),
+    [
+        (
+            "graph_drift",
+            {"noise_scale": 0.25},
+            r"shift\.profile 'graph_drift' only allows shift\.graph_scale override",
+        ),
+        (
+            "mechanism_drift",
+            {"graph_scale": 0.25},
+            r"shift\.profile 'mechanism_drift' only allows shift\.mechanism_scale override",
+        ),
+        (
+            "noise_drift",
+            {"mechanism_scale": 0.25},
+            r"shift\.profile 'noise_drift' only allows shift\.noise_scale override",
+        ),
+    ],
+)
+def test_shift_schema_rejects_incompatible_profile_override_combinations(
+    profile: str,
+    payload: dict[str, float],
+    error_pattern: str,
+) -> None:
+    with pytest.raises(ValueError, match=error_pattern):
+        GeneratorConfig.from_dict(
+            {
+                "shift": {
+                    "enabled": True,
+                    "profile": profile,
+                    **payload,
+                }
+            }
+        )


### PR DESCRIPTION
## Summary
- add top-level shift profile config schema and strict validation
- preserve backward compatibility with defaults when shift is omitted
- fix YAML parsing pitfall by treating YAML-coerced False profile as off

## Testing
- uv run pytest tests/test_config.py -q
- uv run pytest tests/test_generate.py -q
- uv run ruff check src/cauchy_generator/config.py tests/test_config.py

Closes #72