### PR TITLE
feat: add telemetry for noise sampling and packed writer performance

### DIFF
--- a/src/cauchy_generator/bench/guardrails.py
+++ b/src/cauchy_generator/bench/guardrails.py
@@ -24,6 +24,7 @@ from cauchy_generator.core.dataset import generate_batch_iter
 from cauchy_generator.io.parquet_writer import write_packed_parquet_shards_stream
 from cauchy_generator.math_utils import to_numpy as _to_numpy
 from cauchy_generator.rng import offset_seed32
+from cauchy_generator.telemetry import PerfTelemetry
 from cauchy_generator.types import DatasetBundle
 
 
@@ -56,6 +57,7 @@ def _measure_persistence_datasets_per_minute(
     *,
     config: GeneratorConfig,
     num_bundles: int,
+    telemetry: PerfTelemetry | None = None,
 ) -> float:
     """Measure write-path throughput for a fixed number of streamed bundles."""
 
@@ -70,6 +72,7 @@ def _measure_persistence_datasets_per_minute(
             out_dir=out_dir,
             shard_size=max(1, int(config.output.shard_size)),
             compression=str(config.output.compression),
+            telemetry=telemetry,
         )
     elapsed = time.perf_counter() - start
     if elapsed <= 0.0:
@@ -163,6 +166,8 @@ def _measure_lineage_persistence_trials(
     num_bundles: int,
     config: GeneratorConfig,
     trials: int,
+    baseline_telemetry: PerfTelemetry | None = None,
+    current_telemetry: PerfTelemetry | None = None,
 ) -> tuple[list[float], list[float]]:
     """Collect paired baseline/lineage persistence throughput trials."""
 
@@ -176,6 +181,7 @@ def _measure_lineage_persistence_trials(
                 baseline_bundles,
                 config=config,
                 num_bundles=num_bundles,
+                telemetry=baseline_telemetry,
             )
         )
         current_bundles = _iter_staged_bundles(current_stage_dir, num_bundles=num_bundles)
@@ -184,6 +190,7 @@ def _measure_lineage_persistence_trials(
                 current_bundles,
                 config=config,
                 num_bundles=num_bundles,
+                telemetry=current_telemetry,
             )
         )
     return baseline_trials, current_trials
