### PR TITLE
feat(shift): integrate shift/drift controls into generation sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ ______________________________________________________________________
 
 - **Configurable Missingness:** Native support for MCAR, MAR, and MNAR mechanisms with deterministic seeded behavior and benchmark guardrails.
 - **Complexity Curriculum:** Stage-aware scaling of row counts, feature counts, node counts, and graph depth to support progressive model training.
+- **Configurable Shift/Drift:** Opt-in graph/mechanism/noise shift profiles with interpretable scale semantics and deterministic seed behavior.
 - **Meta-Feature Steering:** soft-steering loop that biases generation toward target meta-feature bands (e.g., specific linearity or SNR ranges) using under-coverage reweighting.
 - **Lineage Integrity:** Every dataset includes a versioned DAG lineage artifact with adjacency matrices and feature-to-node assignments.
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -107,6 +107,28 @@ flowchart LR
 - Postprocess standardizes/clips/permutes as configured.
 - Missingness injection (MCAR/MAR/MNAR) is optional and applied after
   postprocess, before bundle emission.
+- Shift/drift controls are optional and can bias graph density, mechanism-family
+  sampling, and stochastic noise magnitudes.
+
+### 4.5 Shift/drift controls
+
+Shift controls are opt-in (`shift.enabled: true`). When disabled, generation
+follows the baseline path unchanged.
+
+The three shift axes use explicit scale semantics:
+
+| Axis              | What changes                           | Scale mapping                                       |
+| ----------------- | -------------------------------------- | --------------------------------------------------- |
+| `graph_scale`     | DAG edge-density prior                 | `edge_logit_bias_shift = ln(2) * graph_scale`       |
+| `mechanism_scale` | function-family sampling probabilities | `softmax(mechanism_scale * centered_family_logits)` |
+| `noise_scale`     | stochastic noise magnitude             | `sigma_multiplier = exp((ln(2)/2) * noise_scale)`   |
+
+Interpretation:
+
+- `graph_scale = 1.0` doubles edge odds relative to baseline.
+- `noise_scale = 1.0` corresponds to +3 dB variance (2x variance).
+- `mechanism_scale > 0` shifts mass toward nonlinear families (`nn`, `tree`,
+  `discretization`, `gp`, `product`) while remaining probabilistic.
 
 ### 5. Optional steering and diagnostics
 
@@ -185,6 +207,8 @@ sections such as `missingness_guardrails`, `lineage_guardrails`, and
 - **stage bounds**: min/max constraints for features, nodes, and depth.
 - **learnability filter**: random-forest-based gate for signal quality.
 - **wins ratio**: bootstrap fraction where model beats baseline.
+- **shift profile**: opt-in distribution-drift control over graph, mechanism,
+  and noise sampling axes.
 
 ### Steering and metrics
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -116,7 +116,66 @@ The benchmark summary includes throughput/latency plus standard guardrail payloa
 
 ______________________________________________________________________
 
-## 6. Benchmark workflows and guardrails
+## 6. Shift workflows
+
+Use shift profiles when you want controlled distribution drift while preserving
+deterministic seeds.
+
+Profile examples:
+
+```yaml
+shift:
+  enabled: true
+  profile: graph_drift
+```
+
+```yaml
+shift:
+  enabled: true
+  profile: mechanism_drift
+```
+
+```yaml
+shift:
+  enabled: true
+  profile: noise_drift
+```
+
+```yaml
+shift:
+  enabled: true
+  profile: mixed
+```
+
+Custom overrides:
+
+```yaml
+shift:
+  enabled: true
+  profile: custom
+  graph_scale: 0.6
+  mechanism_scale: 0.2
+  noise_scale: 0.4
+```
+
+How to pick scales:
+
+- `graph_scale`: edge-odds multiplier is `exp(ln(2) * graph_scale)`. Start at
+  `0.5` for moderate structure drift.
+- `mechanism_scale`: increases probability mass on nonlinear mechanism
+  families. Start at `0.5` for moderate tilt.
+- `noise_scale`: variance multiplier is `exp(ln(2) * noise_scale)`. Start at
+  `0.5` (+1.5 dB) for moderate noise drift.
+
+Run with any shift-enabled config:
+
+```bash
+cauchy-gen generate --config path/to/shift_config.yaml --num-datasets 25 --out data/run_shift
+```
+
+______________________________________________________________________
+
+## 7. Benchmark workflows and guardrails
 
 Use smoke benchmarks for quick validation and standard benchmarks for broader
 performance checks.

--- a/src/cauchy_generator/core/curriculum.py
+++ b/src/cauchy_generator/core/curriculum.py
@@ -223,6 +223,8 @@ def _sample_stagewise_graph(
     depth_max: int | None,
     generator: torch.Generator,
     device: str,
+    *,
+    edge_logit_bias_shift: float = 0.0,
 ) -> tuple[torch.Tensor, int, float]:
     """Sample DAG adjacency with optional stage-conditioned structure/depth constraints."""
 
