### PR TITLE
perf: add configurable ExtraTrees n_jobs and default to multicore

### DIFF
--- a/src/cauchy_generator/config.py
+++ b/src/cauchy_generator/config.py
@@ -588,6 +588,16 @@ class FilterConfig:
     n_bootstrap: int = 200
     threshold: float = 0.95
     max_attempts: int = 3
+    n_jobs: int = -1
+
+    def __post_init__(self) -> None:
+        self.n_jobs = _validate_int_field(
+            field_name="filter.n_jobs",
+            value=self.n_jobs,
+            minimum=-1,
+        )
+        if self.n_jobs == 0:
+            raise ValueError("filter.n_jobs must be -1 or an integer >= 1, got 0.")
 
 
 @dataclass(slots=True)

--- a/src/cauchy_generator/core/dataset.py
+++ b/src/cauchy_generator/core/dataset.py
@@ -398,6 +398,7 @@ def _apply_filter(
         max_features=config.filter.max_features,
         n_bootstrap=config.filter.n_bootstrap,
         threshold=config.filter.threshold,
+        n_jobs=config.filter.n_jobs,
     )
     details.update(filter_details)
     details["accepted"] = accepted

--- a/src/cauchy_generator/filtering/extra_trees_filter.py
+++ b/src/cauchy_generator/filtering/extra_trees_filter.py
@@ -149,6 +149,7 @@ def apply_extra_trees_filter(
     max_features: str | int | float = "auto",
     n_bootstrap: int = 200,
     threshold: float = 0.95,
+    n_jobs: int = -1,
 ) -> tuple[bool, dict[str, Any]]:
     """Apply CPU ExtraTrees filtering with OOB bootstrap win-ratio scoring."""
 
@@ -163,6 +164,10 @@ def apply_extra_trees_filter(
         raise ValueError(f"max_leaf_nodes must be >= 1 when set, got {max_leaf_nodes}")
     if n_bootstrap < 1:
         raise ValueError(f"n_bootstrap must be >= 1, got {n_bootstrap}")
+    if isinstance(n_jobs, bool) or not isinstance(n_jobs, int):
+        raise ValueError(f"n_jobs must be -1 or an integer >= 1, got {n_jobs!r}")
+    if n_jobs == 0 or n_jobs < -1:
+        raise ValueError(f"n_jobs must be -1 or an integer >= 1, got {n_jobs}")
 
     x_cpu = x.detach().to(device="cpu", dtype=torch.float32)
     if x_cpu.ndim != 2:
@@ -217,7 +222,7 @@ def apply_extra_trees_filter(
         "max_features": int(m_try),
         "oob_score": True,
         "random_state": seed,
-        "n_jobs": 1,
+        "n_jobs": int(n_jobs),
     }
     if max_depth == 0:
         # Preserve prior semantics where depth=0 forbids splits.
@@ -251,6 +256,7 @@ def apply_extra_trees_filter(
             "reason": "insufficient_oob_predictions",
             "n_valid_oob": n_valid,
             "backend": "extra_trees_cpu",
+            "n_jobs": int(n_jobs),
             **threshold_details,
         }
 
@@ -268,5 +274,6 @@ def apply_extra_trees_filter(
         "wins_ratio": float(wins_ratio),
         "n_valid_oob": n_valid,
         "backend": "extra_trees_cpu",
+        "n_jobs": int(n_jobs),
         **threshold_details,
     }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,6 +28,7 @@ def test_load_default_config() -> None:
     assert cfg.filter.n_estimators > 0
     assert cfg.filter.max_depth >= 0
     assert cfg.filter.max_features == "auto"
+    assert cfg.filter.n_jobs == -1
     assert cfg.dataset.missing_rate == 0.0
     assert cfg.dataset.missing_mechanism == MISSINGNESS_MECHANISM_NONE
     assert cfg.dataset.missing_mar_observed_fraction == 0.5
@@ -219,6 +220,22 @@ def test_legacy_filter_keys_are_rejected() -> None:
                 }
             }
         )
+
+
+def test_filter_n_jobs_accepts_minus_one_and_positive_values() -> None:
+    cfg_auto = GeneratorConfig.from_dict({"filter": {"n_jobs": -1}})
+    cfg_single = GeneratorConfig.from_dict({"filter": {"n_jobs": 1}})
+    cfg_multi = GeneratorConfig.from_dict({"filter": {"n_jobs": 8}})
+
+    assert cfg_auto.filter.n_jobs == -1
+    assert cfg_single.filter.n_jobs == 1
+    assert cfg_multi.filter.n_jobs == 8
+
+
+@pytest.mark.parametrize("value", [0, -2, True])
+def test_filter_n_jobs_rejects_invalid_values(value: int | bool) -> None:
+    with pytest.raises(ValueError, match=r"filter\.n_jobs must"):
+        GeneratorConfig.from_dict({"filter": {"n_jobs": value}})
 
 
 def test_missingness_mechanism_normalization_is_case_insensitive() -> None:

--- a/tests/test_extra_trees_filter.py
+++ b/tests/test_extra_trees_filter.py
@@ -75,6 +75,7 @@ def test_extra_trees_filter_is_deterministic_for_fixed_seed() -> None:
     assert details_a["wins_ratio"] == details_b["wins_ratio"]
     assert details_a["n_valid_oob"] == details_b["n_valid_oob"]
     assert details_a["backend"] == "extra_trees_cpu"
+    assert int(details_a["n_jobs"]) == -1
 
 
 def test_extra_trees_filter_handles_non_divisible_bootstrap_chunks() -> None:
@@ -132,6 +133,7 @@ def test_extra_trees_filter_can_report_insufficient_oob_predictions() -> None:
     assert details["reason"] == "insufficient_oob_predictions"
     assert 0 <= int(details["n_valid_oob"]) < 16
     assert details["backend"] == "extra_trees_cpu"
+    assert int(details["n_jobs"]) == -1
     assert details["threshold_requested"] == pytest.approx(0.5)
     assert details["threshold_effective"] == pytest.approx(0.5)
     assert details["threshold_policy"] == "class_aware_piecewise_v1"
@@ -367,3 +369,38 @@ def test_extra_trees_filter_accepts_32bit_seed_boundaries(seed: int) -> None:
     )
     assert isinstance(accepted, bool)
     assert details["backend"] == "extra_trees_cpu"
+
+
+def test_extra_trees_filter_honors_explicit_n_jobs() -> None:
+    x, y = _make_regression_data(seed=1234)
+    accepted, details = apply_extra_trees_filter(
+        x,
+        y,
+        task="regression",
+        seed=99,
+        n_estimators=4,
+        max_depth=3,
+        n_bootstrap=8,
+        threshold=0.5,
+        n_jobs=1,
+    )
+
+    assert isinstance(accepted, bool)
+    assert int(details["n_jobs"]) == 1
+
+
+@pytest.mark.parametrize("bad_n_jobs", [0, -2, True])
+def test_extra_trees_filter_rejects_invalid_n_jobs(bad_n_jobs: int | bool) -> None:
+    x, y = _make_regression_data(seed=123)
+    with pytest.raises(ValueError, match=r"n_jobs must be -1 or an integer >= 1"):
+        apply_extra_trees_filter(
+            x,
+            y,
+            task="regression",
+            seed=42,
+            n_estimators=4,
+            max_depth=3,
+            n_bootstrap=8,
+            threshold=0.5,
+            n_jobs=bad_n_jobs,
+        )

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -764,10 +764,11 @@ def test_generate_one_returns_torch_tensors_on_cpu() -> None:
 
 
 def test_torch_path_applies_filter_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
-    called: dict[str, int] = {"count": 0}
+    called: dict[str, int] = {"count": 0, "n_jobs": 0}
 
     def _stub_filter(*_args, **_kwargs):
         called["count"] += 1
+        called["n_jobs"] = int(_kwargs["n_jobs"])
         return True, {
             "wins_ratio": 1.0,
             "n_valid_oob": 128,
@@ -791,6 +792,7 @@ def test_torch_path_applies_filter_when_enabled(monkeypatch: pytest.MonkeyPatch)
     assert bundle.metadata["filter"]["threshold_policy"] == "class_aware_piecewise_v1"
     assert bundle.metadata["filter"]["class_bucket"] == "25-32"
     assert float(bundle.metadata["filter"]["threshold_effective"]) == pytest.approx(0.80)
+    assert called["n_jobs"] == int(cfg.filter.n_jobs)
     assert "reason" not in bundle.metadata["filter"]
 
 


### PR DESCRIPTION
## Summary
- add `filter.n_jobs` to `FilterConfig` with validation (`-1` or `>=1`) and default to `-1`
- thread `filter.n_jobs` through dataset filtering into `apply_extra_trees_filter`
- update ExtraTrees backend to honor `n_jobs`, validate invalid values, and include `n_jobs` in filter metadata
- add tests for config validation/defaults, filter `n_jobs` behavior, and generation-path forwarding

## Validation
- `.venv/bin/ruff check src/cauchy_generator/config.py src/cauchy_generator/core/dataset.py src/cauchy_generator/filtering/extra_trees_filter.py tests/test_config.py tests/test_extra_trees_filter.py tests/test_generate.py`
- `.venv/bin/pytest -q tests/test_config.py tests/test_extra_trees_filter.py tests/test_generate.py`
- `.venv/bin/pytest -q tests/test_cli_validation.py tests/test_curriculum_shell.py`