@@ -317,6 +324,8 @@ def _collect_lineage_guardrails(
 
         lineage_coverage_rate = float(bundles_with_lineage) / float(bundles_seen)
 
+        baseline_perf_telemetry = PerfTelemetry(enabled=True)
+        current_perf_telemetry = PerfTelemetry(enabled=True)
         try:
             baseline_trials, current_trials = _measure_lineage_persistence_trials(
                 baseline_stage_dir=baseline_stage_dir,
@@ -324,6 +333,8 @@ def _collect_lineage_guardrails(
                 num_bundles=bundles_seen,
                 config=config,
                 trials=LINEAGE_GUARDRAIL_RUNTIME_TRIALS,
+                baseline_telemetry=baseline_perf_telemetry,
+                current_telemetry=current_perf_telemetry,
             )
         except Exception as exc:
             return {
@@ -391,6 +402,8 @@ def _collect_lineage_guardrails(
         ),
         "runtime_warn_threshold_pct": float(warn_threshold_pct),
         "runtime_fail_threshold_pct": float(fail_threshold_pct),
+        "performance_telemetry_baseline": baseline_perf_telemetry.snapshot(),
+        "performance_telemetry_with_lineage": current_perf_telemetry.snapshot(),
         "issues": issues,
         "status": _status_from_issues(issues),
     }

--- a/src/cauchy_generator/bench/suite.py
+++ b/src/cauchy_generator/bench/suite.py
@@ -83,6 +83,7 @@ from cauchy_generator.meta_targets import (
     merge_target_bands,
 )
 from cauchy_generator.rng import SeedManager, offset_seed32
+from cauchy_generator.telemetry import PerfTelemetry
 
 
 DEFAULT_PROFILE_CONFIGS: dict[str, str] = {
@@ -406,6 +407,7 @@ def run_profile_benchmark(
         shift_guardrails=shift_guardrails,
         noise_guardrails=noise_guardrails,
     )
+    perf_telemetry = PerfTelemetry(enabled=True)
 
     result = run_throughput_benchmark(
         config,
@@ -413,6 +415,7 @@ def run_profile_benchmark(
         warmup_datasets=warmup,
         device=requested_device,
         on_bundle=on_bundle_callback,
+        telemetry=perf_telemetry,
     )
     result["profile_key"] = spec.key
     result["suite"] = suite

--- a/src/cauchy_generator/bench/throughput.py
+++ b/src/cauchy_generator/bench/throughput.py
@@ -14,6 +14,7 @@ from cauchy_generator.bench.constants import (
 from cauchy_generator.config import GeneratorConfig
 from cauchy_generator.core.dataset import generate_batch_iter
 from cauchy_generator.rng import offset_seed32
+from cauchy_generator.telemetry import PerfTelemetry
 from cauchy_generator.types import DatasetBundle
 
 
@@ -24,6 +25,7 @@ def _consume_generation(
     seed: int,
     device: str | None,
     on_bundle: Callable[[DatasetBundle], object] | None = None,
+    telemetry: PerfTelemetry | None = None,
 ) -> None:
     """Run generation for ``num_datasets`` items while discarding outputs."""
 
@@ -32,6 +34,7 @@ def _consume_generation(
         num_datasets=num_datasets,
         seed=seed,
         device=device,
+        telemetry=telemetry,
     ):
         if on_bundle is not None:
             on_bundle(bundle)
@@ -44,6 +47,7 @@ def run_throughput_benchmark(
     warmup_datasets: int = 10,
     device: str | None = None,
     on_bundle: Callable[[DatasetBundle], object] | None = None,
+    telemetry: PerfTelemetry | None = None,
 ) -> dict[str, Any]:
     """Measure end-to-end generation throughput for a benchmark profile."""
 
@@ -62,11 +66,12 @@ def run_throughput_benchmark(
         seed=offset_seed32(config.seed, THROUGHPUT_MEASURE_SEED_OFFSET),
         device=device,
         on_bundle=on_bundle,
+        telemetry=telemetry,
     )
     elapsed = time.perf_counter() - start
     dps = num_datasets / elapsed if elapsed > 0 else 0.0
     dpm = dps * SECONDS_PER_MINUTE
-    return {
+    payload: dict[str, Any] = {
         "profile": config.benchmark.profile_name,
         "num_datasets": num_datasets,
         "warmup_datasets": warmup_datasets,
@@ -75,3 +80,6 @@ def run_throughput_benchmark(
         "datasets_per_minute": dpm,
         "slo_pass_100_datasets_per_min": dpm >= THROUGHPUT_SLO_DATASETS_PER_MINUTE,
     }
+    if telemetry is not None:
+        payload["performance_telemetry"] = telemetry.snapshot()
+    return payload

--- a/src/cauchy_generator/cli.py
+++ b/src/cauchy_generator/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import json
 import math
 import sys
 from collections.abc import Iterator
@@ -40,11 +41,13 @@ from cauchy_generator.hardware import (
     detect_hardware,
 )
 from cauchy_generator.io.parquet_writer import write_packed_parquet_shards_stream
+from cauchy_generator.math_utils import sanitize_json as _sanitize_json
 from cauchy_generator.meta_targets import (
     coerce_quantiles,
     merge_target_bands,
 )
 from cauchy_generator.rng import SEED32_MAX, SEED32_MIN
+from cauchy_generator.telemetry import PerfTelemetry
 
 DEVICE_CHOICES = ("auto", "cpu", "cuda", "mps")
 MISSINGNESS_MECHANISM_CLI_CHOICES = (
@@ -276,6 +279,11 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Override MNAR logit scale (> 0).",
     )
+    g.add_argument(
+        "--telemetry-json",
+        default=None,
+        help="Optional path to write performance telemetry JSON for this generate run.",
+    )
     b = sub.add_parser("benchmark", help="Run benchmark suite across one or more profiles.")
     b.add_argument("--config", default=None, help="Optional YAML config for profile 'custom'.")
     b.add_argument(
@@ -422,6 +430,28 @@ def _apply_missingness_cli_overrides(config: GeneratorConfig, args: argparse.Nam
         _raise_usage_error(str(exc))
 
 
+def _write_perf_telemetry_json(
+    telemetry: PerfTelemetry,
+    *,
+    out_path: str | Path,
+    command: str,
+    num_datasets: int,
+) -> Path:
+    """Write one performance telemetry payload JSON."""
+
+    path = Path(out_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "command": str(command),
+        "num_datasets": int(num_datasets),
+        "generated_at": dt.datetime.now(dt.UTC).isoformat(),
+        "performance_telemetry": telemetry.snapshot(),
+    }
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(_sanitize_json(payload), f, indent=2, sort_keys=True)
+    return path
+
+
 def _run_generate(args: argparse.Namespace) -> int:
     """Execute the ``generate`` command."""
 
@@ -460,12 +490,16 @@ def _run_generate(args: argparse.Namespace) -> int:
         f"Hardware backend={hw.backend} device='{hw.device_name}' "
         f"memory_gb={hw.total_memory_gb} peak_flops={hw.peak_flops:.3e} profile={hw.profile}"
     )
+    perf_telemetry: PerfTelemetry | None = None
+    if args.telemetry_json:
+        perf_telemetry = PerfTelemetry(enabled=True)
 
     stream: Iterator[Any] = generate_batch_iter(
         config,
         num_datasets=args.num_datasets,
         seed=seed,
         device=args.device,
+        telemetry=perf_telemetry,
     )
     if diagnostics_aggregator is not None:
         base_stream = stream
@@ -489,6 +523,14 @@ def _run_generate(args: argparse.Namespace) -> int:
                 summary, diagnostics_out_dir / "coverage_summary.md"
             )
             print(f"Wrote diagnostics artifacts: {json_path} and {md_path}")
+        if perf_telemetry is not None and args.telemetry_json:
+            perf_path = _write_perf_telemetry_json(
+                perf_telemetry,
+                out_path=args.telemetry_json,
+                command="generate",
+                num_datasets=generated,
+            )
+            print(f"Wrote performance telemetry: {perf_path}")
         print(f"Generated {generated} datasets (no-write mode).")
         return 0
 
@@ -497,6 +539,7 @@ def _run_generate(args: argparse.Namespace) -> int:
         out_dir=out_dir,
         shard_size=config.output.shard_size,
         compression=config.output.compression,
+        telemetry=perf_telemetry,
     )
     if diagnostics_aggregator is not None:
         assert diagnostics_out_dir is not None
@@ -508,6 +551,14 @@ def _run_generate(args: argparse.Namespace) -> int:
             summary, diagnostics_out_dir / "coverage_summary.md"
         )
         print(f"Wrote diagnostics artifacts: {json_path} and {md_path}")
+    if perf_telemetry is not None and args.telemetry_json:
+        perf_path = _write_perf_telemetry_json(
+            perf_telemetry,
+            out_path=args.telemetry_json,
+            command="generate",
+            num_datasets=written,
+        )
+        print(f"Wrote performance telemetry: {perf_path}")
     print(f"Wrote {written} datasets to: {Path(out_dir)}")
     return 0
 

--- a/src/cauchy_generator/core/dataset.py
+++ b/src/cauchy_generator/core/dataset.py
@@ -37,6 +37,7 @@ from cauchy_generator.sampling.noise import (
     sample_mixture_component_family,
     sample_noise_from_spec,
 )
+from cauchy_generator.telemetry import PerfTelemetry, activate_perf_telemetry
 from cauchy_generator.types import DatasetBundle
 
 
@@ -709,18 +710,20 @@ def generate_one(
     *,
     seed: int | None = None,
     device: str | None = None,
+    telemetry: PerfTelemetry | None = None,
 ) -> DatasetBundle:
     """Generate one dataset bundle with deterministic per-dataset randomness."""
 
     run_seed = _resolve_run_seed(config, seed)
     requested_device = (device or config.runtime.device or "auto").lower()
     resolved_device = _resolve_device(config, device)
-    return _generate_one_seeded(
-        config,
-        seed=run_seed,
-        requested_device=requested_device,
-        resolved_device=resolved_device,
-    )
+    with activate_perf_telemetry(telemetry):
+        return _generate_one_seeded(
+            config,
+            seed=run_seed,
+            requested_device=requested_device,
+            resolved_device=resolved_device,
+        )
 
 
 def generate_batch(
@@ -729,6 +732,7 @@ def generate_batch(
     num_datasets: int,
     seed: int | None = None,
     device: str | None = None,
+    telemetry: PerfTelemetry | None = None,
 ) -> list[DatasetBundle]:
     """Generate a batch of datasets using deterministic per-dataset child seeds."""
 
@@ -738,6 +742,7 @@ def generate_batch(
             num_datasets=num_datasets,
             seed=seed,
             device=device,
+            telemetry=telemetry,
         )
     )
 
@@ -748,6 +753,7 @@ def generate_batch_iter(
     num_datasets: int,
     seed: int | None = None,
     device: str | None = None,
+    telemetry: PerfTelemetry | None = None,
 ) -> Iterator[DatasetBundle]:
     """Yield datasets lazily using deterministic per-dataset child seeds."""
 
@@ -760,14 +766,15 @@ def generate_batch_iter(
     resolved_device = _resolve_device(config, device)
     run_seed = _resolve_run_seed(config, seed)
     manager = SeedManager(run_seed)
-    for i in range(num_datasets):
-        dataset_seed = manager.child("dataset", i)
-        yield _generate_one_seeded(
-            config,
-            seed=dataset_seed,
-            requested_device=requested_device,
-            resolved_device=resolved_device,
-        )
+    with activate_perf_telemetry(telemetry):
+        for i in range(num_datasets):
+            dataset_seed = manager.child("dataset", i)
+            yield _generate_one_seeded(
+                config,
+                seed=dataset_seed,
+                requested_device=requested_device,
+                resolved_device=resolved_device,
+            )
 
 
 def _annotate_fixed_layout_metadata(bundle: DatasetBundle, *, plan: FixedLayoutPlan) -> None:
@@ -889,6 +896,7 @@ def generate_batch_fixed_layout_iter(
     plan: FixedLayoutPlan,
     num_datasets: int,
     seed: int | None = None,
+    telemetry: PerfTelemetry | None = None,
 ) -> Iterator[DatasetBundle]:
     """Yield datasets that share one pre-sampled fixed layout and split shape."""
 
@@ -901,28 +909,29 @@ def generate_batch_fixed_layout_iter(
     run_seed = _resolve_run_seed(config, seed)
     manager = SeedManager(run_seed)
     expected_schema: tuple[int, tuple[str, ...], tuple[int, ...]] | None = None
-    for i in range(num_datasets):
-        dataset_seed = manager.child("dataset", i)
-        bundle = _generate_one_with_resolved_layout(
-            config,
-            seed=dataset_seed,
-            requested_device=plan.requested_device,
-            resolved_device=validated_resolved_device,
-            n_train=int(plan.n_train),
-            n_test=int(plan.n_test),
-            layout=plan.layout,
-            preserve_feature_schema=True,
-        )
-        _annotate_fixed_layout_metadata(bundle, plan=plan)
-        schema = _extract_emitted_schema_signature(bundle)
-        if expected_schema is None:
-            expected_schema = schema
-        elif schema != expected_schema:
-            raise ValueError(
-                "Fixed-layout schema mismatch: emitted dataset does not match "
-                "the first fixed-layout bundle schema."
+    with activate_perf_telemetry(telemetry):
+        for i in range(num_datasets):
+            dataset_seed = manager.child("dataset", i)
+            bundle = _generate_one_with_resolved_layout(
+                config,
+                seed=dataset_seed,
+                requested_device=plan.requested_device,
+                resolved_device=validated_resolved_device,
+                n_train=int(plan.n_train),
+                n_test=int(plan.n_test),
+                layout=plan.layout,
+                preserve_feature_schema=True,
             )
-        yield bundle
+            _annotate_fixed_layout_metadata(bundle, plan=plan)
+            schema = _extract_emitted_schema_signature(bundle)
+            if expected_schema is None:
+                expected_schema = schema
+            elif schema != expected_schema:
+                raise ValueError(
+                    "Fixed-layout schema mismatch: emitted dataset does not match "
+                    "the first fixed-layout bundle schema."
+                )
+            yield bundle
 
 
 def generate_batch_fixed_layout(
@@ -931,6 +940,7 @@ def generate_batch_fixed_layout(
     plan: FixedLayoutPlan,
     num_datasets: int,
     seed: int | None = None,
+    telemetry: PerfTelemetry | None = None,
 ) -> list[DatasetBundle]:
     """Generate a materialized fixed-layout batch using a reusable plan."""
 
@@ -940,5 +950,6 @@ def generate_batch_fixed_layout(
             plan=plan,
             num_datasets=num_datasets,
             seed=seed,
+            telemetry=telemetry,
         )
     )

--- a/src/cauchy_generator/io/parquet_writer.py
+++ b/src/cauchy_generator/io/parquet_writer.py
@@ -24,6 +24,7 @@ from cauchy_generator.io.lineage_schema import (
     validate_lineage_payload,
 )
 from cauchy_generator.math_utils import sanitize_json as _sanitize_json, to_numpy as _to_numpy
+from cauchy_generator.telemetry import PerfTelemetry
 from cauchy_generator.types import DatasetBundle
 
 try:
@@ -240,6 +241,7 @@ def _persist_lineage_artifact_for_dataset(
     shard_id: int,
     shard_dir: Path,
     lineage_states: dict[int, _ShardLineageState],
+    telemetry: PerfTelemetry | None = None,
 ) -> dict[str, Any]:
     """Convert dense lineage payload to compact shard artifact pointers for one dataset."""
 
@@ -247,7 +249,11 @@ def _persist_lineage_artifact_for_dataset(
     if not isinstance(lineage_raw, Mapping):
         return metadata
     lineage = cast(Mapping[str, Any], lineage_raw)
-    validate_lineage_payload(lineage)
+    if telemetry is not None:
+        with telemetry.timer("lineage.validate_dense"):
+            validate_lineage_payload(lineage)
+    else:
+        validate_lineage_payload(lineage)
 
     schema_version = cast(str, lineage["schema_version"])
     if schema_version != LINEAGE_SCHEMA_VERSION_DENSE:
@@ -255,7 +261,11 @@ def _persist_lineage_artifact_for_dataset(
 
     graph = cast(Mapping[str, Any], lineage["graph"])
     adjacency_raw = graph["adjacency"]
-    n_nodes, edge_count, packed = pack_upper_triangle_adjacency(adjacency_raw)
+    if telemetry is not None:
+        with telemetry.timer("lineage.pack_adjacency"):
+            n_nodes, edge_count, packed = pack_upper_triangle_adjacency(adjacency_raw)
+    else:
+        n_nodes, edge_count, packed = pack_upper_triangle_adjacency(adjacency_raw)
     bit_length = upper_triangle_bit_length(n_nodes)
 
     state = _lineage_state_for_shard(
@@ -267,7 +277,12 @@ def _persist_lineage_artifact_for_dataset(
     state.byte_offset += len(packed)
 
     blob_file = _ensure_shard_blob_open(state)
-    blob_file.write(packed)
+    if telemetry is not None:
+        with telemetry.timer("lineage.blob_write"):
+            blob_file.write(packed)
+        telemetry.increment("lineage.adjacency_bytes_written", float(len(packed)))
+    else:
+        blob_file.write(packed)
     checksum = sha256_hex(packed)
 
     blob_path = str(Path("lineage") / state.blob_path.name)
@@ -283,8 +298,14 @@ def _persist_lineage_artifact_for_dataset(
         index_path=index_path,
         n_nodes=n_nodes,
     )
-    validate_lineage_payload(compact_lineage)
+    if telemetry is not None:
+        with telemetry.timer("lineage.validate_compact"):
+            validate_lineage_payload(compact_lineage)
+    else:
+        validate_lineage_payload(compact_lineage)
     metadata["lineage"] = compact_lineage
+    if telemetry is not None:
+        telemetry.increment("lineage.datasets_with_lineage", 1.0)
 
     state.records.append(
         {
@@ -299,7 +320,11 @@ def _persist_lineage_artifact_for_dataset(
     return metadata
 
 
-def _write_shard_lineage_indexes(lineage_states: Mapping[int, _ShardLineageState]) -> None:
+def _write_shard_lineage_indexes(
+    lineage_states: Mapping[int, _ShardLineageState],
+    *,
+    telemetry: PerfTelemetry | None = None,
+) -> None:
     """Write shard-level lineage index files after all datasets are persisted."""
 
     for state in lineage_states.values():
@@ -311,20 +336,33 @@ def _write_shard_lineage_indexes(lineage_states: Mapping[int, _ShardLineageState
             "encoding": LINEAGE_ADJACENCY_ENCODING,
             "records": state.records,
         }
-        with state.index_path.open("w", encoding="utf-8") as f:
-            json.dump(
-                _sanitize_json(payload),
-                f,
-                indent=2,
-                sort_keys=True,
-                allow_nan=False,
-            )
+        if telemetry is not None:
+            with telemetry.timer("lineage.index_write"):
+                with state.index_path.open("w", encoding="utf-8") as f:
+                    json.dump(
+                        _sanitize_json(payload),
+                        f,
+                        indent=2,
+                        sort_keys=True,
+                        allow_nan=False,
+                    )
+            telemetry.increment("lineage.index_records_written", float(len(state.records)))
+        else:
+            with state.index_path.open("w", encoding="utf-8") as f:
+                json.dump(
+                    _sanitize_json(payload),
+                    f,
+                    indent=2,
+                    sort_keys=True,
+                    allow_nan=False,
+                )
 
 
 def _finalize_lineage_states(
     lineage_states: Mapping[int, _ShardLineageState],
     *,
     strict_index_write: bool,
+    telemetry: PerfTelemetry | None = None,
 ) -> None:
     """Close handles and flush lineage indexes.
 
@@ -334,15 +372,21 @@ def _finalize_lineage_states(
 
     _close_shard_lineage_files(lineage_states)
     if strict_index_write:
-        _write_shard_lineage_indexes(lineage_states)
+        _write_shard_lineage_indexes(lineage_states, telemetry=telemetry)
         return
     try:
-        _write_shard_lineage_indexes(lineage_states)
+        _write_shard_lineage_indexes(lineage_states, telemetry=telemetry)
     except Exception:
         return
 
 
-def _build_split_table(*, dataset_index: int, x: np.ndarray, y: np.ndarray) -> Any:
+def _build_split_table(
+    *,
+    dataset_index: int,
+    x: np.ndarray,
+    y: np.ndarray,
+    telemetry: PerfTelemetry | None = None,
+) -> Any:
     """Build packed row-wise table for one split of one dataset."""
 
     if pa is None:
@@ -360,6 +404,32 @@ def _build_split_table(*, dataset_index: int, x: np.ndarray, y: np.ndarray) -> A
         raise ValueError(
             f"Mismatched split sizes: features rows={n_rows} targets rows={y.shape[0]}."
         )
+
+    if telemetry is not None:
+        telemetry.increment("io.split_rows_total", float(n_rows))
+        telemetry.increment("io.split_features_total", float(n_features))
+        with telemetry.timer("io.build_split_table"):
+            x_item_type = pa.float64() if x.dtype == np.float64 else pa.float32()
+            x_contig = np.ascontiguousarray(x)
+            y_contig = np.ascontiguousarray(y)
+
+            x_values = pa.array(x_contig.reshape(-1), type=x_item_type)
+            if n_features > 0:
+                offsets_np = np.arange(0, (n_rows + 1) * n_features, n_features, dtype=np.int64)
+            else:
+                offsets_np = np.zeros(n_rows + 1, dtype=np.int64)
+            x_column = pa.ListArray.from_arrays(
+                pa.array(offsets_np),
+                x_values,
+                type=pa.list_(x_item_type),
+            )
+            data = {
+                "dataset_index": pa.array(np.full(n_rows, dataset_index, dtype=np.int64)),
+                "row_index": pa.array(np.arange(n_rows, dtype=np.int64)),
+                "x": x_column,
+                "y": pa.array(y_contig),
+            }
+            return pa.table(data)
 
     x_item_type = pa.float64() if x.dtype == np.float64 else pa.float32()
     x_contig = np.ascontiguousarray(x)
@@ -422,10 +492,11 @@ def _write_packed_split(
     x: np.ndarray,
     y: np.ndarray,
     compression: str,
+    telemetry: PerfTelemetry | None = None,
 ) -> None:
     """Append one dataset split into shard-level packed parquet."""
 
-    table = _build_split_table(dataset_index=dataset_index, x=x, y=y)
+    table = _build_split_table(dataset_index=dataset_index, x=x, y=y, telemetry=telemetry)
     writer = _ensure_split_writer(
         state=state,
         split=split,
@@ -441,7 +512,12 @@ def _write_packed_split(
             f"(dataset_index={dataset_index}). "
             "Mixed feature/target dtypes within one shard are not supported."
         )
-    writer.write_table(table)
+    if telemetry is not None:
+        with telemetry.timer("io.parquet_write_table"):
+            writer.write_table(table)
+        telemetry.increment(f"io.split_count.{split}", 1.0)
+    else:
+        writer.write_table(table)
 
 
 def _write_metadata_record(
@@ -453,26 +529,47 @@ def _write_metadata_record(
     n_train: int,
     n_test: int,
     n_features: int,
+    telemetry: PerfTelemetry | None = None,
 ) -> None:
     """Append one dataset metadata record to shard metadata stream."""
 
     metadata_file = _ensure_metadata_file_open(state)
-    payload = {
-        "dataset_index": int(dataset_index),
-        "n_train": int(n_train),
-        "n_test": int(n_test),
-        "n_features": int(n_features),
-        "feature_types": list(feature_types),
-        "metadata": dict(metadata),
-    }
-    metadata_file.write(
-        json.dumps(
-            _sanitize_json(payload),
-            sort_keys=True,
-            allow_nan=False,
+    if telemetry is not None:
+        with telemetry.timer("io.metadata_json_write"):
+            payload = {
+                "dataset_index": int(dataset_index),
+                "n_train": int(n_train),
+                "n_test": int(n_test),
+                "n_features": int(n_features),
+                "feature_types": list(feature_types),
+                "metadata": dict(metadata),
+            }
+            metadata_file.write(
+                json.dumps(
+                    _sanitize_json(payload),
+                    sort_keys=True,
+                    allow_nan=False,
+                )
+            )
+            metadata_file.write("\n")
+        telemetry.increment("io.metadata_records_written", 1.0)
+    else:
+        payload = {
+            "dataset_index": int(dataset_index),
+            "n_train": int(n_train),
+            "n_test": int(n_test),
+            "n_features": int(n_features),
+            "feature_types": list(feature_types),
+            "metadata": dict(metadata),
+        }
+        metadata_file.write(
+            json.dumps(
+                _sanitize_json(payload),
+                sort_keys=True,
+                allow_nan=False,
+            )
         )
-    )
-    metadata_file.write("\n")
+        metadata_file.write("\n")
 
 
 def _write_bundle_to_shard(
@@ -484,6 +581,7 @@ def _write_bundle_to_shard(
     compression: str,
     shard_states: dict[int, _PackedShardState],
     lineage_states: dict[int, _ShardLineageState],
+    telemetry: PerfTelemetry | None = None,
 ) -> None:
     """Write one dataset bundle into packed shard artifacts."""
 
@@ -494,10 +592,18 @@ def _write_bundle_to_shard(
         shard_states=shard_states,
     )
 
-    x_train = _to_numpy(bundle.X_train)
-    y_train = _to_numpy(bundle.y_train)
-    x_test = _to_numpy(bundle.X_test)
-    y_test = _to_numpy(bundle.y_test)
+    if telemetry is not None:
+        with telemetry.timer("io.to_numpy"):
+            x_train = _to_numpy(bundle.X_train)
+            y_train = _to_numpy(bundle.y_train)
+            x_test = _to_numpy(bundle.X_test)
+            y_test = _to_numpy(bundle.y_test)
+        telemetry.increment("io.datasets_written", 1.0)
+    else:
+        x_train = _to_numpy(bundle.X_train)
+        y_train = _to_numpy(bundle.y_train)
+        x_test = _to_numpy(bundle.X_test)
+        y_test = _to_numpy(bundle.y_test)
 
     _write_packed_split(
         state=shard_state,
@@ -506,6 +612,7 @@ def _write_bundle_to_shard(
         x=x_train,
         y=y_train,
         compression=compression,
+        telemetry=telemetry,
     )
     _write_packed_split(
         state=shard_state,
@@ -514,6 +621,7 @@ def _write_bundle_to_shard(
         x=x_test,
         y=y_test,
         compression=compression,
+        telemetry=telemetry,
     )
 
     metadata = deepcopy(bundle.metadata)
@@ -523,6 +631,7 @@ def _write_bundle_to_shard(
         shard_id=shard_id,
         shard_dir=shard_state.shard_dir,
         lineage_states=lineage_states,
+        telemetry=telemetry,
     )
     _write_metadata_record(
         state=shard_state,
@@ -532,6 +641,7 @@ def _write_bundle_to_shard(
         n_train=int(x_train.shape[0]),
         n_test=int(x_test.shape[0]),
         n_features=int(x_train.shape[1]),
+        telemetry=telemetry,
     )
 
 
@@ -541,6 +651,7 @@ def write_packed_parquet_shards_stream(
     *,
     shard_size: int = 128,
     compression: str = "zstd",
+    telemetry: PerfTelemetry | None = None,
 ) -> int:
     """Write bundles into packed shard outputs and return dataset count."""
 
@@ -572,10 +683,11 @@ def write_packed_parquet_shards_stream(
                 compression=compression,
                 shard_states=shard_states,
                 lineage_states=lineage_states,
+                telemetry=telemetry,
             )
             written = idx + 1
         success = True
         return written
     finally:
         _close_packed_shard_files(shard_states)
-        _finalize_lineage_states(lineage_states, strict_index_write=success)
+        _finalize_lineage_states(lineage_states, strict_index_write=success, telemetry=telemetry)

--- a/src/cauchy_generator/sampling/noise.py
+++ b/src/cauchy_generator/sampling/noise.py
@@ -6,10 +6,12 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 import math
 import operator
+import time
 
 import torch
 
 from cauchy_generator.math_utils import normalize_positive_weights
+from cauchy_generator.telemetry import PerfTelemetry, get_active_perf_telemetry
 from cauchy_generator.config import (
     NOISE_FAMILY_GAUSSIAN,
     NOISE_FAMILY_LAPLACE,
@@ -308,30 +310,51 @@ def sample_noise_from_spec(
     device: str,
     noise_spec: NoiseSamplingSpec | None = None,
     scale_multiplier: float = 1.0,
+    telemetry: PerfTelemetry | None = None,
+    tag: str | None = None,
 ) -> torch.Tensor:
     """Sample noise using an optional runtime selection spec."""
+
+    resolved_telemetry = telemetry if telemetry is not None else get_active_perf_telemetry()
+    family = noise_spec.family if noise_spec is not None else NOISE_FAMILY_LEGACY
+
+    start = 0.0
+    if resolved_telemetry is not None and resolved_telemetry.enabled:
+        start = time.perf_counter()
 
     parsed_multiplier = _validate_positive_finite(
         "scale_multiplier", scale_multiplier, lower_bound=0.0
     )
     if noise_spec is None:
-        return sample_noise(
+        samples = sample_noise(
             shape,
             generator=generator,
             device=device,
             family=NOISE_FAMILY_LEGACY,
             scale=parsed_multiplier,
         )
+    else:
+        samples = sample_noise(
+            shape,
+            generator=generator,
+            device=device,
+            family=noise_spec.family,
+            scale=float(noise_spec.scale) * float(parsed_multiplier),
+            student_t_df=float(noise_spec.student_t_df),
+            mixture_weights=noise_spec.mixture_weights,
+        )
 
-    return sample_noise(
-        shape,
-        generator=generator,
-        device=device,
-        family=noise_spec.family,
-        scale=float(noise_spec.scale) * float(parsed_multiplier),
-        student_t_df=float(noise_spec.student_t_df),
-        mixture_weights=noise_spec.mixture_weights,
-    )
+    if resolved_telemetry is not None and resolved_telemetry.enabled:
+        elapsed = time.perf_counter() - start
+        resolved_telemetry.add_time("noise.sample_total", elapsed)
+        resolved_telemetry.add_time(f"noise.sample_family.{family}", elapsed)
+        resolved_telemetry.increment("noise.calls_total", 1.0)
+        resolved_telemetry.increment(f"noise.calls_family.{family}", 1.0)
+        resolved_telemetry.increment("noise.numel_total", float(samples.numel()))
+        if tag:
+            resolved_telemetry.increment(f"noise.calls_tag.{tag}", 1.0)
+
+    return samples
 
 
 __all__ = [

--- a/src/cauchy_generator/telemetry/__init__.py
+++ b/src/cauchy_generator/telemetry/__init__.py
@@ -1,0 +1,13 @@
+"""Runtime performance telemetry helpers."""
+
+from .perf import (
+    PerfTelemetry,
+    activate_perf_telemetry,
+    get_active_perf_telemetry,
+)
+
+__all__ = [
+    "PerfTelemetry",
+    "activate_perf_telemetry",
+    "get_active_perf_telemetry",
+]

--- a/src/cauchy_generator/telemetry/perf.py
+++ b/src/cauchy_generator/telemetry/perf.py
@@ -1,0 +1,90 @@
+"""Low-overhead runtime performance telemetry collection."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+import contextvars
+from dataclasses import dataclass, field
+import math
+import time
+from typing import Any
+
+_ACTIVE_PERF_TELEMETRY: contextvars.ContextVar[PerfTelemetry | None] = contextvars.ContextVar(
+    "active_perf_telemetry",
+    default=None,
+)
+
+
+@dataclass(slots=True)
+class PerfTelemetry:
+    """Collect run-level timers and counters for performance diagnostics."""
+
+    enabled: bool = True
+    timers_seconds: dict[str, float] = field(default_factory=dict)
+    counters: dict[str, float] = field(default_factory=dict)
+
+    def add_time(self, key: str, seconds: float) -> None:
+        """Accumulate one timer duration in seconds."""
+
+        if not self.enabled:
+            return
+        seconds_value = float(seconds)
+        if not math.isfinite(seconds_value) or seconds_value < 0.0:
+            return
+        self.timers_seconds[key] = float(self.timers_seconds.get(key, 0.0)) + seconds_value
+
+    def increment(self, key: str, value: float = 1.0) -> None:
+        """Accumulate one numeric counter."""
+
+        if not self.enabled:
+            return
+        increment_value = float(value)
+        if not math.isfinite(increment_value):
+            return
+        self.counters[key] = float(self.counters.get(key, 0.0)) + increment_value
+
+    @contextmanager
+    def timer(self, key: str) -> Iterator[None]:
+        """Context manager for recording one timed section."""
+
+        if not self.enabled:
+            yield
+            return
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            self.add_time(key, time.perf_counter() - start)
+
+    def snapshot(self) -> dict[str, Any]:
+        """Build JSON-safe telemetry payload."""
+
+        if not self.enabled:
+            return {"enabled": False, "timers_ms": {}, "counters": {}}
+        timers_ms = {
+            key: float(value * 1000.0)
+            for key, value in sorted(self.timers_seconds.items(), key=lambda item: item[0])
+        }
+        counters = {
+            key: float(value)
+            for key, value in sorted(self.counters.items(), key=lambda item: item[0])
+        }
+        return {"enabled": True, "timers_ms": timers_ms, "counters": counters}
+
+
+def get_active_perf_telemetry() -> PerfTelemetry | None:
+    """Return active performance telemetry context, when set."""
+
+    return _ACTIVE_PERF_TELEMETRY.get()
+
+
+@contextmanager
+def activate_perf_telemetry(telemetry: PerfTelemetry | None) -> Iterator[None]:
+    """Temporarily set active performance telemetry for nested calls."""
+
+    token = _ACTIVE_PERF_TELEMETRY.set(telemetry)
+    try:
+        yield
+    finally:
+        _ACTIVE_PERF_TELEMETRY.reset(token)

--- a/tests/test_benchmark_suite.py
+++ b/tests/test_benchmark_suite.py
@@ -93,9 +93,14 @@ def test_run_benchmark_suite_smoke_single_profile() -> None:
     assert result["profile_key"] == "cpu_test"
     assert result["datasets_per_minute"] > 0
     assert result["latency_p95_ms"] >= 0
+    perf = result["performance_telemetry"]
+    assert perf["enabled"] is True
+    assert "noise.calls_total" in perf["counters"]
     lineage_guardrails = result["lineage_guardrails"]
     assert lineage_guardrails["enabled"] is True
     assert lineage_guardrails["status"] in {"pass", "warn", "fail"}
+    assert "performance_telemetry_baseline" in lineage_guardrails
+    assert "performance_telemetry_with_lineage" in lineage_guardrails
 
 
 def test_run_benchmark_suite_missingness_guardrails_emit_metrics() -> None:
@@ -144,9 +149,11 @@ def test_run_benchmark_suite_missingness_runtime_guardrail_updates_regression_st
         warmup_datasets: int = 10,
         device: str | None = None,
         on_bundle=None,
+        telemetry=None,
     ):
         _ = warmup_datasets
         _ = device
+        _ = telemetry
         missing_enabled = float(config.dataset.missing_rate) > 0.0
         calls.append(
             {
@@ -273,9 +280,11 @@ def test_run_benchmark_suite_shift_runtime_guardrail_updates_regression_status(
         warmup_datasets: int = 10,
         device: str | None = None,
         on_bundle=None,
+        telemetry=None,
     ):
         _ = warmup_datasets
         _ = device
+        _ = telemetry
         shift_enabled = bool(config.shift.enabled)
         calls.append(
             {
@@ -384,9 +393,11 @@ def test_run_benchmark_suite_shift_directional_guardrail_failure_updates_status(
         warmup_datasets: int = 10,
         device: str | None = None,
         on_bundle=None,
+        telemetry=None,
     ):
         _ = warmup_datasets
         _ = device
+        _ = telemetry
         shift_enabled = bool(config.shift.enabled)
         dpm = 100.0
         dps = dpm / 60.0
@@ -517,9 +528,11 @@ def test_run_benchmark_suite_noise_runtime_guardrail_updates_regression_status(
         warmup_datasets: int = 10,
         device: str | None = None,
         on_bundle=None,
+        telemetry=None,
     ):
         _ = warmup_datasets
         _ = device
+        _ = telemetry
         nonlegacy_noise = str(config.noise.family) != "legacy"
         dpm = 70.0 if nonlegacy_noise else 100.0
         dps = dpm / 60.0
@@ -619,9 +632,11 @@ def test_run_benchmark_suite_noise_metadata_coverage_failure_updates_status(
         warmup_datasets: int = 10,
         device: str | None = None,
         on_bundle=None,
+        telemetry=None,
     ):
         _ = warmup_datasets
         _ = device
+        _ = telemetry
         dpm = 100.0
         dps = dpm / 60.0
         elapsed = (float(num_datasets) / dps) if dps > 0 else 0.0
@@ -819,9 +834,11 @@ def test_collect_lineage_guardrails_uses_median_of_three_trials_with_runtime_gat
         num_datasets: int,
         seed: int | None = None,
         device: str | None = None,
+        telemetry=None,
     ):
         _ = seed
         _ = device
+        _ = telemetry
         for i in range(num_datasets):
             yield DatasetBundle(
                 X_train=np.zeros((3, 4), dtype=np.float32),
@@ -843,8 +860,10 @@ def test_collect_lineage_guardrails_uses_median_of_three_trials_with_runtime_gat
         *,
         config: GeneratorConfig,
         num_bundles: int,
+        telemetry=None,
     ) -> float:
         _ = config
+        _ = telemetry
         assert not isinstance(_bundles, list)
         assert num_bundles > 0
         return float(next(trial_values))
@@ -895,9 +914,11 @@ def test_collect_lineage_guardrails_emits_runtime_issue_when_sample_is_sufficien
         num_datasets: int,
         seed: int | None = None,
         device: str | None = None,
+        telemetry=None,
     ):
         _ = seed
         _ = device
+        _ = telemetry
         for i in range(num_datasets):
             yield DatasetBundle(
                 X_train=np.zeros((3, 4), dtype=np.float32),
@@ -919,8 +940,10 @@ def test_collect_lineage_guardrails_emits_runtime_issue_when_sample_is_sufficien
         *,
         config: GeneratorConfig,
         num_bundles: int,
+        telemetry=None,
     ) -> float:
         _ = config
+        _ = telemetry
         assert not isinstance(_bundles, list)
         assert num_bundles > 0
         return float(next(trial_values))
@@ -965,9 +988,11 @@ def test_collect_lineage_guardrails_reports_unavailable_for_non_runtime_persiste
         num_datasets: int,
         seed: int | None = None,
         device: str | None = None,
+        telemetry=None,
     ):
         _ = seed
         _ = device
+        _ = telemetry
         for i in range(num_datasets):
             yield DatasetBundle(
                 X_train=np.zeros((3, 4), dtype=np.float32),
@@ -989,12 +1014,16 @@ def test_collect_lineage_guardrails_reports_unavailable_for_non_runtime_persiste
         num_bundles: int,
         config: GeneratorConfig,
         trials: int,
+        baseline_telemetry=None,
+        current_telemetry=None,
     ) -> tuple[list[float], list[float]]:
         _ = baseline_stage_dir
         _ = current_stage_dir
         _ = num_bundles
         _ = config
         _ = trials
+        _ = baseline_telemetry
+        _ = current_telemetry
         raise ValueError("codec unavailable")
 
     monkeypatch.setattr(
@@ -1052,8 +1081,10 @@ def test_measure_lineage_persistence_trials_replays_staged_bundles_without_gener
         *,
         config: GeneratorConfig,
         num_bundles: int,
+        telemetry=None,
     ) -> float:
         _ = config
+        _ = telemetry
         seen = sum(1 for _ in bundles)
         call_counts.append(seen)
         assert num_bundles == 2
@@ -1115,7 +1146,9 @@ def test_collect_reproducibility_uses_streaming_generation(
         num_datasets: int,
         seed: int | None = None,
         device: str | None = None,
+        telemetry=None,
     ):
+        _ = telemetry
         calls.append((num_datasets, int(seed or 0), device))
         for i in range(num_datasets):
             yield _bundle(int(seed or 0) + i)

--- a/tests/test_benchmark_throughput.py
+++ b/tests/test_benchmark_throughput.py
@@ -16,7 +16,9 @@ def test_run_throughput_benchmark_uses_streaming_generation(
         num_datasets: int,
         seed: int | None = None,
         device: str | None = None,
+        telemetry=None,
     ):
+        _ = telemetry
         calls.append((num_datasets, int(seed or 0), device))
         for _ in range(num_datasets):
             yield None
@@ -55,9 +57,11 @@ def test_run_throughput_benchmark_updates_callback_on_measured_generation(
         num_datasets: int,
         seed: int | None = None,
         device: str | None = None,
+        telemetry=None,
     ):
         _ = seed
         _ = device
+        _ = telemetry
         for idx in range(num_datasets):
             yield idx
 

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 import yaml
 
@@ -82,10 +84,12 @@ def test_generate_cli_uses_default_config_without_legacy_overrides(
         num_datasets: int,
         seed: int | None = None,
         device: str | None = None,
+        telemetry=None,
     ):
         _ = config
         _ = seed
         _ = device
+        _ = telemetry
         _ = num_datasets
         captured["called"] = True
         yield object()
@@ -123,12 +127,14 @@ def test_generate_cli_many_class_preset_end_to_end_no_write(
         num_datasets: int,
         seed: int | None = None,
         device: str | None = None,
+        telemetry=None,
     ):
         for bundle in original_generate_batch_iter(
             config,
             num_datasets=num_datasets,
             seed=seed,
             device=device,
+            telemetry=telemetry,
         ):
             captured_metadata.append(bundle.metadata)
             yield bundle
@@ -189,12 +195,14 @@ def test_generate_cli_shift_presets_emit_shift_metadata_no_write(
         num_datasets: int,
         seed: int | None = None,
         device: str | None = None,
+        telemetry=None,
     ):
         for bundle in original_generate_batch_iter(
             config,
             num_datasets=num_datasets,
             seed=seed,
             device=device,
+            telemetry=telemetry,
         ):
             payload = bundle.metadata["shift"]
             assert isinstance(payload, dict)
@@ -252,12 +260,14 @@ def test_generate_cli_noise_presets_emit_noise_metadata_no_write(
         num_datasets: int,
         seed: int | None = None,
         device: str | None = None,
+        telemetry=None,
     ):
         for bundle in original_generate_batch_iter(
             config,
             num_datasets=num_datasets,
             seed=seed,
             device=device,
+            telemetry=telemetry,
         ):
             payload = bundle.metadata["noise"]
             assert isinstance(payload, dict)
@@ -336,9 +346,11 @@ def test_generate_cli_coverage_tolerates_null_quantiles_and_targets(
         num_datasets: int,
         seed: int | None = None,
         device: str | None = None,
+        telemetry=None,
     ):
         _ = seed
         _ = device
+        _ = telemetry
         for _ in range(num_datasets):
             yield object()
 
@@ -383,9 +395,11 @@ def test_generate_cli_no_write_allows_null_output_dir_when_coverage_disabled(
         num_datasets: int,
         seed: int | None = None,
         device: str | None = None,
+        telemetry=None,
     ):
         _ = seed
         _ = device
+        _ = telemetry
         for _ in range(num_datasets):
             yield object()
 
@@ -418,10 +432,12 @@ def test_generate_cli_enables_diagnostics_flag(
         num_datasets: int,
         seed: int | None = None,
         device: str | None = None,
+        telemetry=None,
     ):
         captured["diagnostics_enabled"] = config.diagnostics.enabled
         _ = seed
         _ = device
+        _ = telemetry
         for _ in range(num_datasets):
             yield object()
 
@@ -459,6 +475,7 @@ def test_generate_cli_applies_missingness_overrides_no_write(
         num_datasets: int,
         seed: int | None = None,
         device: str | None = None,
+        telemetry=None,
     ):
         captured["missing_rate"] = config.dataset.missing_rate
         captured["missing_mechanism"] = config.dataset.missing_mechanism
@@ -467,6 +484,7 @@ def test_generate_cli_applies_missingness_overrides_no_write(
         captured["missing_mnar_logit_scale"] = config.dataset.missing_mnar_logit_scale
         _ = seed
         _ = device
+        _ = telemetry
         for _ in range(num_datasets):
             yield object()
 
@@ -607,3 +625,28 @@ def test_generate_cli_missingness_no_write_end_to_end(tmp_path) -> None:
         ]
     )
     assert code == 0
+
+
+def test_generate_cli_writes_perf_telemetry_json_no_write(tmp_path) -> None:
+    telemetry_path = tmp_path / "perf_telemetry.json"
+    code = main(
+        [
+            "generate",
+            "--config",
+            "configs/default.yaml",
+            "--num-datasets",
+            "1",
+            "--device",
+            "cpu",
+            "--no-hardware-aware",
+            "--no-write",
+            "--telemetry-json",
+            str(telemetry_path),
+        ]
+    )
+    assert code == 0
+    assert telemetry_path.exists()
+    payload = json.loads(telemetry_path.read_text(encoding="utf-8"))
+    perf = payload["performance_telemetry"]
+    assert perf["enabled"] is True
+    assert "noise.calls_total" in perf["counters"]

--- a/tests/test_noise_sampling.py
+++ b/tests/test_noise_sampling.py
@@ -7,6 +7,7 @@ from cauchy_generator.sampling.noise import (
     sample_noise,
     sample_noise_from_spec,
 )
+from cauchy_generator.telemetry import PerfTelemetry
 from conftest import make_generator as _make_generator
 import cauchy_generator.sampling.noise as noise_mod
 
@@ -273,3 +274,25 @@ def test_sample_noise_mixture_student_t_falls_back_when_standard_gamma_is_unavai
     )
     assert samples.shape == (128,)
     assert torch.all(torch.isfinite(samples))
+
+
+def test_sample_noise_from_spec_populates_perf_telemetry() -> None:
+    telemetry = PerfTelemetry(enabled=True)
+    _ = sample_noise_from_spec(
+        (32, 4),
+        generator=_make_generator(123),
+        device="cpu",
+        noise_spec=NoiseSamplingSpec(family="laplace", scale=1.5),
+        telemetry=telemetry,
+        tag="unit_test",
+    )
+    snapshot = telemetry.snapshot()
+    counters = snapshot["counters"]
+    timers = snapshot["timers_ms"]
+
+    assert counters["noise.calls_total"] == pytest.approx(1.0)
+    assert counters["noise.calls_family.laplace"] == pytest.approx(1.0)
+    assert counters["noise.calls_tag.unit_test"] == pytest.approx(1.0)
+    assert counters["noise.numel_total"] == pytest.approx(128.0)
+    assert timers["noise.sample_total"] >= 0.0
+    assert timers["noise.sample_family.laplace"] >= 0.0

--- a/tests/test_parquet_writer.py
+++ b/tests/test_parquet_writer.py
@@ -17,6 +17,7 @@ from cauchy_generator.io.lineage_schema import (
     validate_lineage_payload,
 )
 from cauchy_generator.io.parquet_writer import _sanitize_json, write_packed_parquet_shards_stream
+from cauchy_generator.telemetry import PerfTelemetry
 from cauchy_generator.types import DatasetBundle
 
 
@@ -89,10 +90,13 @@ def _generate_one_with_retries(
     raise AssertionError("unreachable")
 
 
-def _stub_write_packed_split(*, state, split, dataset_index, x, y, compression) -> None:
+def _stub_write_packed_split(
+    *, state, split, dataset_index, x, y, compression, telemetry=None
+) -> None:
     _ = x
     _ = y
     _ = compression
+    _ = telemetry
     split_path = state.train_path if split == "train" else state.test_path
     with split_path.open("a", encoding="utf-8") as f:
         f.write(f"{dataset_index}\n")
@@ -150,6 +154,31 @@ def test_write_packed_parquet_shards_stream_writes_real_parquet_tables(tmp_path)
     train_x = train_table.column("x").to_pylist()
     assert len(train_x[0]) == 2
     assert train_x[0] == [1.0, 1.0]
+
+
+def test_write_packed_parquet_shards_stream_populates_perf_telemetry(tmp_path) -> None:
+    pytest.importorskip("pyarrow.parquet")
+    telemetry = PerfTelemetry(enabled=True)
+    written = write_packed_parquet_shards_stream(
+        [_bundle_with_dense_lineage(5)],
+        tmp_path,
+        shard_size=1,
+        compression="zstd",
+        telemetry=telemetry,
+    )
+    assert written == 1
+
+    snapshot = telemetry.snapshot()
+    counters = snapshot["counters"]
+    timers = snapshot["timers_ms"]
+    assert counters["io.datasets_written"] == pytest.approx(1.0)
+    assert counters["io.metadata_records_written"] == pytest.approx(1.0)
+    assert counters["lineage.datasets_with_lineage"] == pytest.approx(1.0)
+    assert counters["lineage.adjacency_bytes_written"] >= 1.0
+    assert timers["io.to_numpy"] >= 0.0
+    assert timers["io.build_split_table"] >= 0.0
+    assert timers["io.parquet_write_table"] >= 0.0
+    assert timers["lineage.pack_adjacency"] >= 0.0
 
 
 def test_write_packed_parquet_shards_stream_preserves_float_targets(tmp_path) -> None:
@@ -410,13 +439,16 @@ def test_write_packed_parquet_shards_stream_closes_lineage_blob_on_failure(
 ) -> None:
     split_calls = {"count": 0}
 
-    def _failing_write_packed_split(*, state, split, dataset_index, x, y, compression):
+    def _failing_write_packed_split(
+        *, state, split, dataset_index, x, y, compression, telemetry=None
+    ):
         _ = state
         _ = split
         _ = dataset_index
         _ = x
         _ = y
         _ = compression
+        _ = telemetry
         split_calls["count"] += 1
         if split_calls["count"] >= 3:
             raise RuntimeError("forced split failure")
@@ -463,13 +495,16 @@ def test_write_packed_parquet_shards_stream_writes_lineage_index_on_failure(
 ) -> None:
     split_calls = {"count": 0}
 
-    def _failing_write_packed_split(*, state, split, dataset_index, x, y, compression):
+    def _failing_write_packed_split(
+        *, state, split, dataset_index, x, y, compression, telemetry=None
+    ):
         _ = state
         _ = split
         _ = dataset_index
         _ = x
         _ = y
         _ = compression
+        _ = telemetry
         split_calls["count"] += 1
         if split_calls["count"] >= 3:
             raise RuntimeError("forced split failure")

--- a/tests/test_perf_telemetry.py
+++ b/tests/test_perf_telemetry.py
@@ -1,0 +1,25 @@
+from cauchy_generator.telemetry import (
+    PerfTelemetry,
+    activate_perf_telemetry,
+    get_active_perf_telemetry,
+)
+
+
+def test_perf_telemetry_collects_counters_and_timers() -> None:
+    telemetry = PerfTelemetry(enabled=True)
+    telemetry.increment("x", 2.0)
+    telemetry.increment("x", 3.0)
+    with telemetry.timer("t"):
+        pass
+    payload = telemetry.snapshot()
+    assert payload["enabled"] is True
+    assert payload["counters"]["x"] == 5.0
+    assert payload["timers_ms"]["t"] >= 0.0
+
+
+def test_activate_perf_telemetry_context_is_scoped() -> None:
+    telemetry = PerfTelemetry(enabled=True)
+    assert get_active_perf_telemetry() is None
+    with activate_perf_telemetry(telemetry):
+        assert get_active_perf_telemetry() is telemetry
+    assert get_active_perf_telemetry() is None


### PR DESCRIPTION
## Summary
- add low-overhead run-level performance telemetry collector (PerfTelemetry)
- instrument noise sampling hot paths (sample_noise_from_spec) with family/call/numel counters and timers
- instrument packed parquet writer phases (to_numpy, split table build, parquet writes, metadata writes, lineage pack/validate/blob/index)
- thread telemetry through generation and benchmark throughput paths
- add cauchy-gen generate --telemetry-json PATH for opt-in generate telemetry output
- include telemetry payloads in benchmark throughput results and lineage guardrail baseline/current measurements

## Why
This provides concrete attribution for the regressions observed around PR #126 (lineage export path changes) and PR #127 (noise sampling indirection overhead), so we can tune based on measured phase-level cost.

## Validation
- uv run pytest -q
- uv run ruff check src tests
- uv run mypy src