@@ -230,6 +232,7 @@ def _sample_stagewise_graph(
         edge_logit_bias = 0.0
     else:
         edge_logit_bias = _CURRICULUM_STAGE_STRUCTURE_EDGE_LOGIT_BIAS.get(stage, 0.0)
+    edge_logit_bias += float(edge_logit_bias_shift)
     effective_depth_min = int(depth_min) if depth_min is not None else 1
     effective_depth_max = int(depth_max) if depth_max is not None else int(n_nodes)
     if effective_depth_min > effective_depth_max:

--- a/src/cauchy_generator/core/dataset.py
+++ b/src/cauchy_generator/core/dataset.py
@@ -23,6 +23,7 @@ from cauchy_generator.core.constants import (
 )
 from cauchy_generator.core.layout import _build_node_specs, _sample_layout
 from cauchy_generator.core.metadata import _build_curriculum_metadata, _build_lineage_metadata
+from cauchy_generator.core.shift import ShiftRuntimeParams, resolve_shift_runtime_params
 from cauchy_generator.core.steering_metrics import extract_steering_metrics
 from cauchy_generator.core.validation import _classification_split_valid, _stratified_split_indices
 from cauchy_generator.filtering import apply_torch_rf_filter
@@ -108,6 +109,8 @@ def _generate_graph_dataset_torch(
     device: str,
     *,
     n_rows: int,
+    mechanism_logit_tilt: float = 0.0,
+    noise_sigma_multiplier: float = 1.0,
 ) -> tuple[torch.Tensor, torch.Tensor, dict[str, Any]]:
     """Generate raw X/y tensors via the Torch graph pipeline."""
     generator = torch.Generator(device=device)
@@ -134,7 +137,15 @@ def _generate_graph_dataset_torch(
         spec_gen.manual_seed(seed + node_idx + NODE_SPEC_SEED_OFFSET)
         specs = _build_node_specs(node_idx, layout, task, spec_gen)
 
-        x_node, extracted = apply_node_pipeline(parent_data, n_rows, specs, generator, device)
+        x_node, extracted = apply_node_pipeline(
+            parent_data,
+            n_rows,
+            specs,
+            generator,
+            device,
+            mechanism_logit_tilt=mechanism_logit_tilt,
+            noise_sigma_multiplier=noise_sigma_multiplier,
+        )
         node_outputs[node_idx] = x_node
 
         for key, values in extracted.items():
@@ -183,9 +194,11 @@ def _generate_torch(
     n_train: int,
     n_test: int,
     curriculum: dict[str, Any],
+    shift_params: ShiftRuntimeParams | None = None,
 ) -> DatasetBundle:
     """Generate one dataset in Torch while preserving postprocess/filter contracts."""
 
+    shift_params = shift_params or resolve_shift_runtime_params(config)
     attempts = max(1, int(config.filter.max_attempts))
     last_reason = "unknown"
     dtype = _torch_dtype(config)
@@ -199,6 +212,8 @@ def _generate_torch(
                 seed + attempt,
                 device,
                 n_rows=n_rows,
+                mechanism_logit_tilt=float(shift_params.mechanism_logit_tilt),
+                noise_sigma_multiplier=float(shift_params.noise_sigma_multiplier),
             )
         except Exception as exc:
             last_reason = f"generation_exception:{exc.__class__.__name__}"
@@ -362,6 +377,7 @@ def _generate_one_seeded(
     )
     layout_gen = manager.torch_rng("layout")
     layout = _sample_layout(config, layout_gen, "cpu", curriculum=curriculum)
+    shift_params = resolve_shift_runtime_params(config)
     data_seed = manager.child("data")
     n_train = int(curriculum["n_train"])
     n_test = int(curriculum["n_test"])
@@ -386,6 +402,7 @@ def _generate_one_seeded(
                 n_train=n_train,
                 n_test=n_test,
                 curriculum=curriculum,
+                shift_params=shift_params,
             )
         except Exception:
             # Keep auto mode robust on partially supported MPS runtimes by retrying on CPU.
@@ -397,6 +414,7 @@ def _generate_one_seeded(
                 n_train=n_train,
                 n_test=n_test,
                 curriculum=curriculum,
+                shift_params=shift_params,
             )
 
     return _generate_torch(
@@ -407,6 +425,7 @@ def _generate_one_seeded(
         n_train=n_train,
         n_test=n_test,
         curriculum=curriculum,
+        shift_params=shift_params,
     )
 
 

--- a/src/cauchy_generator/core/layout.py
+++ b/src/cauchy_generator/core/layout.py
@@ -13,6 +13,7 @@ from cauchy_generator.core.curriculum import (
     _sample_log_uniform_int,
     _sample_stagewise_graph,
 )
+from cauchy_generator.core.shift import resolve_shift_runtime_params
 from cauchy_generator.core.node_pipeline import ConverterSpec
 from cauchy_generator.sampling import CorrelatedSampler
 
@@ -52,6 +53,7 @@ def _sample_layout(
 ) -> dict[str, Any]:
     """Sample dataset layout, graph, and node assignments for one dataset instance."""
 
+    shift_params = resolve_shift_runtime_params(config)
     bounds = _resolve_stagewise_layout_bounds(config, curriculum)
     n_features = int(
         torch.randint(
@@ -128,6 +130,7 @@ def _sample_layout(
         bounds.depth_max,
         generator,
         device,
+        edge_logit_bias_shift=float(shift_params.edge_logit_bias_shift),
     )
     feature_node_assignment = _sample_assignments(n_features, n_nodes, generator, device)
     target_node_assignment = _sample_assignments(1, n_nodes, generator, device)[0]

--- a/src/cauchy_generator/core/node_pipeline.py
+++ b/src/cauchy_generator/core/node_pipeline.py
@@ -31,6 +31,9 @@ def apply_node_pipeline(
     converter_specs: list[ConverterSpec],
     generator: torch.Generator,
     device: str,
+    *,
+    mechanism_logit_tilt: float = 0.0,
+    noise_sigma_multiplier: float = 1.0,
 ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
     """Apply node transform in torch."""
     required_dim = int(sum(max(1, s.dim) for s in converter_specs))
@@ -38,15 +41,33 @@ def apply_node_pipeline(
     total_dim = required_dim + max(1, latent_extra)
 
     if parent_data:
-        x = apply_multi_function(parent_data, generator, out_dim=total_dim)
+        x = apply_multi_function(
+            parent_data,
+            generator,
+            out_dim=total_dim,
+            mechanism_logit_tilt=mechanism_logit_tilt,
+            noise_sigma_multiplier=noise_sigma_multiplier,
+        )
     else:
-        x = sample_random_points(n_rows, total_dim, generator, device)
+        x = sample_random_points(
+            n_rows,
+            total_dim,
+            generator,
+            device,
+            mechanism_logit_tilt=mechanism_logit_tilt,
+            noise_sigma_multiplier=noise_sigma_multiplier,
+        )
 
     x = torch.nan_to_num(x.to(torch.float32), nan=0.0, posinf=1e6, neginf=-1e6)
     x = torch.clamp(x, -1e6, 1e6)
     x = _standardize(x)
 
-    w = sample_random_weights(x.shape[1], generator, device)
+    w = sample_random_weights(
+        x.shape[1],
+        generator,
+        device,
+        sigma_multiplier=noise_sigma_multiplier,
+    )
     x = x * w.unsqueeze(0)
 
     mean_l2 = torch.mean(torch.norm(x, dim=1))

--- a/src/cauchy_generator/core/shift.py
+++ b/src/cauchy_generator/core/shift.py
@@ -1,0 +1,153 @@
+"""Shift runtime parameter resolution for sampling-path integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+
+from cauchy_generator.config import (
+    GeneratorConfig,
+    SHIFT_PROFILE_CUSTOM,
+    SHIFT_PROFILE_GRAPH_DRIFT,
+    SHIFT_PROFILE_MECHANISM_DRIFT,
+    SHIFT_PROFILE_MIXED,
+    SHIFT_PROFILE_NOISE_DRIFT,
+    SHIFT_PROFILE_OFF,
+)
+
+_LOG_TWO = math.log(2.0)
+_NOISE_VARIANCE_DB_SPAN = _LOG_TWO / 2.0
+
+MECHANISM_FAMILY_ORDER: tuple[str, ...] = (
+    "nn",
+    "tree",
+    "discretization",
+    "gp",
+    "linear",
+    "quadratic",
+    "em",
+    "product",
+)
+
+MECHANISM_FAMILY_BASE_LOGITS: dict[str, float] = {
+    "nn": 0.7,
+    "tree": 0.7,
+    "discretization": 0.5,
+    "gp": 0.5,
+    "linear": -0.8,
+    "quadratic": -0.6,
+    "em": -0.3,
+    "product": 0.9,
+}
+
+_PROFILE_DEFAULT_SCALES: dict[str, tuple[float, float, float]] = {
+    SHIFT_PROFILE_OFF: (0.0, 0.0, 0.0),
+    SHIFT_PROFILE_GRAPH_DRIFT: (0.5, 0.0, 0.0),
+    SHIFT_PROFILE_MECHANISM_DRIFT: (0.0, 0.5, 0.0),
+    SHIFT_PROFILE_NOISE_DRIFT: (0.0, 0.0, 0.5),
+    SHIFT_PROFILE_MIXED: (1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0),
+    SHIFT_PROFILE_CUSTOM: (0.0, 0.0, 0.0),
+}
+
+
+@dataclass(slots=True, frozen=True)
+class ShiftRuntimeParams:
+    """Resolved shift runtime parameters for one generation run."""
+
+    enabled: bool
+    profile: str
+    graph_scale: float
+    mechanism_scale: float
+    noise_scale: float
+    edge_logit_bias_shift: float
+    mechanism_logit_tilt: float
+    noise_sigma_multiplier: float
+
+
+def centered_mechanism_family_logits(families: tuple[str, ...]) -> tuple[float, ...]:
+    """Return centered family logits used for mechanism drift sampling."""
+
+    if not families:
+        return ()
+    raw = tuple(float(MECHANISM_FAMILY_BASE_LOGITS.get(name, 0.0)) for name in families)
+    mean = sum(raw) / float(len(raw))
+    return tuple(value - mean for value in raw)
+
+
+def mechanism_family_probabilities(
+    *,
+    mechanism_logit_tilt: float,
+    families: tuple[str, ...] = MECHANISM_FAMILY_ORDER,
+) -> dict[str, float]:
+    """Resolve mechanism family probabilities for a given tilt value."""
+
+    if not families:
+        return {}
+    if mechanism_logit_tilt <= 0.0:
+        uniform = 1.0 / float(len(families))
+        return {family: uniform for family in families}
+
+    centered_logits = centered_mechanism_family_logits(families)
+    scaled = [float(mechanism_logit_tilt * logit) for logit in centered_logits]
+    max_logit = max(scaled)
+    exp_vals = [math.exp(logit - max_logit) for logit in scaled]
+    denom = sum(exp_vals)
+    return {
+        family: (exp_val / denom if denom > 0.0 else 1.0 / float(len(families)))
+        for family, exp_val in zip(families, exp_vals, strict=True)
+    }
+
+
+def resolve_shift_runtime_params(config: GeneratorConfig) -> ShiftRuntimeParams:
+    """Resolve shift profile/defaults/overrides into runtime coefficients."""
+
+    shift = config.shift
+    if not shift.enabled:
+        return ShiftRuntimeParams(
+            enabled=False,
+            profile=SHIFT_PROFILE_OFF,
+            graph_scale=0.0,
+            mechanism_scale=0.0,
+            noise_scale=0.0,
+            edge_logit_bias_shift=0.0,
+            mechanism_logit_tilt=0.0,
+            noise_sigma_multiplier=1.0,
+        )
+
+    profile = str(shift.profile)
+    default_graph_scale, default_mechanism_scale, default_noise_scale = _PROFILE_DEFAULT_SCALES[
+        profile
+    ]
+
+    graph_scale = (
+        float(shift.graph_scale) if shift.graph_scale is not None else float(default_graph_scale)
+    )
+    mechanism_scale = (
+        float(shift.mechanism_scale)
+        if shift.mechanism_scale is not None
+        else float(default_mechanism_scale)
+    )
+    noise_scale = (
+        float(shift.noise_scale) if shift.noise_scale is not None else float(default_noise_scale)
+    )
+
+    return ShiftRuntimeParams(
+        enabled=True,
+        profile=profile,
+        graph_scale=graph_scale,
+        mechanism_scale=mechanism_scale,
+        noise_scale=noise_scale,
+        edge_logit_bias_shift=float(_LOG_TWO * graph_scale),
+        mechanism_logit_tilt=mechanism_scale,
+        noise_sigma_multiplier=float(math.exp(_NOISE_VARIANCE_DB_SPAN * noise_scale)),
+    )
+
+
+__all__ = [
+    "MECHANISM_FAMILY_BASE_LOGITS",
+    "MECHANISM_FAMILY_ORDER",
+    "ShiftRuntimeParams",
+    "centered_mechanism_family_logits",
+    "mechanism_family_probabilities",
+    "resolve_shift_runtime_params",
+]

--- a/src/cauchy_generator/functions/multi.py
+++ b/src/cauchy_generator/functions/multi.py
@@ -12,18 +12,41 @@ def apply_multi_function(
     generator: torch.Generator,
     *,
     out_dim: int,
+    mechanism_logit_tilt: float = 0.0,
+    noise_sigma_multiplier: float = 1.0,
 ) -> torch.Tensor:
     """Apply composition across parent node tensors in torch."""
     if not inputs:
         raise ValueError("inputs must be non-empty")
     if len(inputs) == 1:
-        return apply_random_function(inputs[0], generator, out_dim=out_dim)
+        return apply_random_function(
+            inputs[0],
+            generator,
+            out_dim=out_dim,
+            mechanism_logit_tilt=mechanism_logit_tilt,
+            noise_sigma_multiplier=noise_sigma_multiplier,
+        )
 
     if torch.rand(1, generator=generator).item() < 0.5:
         concat = torch.cat(inputs, dim=1)
-        return apply_random_function(concat, generator, out_dim=out_dim)
+        return apply_random_function(
+            concat,
+            generator,
+            out_dim=out_dim,
+            mechanism_logit_tilt=mechanism_logit_tilt,
+            noise_sigma_multiplier=noise_sigma_multiplier,
+        )
 
-    transformed = [apply_random_function(inp, generator, out_dim=out_dim) for inp in inputs]
+    transformed = [
+        apply_random_function(
+            inp,
+            generator,
+            out_dim=out_dim,
+            mechanism_logit_tilt=mechanism_logit_tilt,
+            noise_sigma_multiplier=noise_sigma_multiplier,
+        )
+        for inp in inputs
+    ]
     stacked = torch.stack(transformed, dim=1)  # (N, parents, out_dim)
 
     aggs = ["sum", "product", "max", "logsumexp"]

--- a/src/cauchy_generator/functions/random_functions.py
+++ b/src/cauchy_generator/functions/random_functions.py
@@ -6,6 +6,7 @@ import math
 
 import torch
 
+from cauchy_generator.core.shift import MECHANISM_FAMILY_ORDER, mechanism_family_probabilities
 from cauchy_generator.core.trees import compute_odt_leaf_indices, sample_odt_splits
 from cauchy_generator.functions.activations import apply_random_activation
 from cauchy_generator.linalg.random_matrices import sample_random_matrix
@@ -23,13 +24,31 @@ def _standardize(x: torch.Tensor) -> torch.Tensor:
     return _standardize_base(x)
 
 
-def _apply_linear(x: torch.Tensor, out_dim: int, generator: torch.Generator) -> torch.Tensor:
+def _apply_linear(
+    x: torch.Tensor,
+    out_dim: int,
+    generator: torch.Generator,
+    *,
+    noise_sigma_multiplier: float = 1.0,
+) -> torch.Tensor:
     """Apply a sampled random linear map in torch."""
-    m = sample_random_matrix(out_dim, x.shape[1], generator, str(x.device))
+    m = sample_random_matrix(
+        out_dim,
+        x.shape[1],
+        generator,
+        str(x.device),
+        noise_sigma_multiplier=noise_sigma_multiplier,
+    )
     return x @ m.t()
 
 
-def _apply_quadratic(x: torch.Tensor, out_dim: int, generator: torch.Generator) -> torch.Tensor:
+def _apply_quadratic(
+    x: torch.Tensor,
+    out_dim: int,
+    generator: torch.Generator,
+    *,
+    noise_sigma_multiplier: float = 1.0,
+) -> torch.Tensor:
     """Apply quadratic forms in torch."""
     d_cap = min(x.shape[1], 20)
     if x.shape[1] > d_cap:
@@ -41,12 +60,24 @@ def _apply_quadratic(x: torch.Tensor, out_dim: int, generator: torch.Generator) 
 
     y = torch.empty(x_aug.shape[0], out_dim, device=x.device)
     for i in range(out_dim):
-        m = sample_random_matrix(x_aug.shape[1], x_aug.shape[1], generator, str(x.device))
+        m = sample_random_matrix(
+            x_aug.shape[1],
+            x_aug.shape[1],
+            generator,
+            str(x.device),
+            noise_sigma_multiplier=noise_sigma_multiplier,
+        )
         y[:, i] = torch.sum((x_aug @ m) * x_aug, dim=1)
     return y
 
 
-def _apply_nn(x: torch.Tensor, out_dim: int, generator: torch.Generator) -> torch.Tensor:
+def _apply_nn(
+    x: torch.Tensor,
+    out_dim: int,
+    generator: torch.Generator,
+    *,
+    noise_sigma_multiplier: float = 1.0,
+) -> torch.Tensor:
     """Apply a shallow random NN in torch."""
     n_layers = torch.randint(1, 4, (1,), generator=generator).item()
     hidden = int(_log_uniform(generator, 1.0, 127.0, str(x.device)))
@@ -60,7 +91,13 @@ def _apply_nn(x: torch.Tensor, out_dim: int, generator: torch.Generator) -> torc
         y = apply_random_activation(y, generator)
 
     for din, dout in zip(widths[:-1], widths[1:], strict=True):
-        m = sample_random_matrix(dout, din, generator, str(x.device))
+        m = sample_random_matrix(
+            dout,
+            din,
+            generator,
+            str(x.device),
+            noise_sigma_multiplier=noise_sigma_multiplier,
+        )
         y = y @ m.t()
         if dout != out_dim:
             y = apply_random_activation(y, generator)
@@ -99,7 +136,11 @@ def _apply_tree(x: torch.Tensor, out_dim: int, generator: torch.Generator) -> to
 
 
 def _apply_discretization(
-    x: torch.Tensor, out_dim: int, generator: torch.Generator
+    x: torch.Tensor,
+    out_dim: int,
+    generator: torch.Generator,
+    *,
+    noise_sigma_multiplier: float = 1.0,
 ) -> torch.Tensor:
     """Apply discretization function in torch."""
     n_centers = int(_log_uniform(generator, 2.0, 128.0, str(x.device)))
@@ -111,7 +152,7 @@ def _apply_discretization(
     dist = torch.pow(torch.abs(x.unsqueeze(1) - centers.unsqueeze(0)), p).sum(dim=2)
     nearest = torch.argmin(dist, dim=1)
     y = centers[nearest]
-    return _apply_linear(y, out_dim, generator)
+    return _apply_linear(y, out_dim, generator, noise_sigma_multiplier=noise_sigma_multiplier)
 
 
 def _sample_radial_ha(
@@ -126,7 +167,13 @@ def _sample_radial_ha(
     return torch.pow(1.0 - u, 1.0 / (1.0 - a)) - 1.0
 
 
-def _apply_gp(x: torch.Tensor, out_dim: int, generator: torch.Generator) -> torch.Tensor:
+def _apply_gp(
+    x: torch.Tensor,
+    out_dim: int,
+    generator: torch.Generator,
+    *,
+    noise_sigma_multiplier: float = 1.0,
+) -> torch.Tensor:
     """Apply GP approximation in torch."""
     din = x.shape[1]
     p = 256
@@ -148,7 +195,7 @@ def _apply_gp(x: torch.Tensor, out_dim: int, generator: torch.Generator) -> torc
         r = _sample_radial_ha(p, generator, device, a=a)
         omega = z * r.unsqueeze(1)
 
-        w = sample_random_weights(din, generator, device)
+        w = sample_random_weights(din, generator, device, sigma_multiplier=noise_sigma_multiplier)
         alpha = _log_uniform(generator, 0.5, 10.0, device)
         a_mat = torch.randn(din, din, generator=generator, device=device)
         m = alpha * (w.unsqueeze(1) * a_mat)
@@ -160,7 +207,13 @@ def _apply_gp(x: torch.Tensor, out_dim: int, generator: torch.Generator) -> torc
     return (phi @ z_out.t()) / math.sqrt(float(p))
 
 
-def _apply_em(x: torch.Tensor, out_dim: int, generator: torch.Generator) -> torch.Tensor:
+def _apply_em(
+    x: torch.Tensor,
+    out_dim: int,
+    generator: torch.Generator,
+    *,
+    noise_sigma_multiplier: float = 1.0,
+) -> torch.Tensor:
     """Apply EM assignment function in torch."""
     m_val = int(_log_uniform(generator, 2.0, float(max(16, 2 * out_dim)), str(x.device)))
     m_val = max(2, m_val)
@@ -178,18 +231,59 @@ def _apply_em(x: torch.Tensor, out_dim: int, generator: torch.Generator) -> torc
         dist_p / torch.clamp(sigma, min=1e-6), q_val
     )
     probs = torch.softmax(logits, dim=1)
-    return _apply_linear(probs, out_dim, generator)
+    return _apply_linear(probs, out_dim, generator, noise_sigma_multiplier=noise_sigma_multiplier)
 
 
-def _apply_product(x: torch.Tensor, out_dim: int, generator: torch.Generator) -> torch.Tensor:
+def _apply_product(
+    x: torch.Tensor,
+    out_dim: int,
+    generator: torch.Generator,
+    *,
+    mechanism_logit_tilt: float = 0.0,
+    noise_sigma_multiplier: float = 1.0,
+) -> torch.Tensor:
     """Apply product function in torch."""
     allowed = ["tree", "discretization", "gp", "linear", "quadratic"]
     idx_f = torch.randint(0, len(allowed), (1,), generator=generator).item()
     idx_g = torch.randint(0, len(allowed), (1,), generator=generator).item()
 
-    fx = apply_random_function(x, generator, out_dim=out_dim, function_type=allowed[int(idx_f)])
-    gx = apply_random_function(x, generator, out_dim=out_dim, function_type=allowed[int(idx_g)])
+    fx = apply_random_function(
+        x,
+        generator,
+        out_dim=out_dim,
+        function_type=allowed[int(idx_f)],
+        mechanism_logit_tilt=mechanism_logit_tilt,
+        noise_sigma_multiplier=noise_sigma_multiplier,
+    )
+    gx = apply_random_function(
+        x,
+        generator,
+        out_dim=out_dim,
+        function_type=allowed[int(idx_g)],
+        mechanism_logit_tilt=mechanism_logit_tilt,
+        noise_sigma_multiplier=noise_sigma_multiplier,
+    )
     return fx * gx
+
+
+def _sample_function_family(generator: torch.Generator, *, mechanism_logit_tilt: float) -> str:
+    """Sample one function family with optional logit tilt."""
+
+    if mechanism_logit_tilt <= 0.0:
+        idx = torch.randint(0, len(MECHANISM_FAMILY_ORDER), (1,), generator=generator).item()
+        return MECHANISM_FAMILY_ORDER[int(idx)]
+
+    probs_by_family = mechanism_family_probabilities(
+        mechanism_logit_tilt=mechanism_logit_tilt,
+        families=MECHANISM_FAMILY_ORDER,
+    )
+    draw = float(torch.rand(1, generator=generator).item())
+    cumulative = 0.0
+    for family in MECHANISM_FAMILY_ORDER:
+        cumulative += float(probs_by_family[family])
+        if draw <= cumulative:
+            return family
+    return MECHANISM_FAMILY_ORDER[-1]
 
 
 def apply_random_function(
@@ -198,6 +292,8 @@ def apply_random_function(
     *,
     out_dim: int | None = None,
     function_type: str | None = None,
+    mechanism_logit_tilt: float = 0.0,
+    noise_sigma_multiplier: float = 1.0,
 ) -> torch.Tensor:
     """Apply one sampled random function family to `x` in torch."""
     y = x.to(torch.float32)
@@ -208,34 +304,34 @@ def apply_random_function(
     dout = out_dim if out_dim is not None else y.shape[1]
 
     if function_type is None:
-        families = [
-            "nn",
-            "tree",
-            "discretization",
-            "gp",
-            "linear",
-            "quadratic",
-            "em",
-            "product",
-        ]
-        idx = torch.randint(0, len(families), (1,), generator=generator).item()
-        function_type = families[int(idx)]
+        function_type = _sample_function_family(
+            generator,
+            mechanism_logit_tilt=mechanism_logit_tilt,
+        )
 
     if function_type == "nn":
-        return _apply_nn(y, dout, generator)
+        return _apply_nn(y, dout, generator, noise_sigma_multiplier=noise_sigma_multiplier)
     if function_type == "tree":
         return _apply_tree(y, dout, generator)
     if function_type == "discretization":
-        return _apply_discretization(y, dout, generator)
+        return _apply_discretization(
+            y, dout, generator, noise_sigma_multiplier=noise_sigma_multiplier
+        )
     if function_type == "gp":
-        return _apply_gp(y, dout, generator)
+        return _apply_gp(y, dout, generator, noise_sigma_multiplier=noise_sigma_multiplier)
     if function_type == "linear":
-        return _apply_linear(y, dout, generator)
+        return _apply_linear(y, dout, generator, noise_sigma_multiplier=noise_sigma_multiplier)
     if function_type == "quadratic":
-        return _apply_quadratic(y, dout, generator)
+        return _apply_quadratic(y, dout, generator, noise_sigma_multiplier=noise_sigma_multiplier)
     if function_type == "em":
-        return _apply_em(y, dout, generator)
+        return _apply_em(y, dout, generator, noise_sigma_multiplier=noise_sigma_multiplier)
     if function_type == "product":
-        return _apply_product(y, dout, generator)
+        return _apply_product(
+            y,
+            dout,
+            generator,
+            mechanism_logit_tilt=mechanism_logit_tilt,
+            noise_sigma_multiplier=noise_sigma_multiplier,
+        )
 
     raise ValueError(f"Unknown random function family: {function_type}")

--- a/src/cauchy_generator/linalg/random_matrices.py
+++ b/src/cauchy_generator/linalg/random_matrices.py
@@ -22,7 +22,14 @@ def _sample_gaussian(m: int, k: int, generator: torch.Generator, device: str) ->
     return torch.randn(m, k, generator=generator, device=device)
 
 
-def _sample_weights_matrix(m: int, k: int, generator: torch.Generator, device: str) -> torch.Tensor:
+def _sample_weights_matrix(
+    m: int,
+    k: int,
+    generator: torch.Generator,
+    device: str,
+    *,
+    noise_sigma_multiplier: float = 1.0,
+) -> torch.Tensor:
     """Sample weight-modulated Gaussian matrix in torch."""
     g = torch.randn(m, k, generator=generator, device=device)
     q_low = 0.1 / math.log(k + 1.0)
@@ -30,7 +37,14 @@ def _sample_weights_matrix(m: int, k: int, generator: torch.Generator, device: s
     shared_sigma = _log_uniform(generator, 1e-4, 10.0, device)
     rows = torch.stack(
         [
-            sample_random_weights(k, generator, device, q=shared_q, sigma=shared_sigma)
+            sample_random_weights(
+                k,
+                generator,
+                device,
+                q=shared_q,
+                sigma=shared_sigma,
+                sigma_multiplier=noise_sigma_multiplier,
+            )
             for _ in range(m)
         ],
         dim=0,
@@ -39,13 +53,18 @@ def _sample_weights_matrix(m: int, k: int, generator: torch.Generator, device: s
 
 
 def _sample_singular_values_matrix(
-    m: int, k: int, generator: torch.Generator, device: str
+    m: int,
+    k: int,
+    generator: torch.Generator,
+    device: str,
+    *,
+    noise_sigma_multiplier: float = 1.0,
 ) -> torch.Tensor:
     """Sample matrix with random singular values in torch."""
     d = min(m, k)
     u = torch.randn(m, d, generator=generator, device=device)
     v = torch.randn(d, k, generator=generator, device=device)
-    w = sample_random_weights(d, generator, device)
+    w = sample_random_weights(d, generator, device, sigma_multiplier=noise_sigma_multiplier)
     s = torch.diag(w)
     return u @ s @ v
 
@@ -71,6 +90,7 @@ def sample_random_matrix(
     device: str,
     *,
     kind: str | None = None,
+    noise_sigma_multiplier: float = 1.0,
 ) -> torch.Tensor:
     """Sample one of the supported matrix families in torch."""
     if out_dim <= 0 or in_dim <= 0:
@@ -84,15 +104,34 @@ def sample_random_matrix(
     if kind == "gaussian":
         m = _sample_gaussian(out_dim, in_dim, generator, device)
     elif kind == "weights":
-        m = _sample_weights_matrix(out_dim, in_dim, generator, device)
+        m = _sample_weights_matrix(
+            out_dim,
+            in_dim,
+            generator,
+            device,
+            noise_sigma_multiplier=noise_sigma_multiplier,
+        )
     elif kind == "singular_values":
-        m = _sample_singular_values_matrix(out_dim, in_dim, generator, device)
+        m = _sample_singular_values_matrix(
+            out_dim,
+            in_dim,
+            generator,
+            device,
+            noise_sigma_multiplier=noise_sigma_multiplier,
+        )
     elif kind == "kernel":
         m = _sample_kernel_matrix(out_dim, in_dim, generator, device)
     elif kind == "activation":
         other_kinds = ["gaussian", "weights", "singular_values", "kernel"]
         idx = torch.randint(0, len(other_kinds), (1,), generator=generator).item()
-        m = sample_random_matrix(out_dim, in_dim, generator, device, kind=other_kinds[int(idx)])
+        m = sample_random_matrix(
+            out_dim,
+            in_dim,
+            generator,
+            device,
+            kind=other_kinds[int(idx)],
+            noise_sigma_multiplier=noise_sigma_multiplier,
+        )
         m = apply_random_activation(m, generator, with_standardize=False)
         m = m + 1e-3 * torch.randn(m.shape, generator=generator, device=device)
     else:

--- a/src/cauchy_generator/sampling/random_points.py
+++ b/src/cauchy_generator/sampling/random_points.py
@@ -16,11 +16,16 @@ def _sample_unit_ball(n: int, d: int, generator: torch.Generator, device: str) -
 
 
 def _sample_random_covariance_normal(
-    n: int, d: int, generator: torch.Generator, device: str
+    n: int,
+    d: int,
+    generator: torch.Generator,
+    device: str,
+    *,
+    sigma_multiplier: float = 1.0,
 ) -> torch.Tensor:
     """Sample normal points with random anisotropic covariance transform."""
     x = torch.randn(n, d, generator=generator, device=device)
-    w = sample_random_weights(d, generator, device)
+    w = sample_random_weights(d, generator, device, sigma_multiplier=sigma_multiplier)
     a = torch.randn(d, d, generator=generator, device=device)
     return (x * w.unsqueeze(0)) @ a.t()
 
@@ -30,6 +35,9 @@ def sample_random_points(
     dim: int,
     generator: torch.Generator,
     device: str,
+    *,
+    mechanism_logit_tilt: float = 0.0,
+    noise_sigma_multiplier: float = 1.0,
 ) -> torch.Tensor:
     """Sample base points and transform through a random function in torch."""
     if n_rows <= 0 or dim <= 0:
@@ -46,6 +54,18 @@ def sample_random_points(
     elif base_kind == "unit_ball":
         base = _sample_unit_ball(n_rows, dim, generator, device)
     else:
-        base = _sample_random_covariance_normal(n_rows, dim, generator, device)
+        base = _sample_random_covariance_normal(
+            n_rows,
+            dim,
+            generator,
+            device,
+            sigma_multiplier=noise_sigma_multiplier,
+        )
 
-    return apply_random_function(base, generator, out_dim=dim)
+    return apply_random_function(
+        base,
+        generator,
+        out_dim=dim,
+        mechanism_logit_tilt=mechanism_logit_tilt,
+        noise_sigma_multiplier=noise_sigma_multiplier,
+    )

--- a/src/cauchy_generator/sampling/random_weights.py
+++ b/src/cauchy_generator/sampling/random_weights.py
@@ -18,10 +18,13 @@ def sample_random_weights(
     sigma_max: float = 10.0,
     q: float | None = None,
     sigma: float | None = None,
+    sigma_multiplier: float = 1.0,
 ) -> torch.Tensor:
     """Sample positive normalized weights using torch."""
     if dim <= 0:
         raise ValueError(f"dim must be > 0, got {dim}")
+    if not math.isfinite(float(sigma_multiplier)) or float(sigma_multiplier) <= 0.0:
+        raise ValueError(f"sigma_multiplier must be a finite value > 0, got {sigma_multiplier!r}")
 
     m = torch.arange(1, dim + 1, dtype=torch.float32, device=device)
     if q is None:
@@ -29,8 +32,9 @@ def sample_random_weights(
         q = _log_uniform(generator, q_low, max_q, device)
     if sigma is None:
         sigma = _log_uniform(generator, sigma_min, sigma_max, device)
+    effective_sigma = float(sigma) * float(sigma_multiplier)
 
-    noise = torch.randn(dim, generator=generator, device=device) * sigma
+    noise = torch.randn(dim, generator=generator, device=device) * effective_sigma
     w = torch.pow(m, -q) * torch.exp(noise)
     w = torch.clamp(w, min=1e-12)
     w /= torch.sum(w)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -29,6 +29,15 @@ def _tiny_config() -> GeneratorConfig:
     return cfg
 
 
+def _tiny_regression_config() -> GeneratorConfig:
+    cfg = _tiny_config()
+    cfg.dataset.task = "regression"
+    cfg.filter.enabled = False
+    cfg.dataset.n_features_min = 8
+    cfg.dataset.n_features_max = 8
+    return cfg
+
+
 def _layout_stub(
     *,
     feature_types: list[str],
@@ -173,6 +182,105 @@ def test_generate_batch_reproducible_lineage_for_fixed_seed() -> None:
         assert bundle_a.metadata["lineage"] == bundle_b.metadata["lineage"]
 
 
+def test_generate_one_shift_disabled_preserves_baseline_outputs() -> None:
+    baseline = _tiny_regression_config()
+    disabled = _tiny_regression_config()
+    disabled.shift.enabled = False
+    disabled.shift.profile = "off"
+
+    bundle_base = generate_one(baseline, seed=1881, device="cpu")
+    bundle_disabled = generate_one(disabled, seed=1881, device="cpu")
+
+    torch.testing.assert_close(bundle_base.X_train, bundle_disabled.X_train)
+    torch.testing.assert_close(bundle_base.X_test, bundle_disabled.X_test)
+    torch.testing.assert_close(bundle_base.y_train, bundle_disabled.y_train)
+    torch.testing.assert_close(bundle_base.y_test, bundle_disabled.y_test)
+    assert bundle_base.metadata["graph_edges"] == bundle_disabled.metadata["graph_edges"]
+    assert bundle_base.metadata["graph_edge_density"] == pytest.approx(
+        bundle_disabled.metadata["graph_edge_density"]
+    )
+
+
+def test_generate_one_graph_drift_increases_edge_density_for_same_seed() -> None:
+    baseline = _tiny_regression_config()
+    baseline.graph.n_nodes_min = 20
+    baseline.graph.n_nodes_max = 20
+
+    shifted = _tiny_regression_config()
+    shifted.graph.n_nodes_min = 20
+    shifted.graph.n_nodes_max = 20
+    shifted.shift.enabled = True
+    shifted.shift.profile = "graph_drift"
+
+    bundle_base = generate_one(baseline, seed=2203, device="cpu")
+    bundle_shifted = generate_one(shifted, seed=2203, device="cpu")
+
+    assert int(bundle_shifted.metadata["graph_edges"]) >= int(bundle_base.metadata["graph_edges"])
+    assert float(bundle_shifted.metadata["graph_edge_density"]) >= float(
+        bundle_base.metadata["graph_edge_density"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("profile", "override_field", "override_value"),
+    [
+        ("mechanism_drift", "mechanism_scale", 1.0),
+        ("noise_drift", "noise_scale", 1.0),
+    ],
+)
+def test_generate_one_shift_profiles_change_outputs_for_same_seed(
+    profile: str, override_field: str, override_value: float
+) -> None:
+    baseline = _tiny_regression_config()
+    baseline.graph.n_nodes_min = 10
+    baseline.graph.n_nodes_max = 10
+
+    shifted = _tiny_regression_config()
+    shifted.graph.n_nodes_min = 10
+    shifted.graph.n_nodes_max = 10
+    shifted.shift.enabled = True
+    shifted.shift.profile = profile
+    setattr(shifted.shift, override_field, override_value)
+
+    bundle_base = generate_one(baseline, seed=2204, device="cpu")
+    bundle_shifted = generate_one(shifted, seed=2204, device="cpu")
+    assert not torch.allclose(bundle_base.X_train, bundle_shifted.X_train)
+    assert not torch.allclose(bundle_base.X_test, bundle_shifted.X_test)
+
+
+@pytest.mark.parametrize(
+    ("profile", "overrides"),
+    [
+        ("graph_drift", {"graph_scale": 1.0}),
+        ("mechanism_drift", {"mechanism_scale": 1.0}),
+        ("noise_drift", {"noise_scale": 1.0}),
+        ("mixed", {}),
+    ],
+)
+def test_generate_one_shift_profiles_are_seed_reproducible(
+    profile: str, overrides: dict[str, float]
+) -> None:
+    cfg = _tiny_regression_config()
+    cfg.graph.n_nodes_min = 10
+    cfg.graph.n_nodes_max = 10
+    cfg.shift.enabled = True
+    cfg.shift.profile = profile
+    for key, value in overrides.items():
+        setattr(cfg.shift, key, value)
+
+    bundle_a = generate_one(cfg, seed=2205, device="cpu")
+    bundle_b = generate_one(cfg, seed=2205, device="cpu")
+
+    torch.testing.assert_close(bundle_a.X_train, bundle_b.X_train)
+    torch.testing.assert_close(bundle_a.X_test, bundle_b.X_test)
+    torch.testing.assert_close(bundle_a.y_train, bundle_b.y_train)
+    torch.testing.assert_close(bundle_a.y_test, bundle_b.y_test)
+    assert bundle_a.metadata["graph_edges"] == bundle_b.metadata["graph_edges"]
+    assert bundle_a.metadata["graph_edge_density"] == pytest.approx(
+        bundle_b.metadata["graph_edge_density"]
+    )
+
+
 def test_generate_one_lineage_assignments_follow_postprocess_feature_mapping(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -200,7 +308,7 @@ def test_generate_one_lineage_assignments_follow_postprocess_feature_mapping(
         lambda *_args, **_kwargs: layout,
     )
 
-    def _stub_generate_graph_dataset_torch(_config, _layout, _seed, _device, *, n_rows):
+    def _stub_generate_graph_dataset_torch(_config, _layout, _seed, _device, *, n_rows, **_kwargs):
         x = torch.arange(n_rows * 4, dtype=torch.float32).reshape(n_rows, 4)
         y = torch.linspace(0.0, 1.0, n_rows, dtype=torch.float32)
         return x, y, {"filter": {"enabled": False}}

--- a/tests/test_random_functions.py
+++ b/tests/test_random_functions.py
@@ -42,6 +42,25 @@ def test_deterministic() -> None:
     torch.testing.assert_close(y1, y2)
 
 
+def test_deterministic_with_shift_tilt_and_noise_multiplier() -> None:
+    x = torch.randn(32, 4)
+    y1 = apply_random_function(
+        x.clone(),
+        _make_generator(8),
+        out_dim=3,
+        mechanism_logit_tilt=0.7,
+        noise_sigma_multiplier=1.35,
+    )
+    y2 = apply_random_function(
+        x.clone(),
+        _make_generator(8),
+        out_dim=3,
+        mechanism_logit_tilt=0.7,
+        noise_sigma_multiplier=1.35,
+    )
+    torch.testing.assert_close(y1, y2)
+
+
 @pytest.mark.parametrize(
     "family",
     ["nn", "tree", "discretization", "gp", "linear", "quadratic", "em", "product"],

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -4,6 +4,11 @@ from cauchy_generator.sampling.random_weights import sample_random_weights
 from conftest import make_generator as _make_generator
 
 
+def _entropy(weights: torch.Tensor) -> float:
+    probs = torch.clamp(weights, min=1e-12)
+    return float(-(probs * torch.log(probs)).sum().item())
+
+
 def test_random_weights_normalized() -> None:
     g = _make_generator(42)
     w = sample_random_weights(32, g, "cpu")
@@ -22,3 +27,23 @@ def test_random_weights_positive() -> None:
     g = _make_generator(7)
     w = sample_random_weights(64, g, "cpu")
     assert torch.all(w > 0)
+
+
+def test_random_weights_sigma_multiplier_increases_peakedness() -> None:
+    low = sample_random_weights(
+        64,
+        _make_generator(314),
+        "cpu",
+        q=0.0,
+        sigma=1.0,
+        sigma_multiplier=1.0,
+    )
+    high = sample_random_weights(
+        64,
+        _make_generator(314),
+        "cpu",
+        q=0.0,
+        sigma=1.0,
+        sigma_multiplier=1.5,
+    )
+    assert _entropy(high) < _entropy(low)

--- a/tests/test_shift_runtime.py
+++ b/tests/test_shift_runtime.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from cauchy_generator.config import (
+    SHIFT_PROFILE_GRAPH_DRIFT,
+    SHIFT_PROFILE_MECHANISM_DRIFT,
+    SHIFT_PROFILE_MIXED,
+    SHIFT_PROFILE_NOISE_DRIFT,
+    GeneratorConfig,
+)
+from cauchy_generator.core.shift import (
+    MECHANISM_FAMILY_ORDER,
+    mechanism_family_probabilities,
+    resolve_shift_runtime_params,
+)
+
+
+def _cfg() -> GeneratorConfig:
+    return GeneratorConfig.from_yaml("configs/default.yaml")
+
+
+def _entropy_bits(probabilities: list[float]) -> float:
+    return float(-sum(p * math.log(p, 2) for p in probabilities if p > 0.0))
+
+
+def _nonlinear_mass(probs: dict[str, float]) -> float:
+    nonlinear = {"nn", "tree", "discretization", "gp", "product"}
+    return float(sum(prob for family, prob in probs.items() if family in nonlinear))
+
+
+def test_resolve_shift_runtime_params_disabled_returns_identity() -> None:
+    cfg = _cfg()
+    cfg.shift.enabled = False
+    cfg.shift.profile = "off"
+    params = resolve_shift_runtime_params(cfg)
+    assert params.enabled is False
+    assert params.profile == "off"
+    assert params.graph_scale == 0.0
+    assert params.mechanism_scale == 0.0
+    assert params.noise_scale == 0.0
+    assert params.edge_logit_bias_shift == 0.0
+    assert params.mechanism_logit_tilt == 0.0
+    assert params.noise_sigma_multiplier == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize(
+    ("profile", "expected_scales"),
+    [
+        (SHIFT_PROFILE_GRAPH_DRIFT, (0.5, 0.0, 0.0)),
+        (SHIFT_PROFILE_MECHANISM_DRIFT, (0.0, 0.5, 0.0)),
+        (SHIFT_PROFILE_NOISE_DRIFT, (0.0, 0.0, 0.5)),
+        (SHIFT_PROFILE_MIXED, (1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0)),
+    ],
+)
+def test_resolve_shift_runtime_params_uses_profile_defaults(
+    profile: str, expected_scales: tuple[float, float, float]
+) -> None:
+    cfg = _cfg()
+    cfg.shift.enabled = True
+    cfg.shift.profile = profile
+    params = resolve_shift_runtime_params(cfg)
+    assert params.enabled is True
+    assert params.profile == profile
+    assert params.graph_scale == pytest.approx(expected_scales[0])
+    assert params.mechanism_scale == pytest.approx(expected_scales[1])
+    assert params.noise_scale == pytest.approx(expected_scales[2])
+
+
+def test_resolve_shift_runtime_params_prioritizes_explicit_overrides() -> None:
+    cfg = _cfg()
+    cfg.shift.enabled = True
+    cfg.shift.profile = SHIFT_PROFILE_MIXED
+    cfg.shift.graph_scale = 0.9
+    cfg.shift.mechanism_scale = 0.1
+    cfg.shift.noise_scale = 0.4
+    params = resolve_shift_runtime_params(cfg)
+    assert params.graph_scale == pytest.approx(0.9)
+    assert params.mechanism_scale == pytest.approx(0.1)
+    assert params.noise_scale == pytest.approx(0.4)
+
+
+def test_resolve_shift_runtime_params_matches_formula_mappings() -> None:
+    cfg = _cfg()
+    cfg.shift.enabled = True
+    cfg.shift.profile = SHIFT_PROFILE_GRAPH_DRIFT
+    cfg.shift.graph_scale = 0.75
+    cfg.shift.mechanism_scale = 0.25
+    cfg.shift.noise_scale = 0.5
+    params = resolve_shift_runtime_params(cfg)
+    assert params.edge_logit_bias_shift == pytest.approx(math.log(2.0) * 0.75)
+    assert params.mechanism_logit_tilt == pytest.approx(0.25)
+    assert params.noise_sigma_multiplier == pytest.approx(math.exp((math.log(2.0) / 2.0) * 0.5))
+
+
+def test_mechanism_family_probabilities_are_uniform_when_tilt_is_zero() -> None:
+    probs = mechanism_family_probabilities(mechanism_logit_tilt=0.0)
+    expected = 1.0 / float(len(MECHANISM_FAMILY_ORDER))
+    assert set(probs) == set(MECHANISM_FAMILY_ORDER)
+    for prob in probs.values():
+        assert prob == pytest.approx(expected)
+
+
+def test_mechanism_family_probabilities_tilt_increases_nonlinear_mass() -> None:
+    probs_uniform = mechanism_family_probabilities(mechanism_logit_tilt=0.0)
+    probs_tilted = mechanism_family_probabilities(mechanism_logit_tilt=1.0)
+    entropy_uniform = _entropy_bits([probs_uniform[f] for f in MECHANISM_FAMILY_ORDER])
+    entropy_tilted = _entropy_bits([probs_tilted[f] for f in MECHANISM_FAMILY_ORDER])
+
+    assert _nonlinear_mass(probs_tilted) > _nonlinear_mass(probs_uniform)
+    assert entropy_tilted < entropy_uniform


### PR DESCRIPTION
Closes #73

## Summary
- integrate shift runtime controls across graph, mechanism, and noise sampling paths
- preserve default behavior when shift is disabled and keep seeded runs deterministic
- add end-user docs describing shift rationale and interpretable scale semantics

## Test Plan
- uv run ruff check src/cauchy_generator/core/shift.py src/cauchy_generator/core/layout.py src/cauchy_generator/core/curriculum.py src/cauchy_generator/core/node_pipeline.py src/cauchy_generator/core/dataset.py src/cauchy_generator/functions/multi.py src/cauchy_generator/functions/random_functions.py src/cauchy_generator/linalg/random_matrices.py src/cauchy_generator/sampling/random_points.py src/cauchy_generator/sampling/random_weights.py tests/test_shift_runtime.py tests/test_generate.py tests/test_random_functions.py tests/test_sampling.py
- uv run pytest tests/test_shift_runtime.py tests/test_sampling.py tests/test_random_functions.py tests/test_node_pipeline.py tests/test_cauchy_graph.py tests/test_generate.py -q