### PR TITLE
refactor(core): unify finalization and postprocess flows

### DIFF
--- a/src/dagzoo/core/generation_runtime.py
+++ b/src/dagzoo/core/generation_runtime.py
@@ -30,8 +30,10 @@ from dagzoo.types import DatasetBundle
 class _FixedSchemaFinalizationContext:
     """Cached metadata used by fixed-schema chunk finalization."""
 
-    metadata_template: dict[str, Any]
+    config_payload: dict[str, Any]
+    shift_metadata: dict[str, Any]
     feature_types: list[str]
+    feature_index_map: list[int]
 
 
 def _config_payload_for_metadata(
@@ -89,6 +91,63 @@ def _classification_class_structure(
     }
 
 
+def _make_split_postprocess_generator(seed: int, attempt: int) -> torch.Generator:
+    """Create the shared CPU generator used for splitting and postprocess permutation."""
+
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(_split_permutation_seed(seed, attempt))
+    return generator
+
+
+def _resolve_split_indices(
+    y: torch.Tensor,
+    *,
+    task: str,
+    n_train: int,
+    generator: torch.Generator,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Resolve one dataset's train/test split indices using the shared CPU generator."""
+
+    if task == "classification":
+        return _stratified_split_indices(
+            y.to(device="cpu"),
+            n_train,
+            generator,
+            "cpu",
+        )
+
+    total_rows = int(y.shape[0])
+    order_cpu = torch.randperm(
+        total_rows,
+        generator=generator,
+        device="cpu",
+    )
+    return order_cpu[:n_train], order_cpu[n_train:]
+
+
+def _split_raw_tensors(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    *,
+    train_idx_cpu: torch.Tensor,
+    test_idx_cpu: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Split one raw feature/target pair using CPU indices applied on the tensor device."""
+
+    train_idx = train_idx_cpu.to(device=x.device)
+    test_idx = test_idx_cpu.to(device=x.device)
+    return x[train_idx], y[train_idx], x[test_idx], y[test_idx]
+
+
+def _normalized_filter_metadata(aux_meta: dict[str, Any]) -> dict[str, Any]:
+    """Return the emitted filter metadata shape for one dataset."""
+
+    filter_metadata = aux_meta.get("filter", {})
+    if isinstance(filter_metadata, dict):
+        return dict(filter_metadata)
+    return {"mode": "deferred", "status": "not_run"}
+
+
 def _parent_node_indices(adjacency: torch.Tensor, node_index: int) -> list[int]:
     """Return parent indices for node `node_index` from `adjacency[src, dst]`."""
 
@@ -112,28 +171,152 @@ def _build_fixed_schema_finalization_context(
         n_test=n_test,
     )
     feature_types = [str(feature_type) for feature_type in list(layout.feature_types)]
-    metadata_template = {
+    return _FixedSchemaFinalizationContext(
+        config_payload=config_payload,
+        shift_metadata=_build_shift_metadata(
+            shift_params=shift_params,
+            function_family_mix=config.mechanism.function_family_mix,
+        ),
+        feature_types=feature_types,
+        feature_index_map=[int(i) for i in range(int(layout.n_features))],
+    )
+
+
+def _build_bundle_metadata(
+    layout: LayoutPlan,
+    *,
+    feature_types: list[str],
+    feature_index_map: list[int],
+    config_payload: dict[str, Any],
+    shift_metadata: dict[str, Any],
+    seed: int,
+    attempt: int,
+    attempts_used: int,
+    device: str,
+    requested_device: str,
+    resolved_device: str,
+    device_fallback_reason: str | None,
+    aux_meta: dict[str, Any],
+    noise_runtime_selection: NoiseRuntimeSelection,
+    missingness_summary: dict[str, Any] | None,
+    class_structure: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Build emitted dataset metadata for scalar and batched finalization paths."""
+
+    n_classes = None if class_structure is None else int(class_structure["n_classes_realized"])
+    metadata = {
         "backend": "torch",
+        "device": str(device),
+        "requested_device": str(requested_device),
+        "resolved_device": str(resolved_device),
+        "device_fallback_reason": device_fallback_reason,
         "compute_backend": "torch_appendix_full",
-        "n_features": int(layout.n_features),
+        "n_features": int(len(feature_types)),
         "n_categorical_features": int(sum(1 for t in feature_types if t == "cat")),
+        "n_classes": n_classes,
         "graph_nodes": int(layout.graph_nodes),
         "graph_edges": int(layout.graph_edges),
         "graph_depth_nodes": int(layout.graph_depth_nodes),
         "graph_edge_density": float(layout.graph_edge_density),
-        "lineage": _build_lineage_metadata(
-            layout,
-            feature_index_map=[int(i) for i in range(int(layout.n_features))],
-        ),
-        "shift": _build_shift_metadata(
-            shift_params=shift_params,
-            function_family_mix=config.mechanism.function_family_mix,
-        ),
-        "config": config_payload,
+        "lineage": _build_lineage_metadata(layout, feature_index_map=feature_index_map),
+        "seed": int(seed),
+        "attempt_used": int(attempt),
+        "filter": _normalized_filter_metadata(aux_meta),
+        "shift": copy.deepcopy(shift_metadata),
+        "noise_distribution": _build_noise_distribution_metadata(noise_runtime_selection),
+        "generation_attempts": {
+            "total_attempts": int(attempts_used),
+            "retry_count": int(max(0, attempts_used - 1)),
+            "filter_attempts": 0,
+            "filter_rejections": 0,
+            "filter_rejection_rate": None,
+        },
+        "config": copy.deepcopy(config_payload),
     }
-    return _FixedSchemaFinalizationContext(
-        metadata_template=metadata_template,
+    if missingness_summary is not None:
+        metadata["missingness"] = missingness_summary
+    if class_structure is not None:
+        metadata["class_structure"] = class_structure
+    return metadata
+
+
+def _finalize_processed_bundle(
+    config: GeneratorConfig,
+    layout: LayoutPlan,
+    *,
+    seed: int,
+    attempt: int,
+    attempts_used: int,
+    device: str,
+    requested_device: str,
+    resolved_device: str,
+    device_fallback_reason: str | None,
+    x_train: torch.Tensor,
+    y_train: torch.Tensor,
+    x_test: torch.Tensor,
+    y_test: torch.Tensor,
+    feature_types: list[str],
+    feature_index_map: list[int],
+    aux_meta: dict[str, Any],
+    config_payload: dict[str, Any],
+    shift_metadata: dict[str, Any],
+    noise_runtime_selection: NoiseRuntimeSelection,
+    dtype: torch.dtype,
+) -> DatasetBundle:
+    """Finalize one already-postprocessed dataset into the emitted bundle contract."""
+
+    x_train, x_test, missingness_summary = inject_missingness(
+        x_train,
+        x_test,
+        dataset_cfg=config.dataset,
+        seed=seed,
+        attempt=attempt,
+        device=device,
+    )
+
+    if config.dataset.task == "classification" and not _classification_split_valid(y_train, y_test):
+        raise ValueError("invalid_class_split")
+
+    x_train = x_train.to(device=device, dtype=dtype)
+    x_test = x_test.to(device=device, dtype=dtype)
+    y_dtype = torch.int64 if config.dataset.task == "classification" else dtype
+    y_train = y_train.to(device=device, dtype=y_dtype)
+    y_test = y_test.to(device=device, dtype=y_dtype)
+
+    class_structure: dict[str, Any] | None = None
+    if config.dataset.task == "classification":
+        class_structure = _classification_class_structure(
+            y_train=y_train,
+            y_test=y_test,
+            n_classes_sampled=int(layout.n_classes),
+        )
+
+    metadata = _build_bundle_metadata(
+        layout,
         feature_types=feature_types,
+        feature_index_map=feature_index_map,
+        config_payload=config_payload,
+        shift_metadata=shift_metadata,
+        seed=seed,
+        attempt=attempt,
+        attempts_used=attempts_used,
+        device=device,
+        requested_device=requested_device,
+        resolved_device=resolved_device,
+        device_fallback_reason=device_fallback_reason,
+        aux_meta=aux_meta,
+        noise_runtime_selection=noise_runtime_selection,
+        missingness_summary=missingness_summary,
+        class_structure=class_structure,
+    )
+    return DatasetBundle(
+        X_train=x_train,
+        y_train=y_train,
+        X_test=x_test,
+        y_test=y_test,
+        feature_types=list(feature_types),
+        metadata=metadata,
+        runtime_metrics={},
     )
 
 
@@ -167,33 +350,19 @@ def _finalize_generated_chunk_preserve_schema(
     train_idx_cpu_list: list[torch.Tensor] = []
     test_idx_cpu_list: list[torch.Tensor] = []
     postprocess_generator_states: list[torch.Tensor] = []
-    total_rows = int(x.shape[1])
-
     for batch_index, seed in enumerate(seeds):
-        postprocess_seed = _split_permutation_seed(seed, attempt)
-        split_postprocess_generator = torch.Generator(device="cpu")
-        split_postprocess_generator.manual_seed(postprocess_seed)
-
-        if config.dataset.task == "classification":
-            try:
-                train_idx_cpu, test_idx_cpu = _stratified_split_indices(
-                    y[batch_index].to(device="cpu"),
-                    n_train,
-                    split_postprocess_generator,
-                    "cpu",
-                )
-            except ValueError as exc:
-                if str(exc).startswith("infeasible_stratified_split"):
-                    continue
-                raise
-        else:
-            order_cpu = torch.randperm(
-                total_rows,
+        split_postprocess_generator = _make_split_postprocess_generator(seed, attempt)
+        try:
+            train_idx_cpu, test_idx_cpu = _resolve_split_indices(
+                y[batch_index],
+                task=config.dataset.task,
+                n_train=n_train,
                 generator=split_postprocess_generator,
-                device="cpu",
             )
-            train_idx_cpu = order_cpu[:n_train]
-            test_idx_cpu = order_cpu[n_train:]
+        except ValueError as exc:
+            if str(exc).startswith("infeasible_stratified_split"):
+                continue
+            raise
 
         valid_positions.append(int(batch_index))
         train_idx_cpu_list.append(train_idx_cpu)
@@ -231,86 +400,34 @@ def _finalize_generated_chunk_preserve_schema(
         config.dataset.task,
         postprocess_generator_states=postprocess_generator_states,
     )
-    noise_distribution = _build_noise_distribution_metadata(noise_runtime_selection)
-
     for local_index, batch_index in enumerate(valid_positions):
-        x_train_local = x_train[local_index]
-        x_test_local = x_test[local_index]
-        y_train_local = y_train[local_index]
-        y_test_local = y_test[local_index]
-
-        x_train_local, x_test_local, missingness_summary = inject_missingness(
-            x_train_local,
-            x_test_local,
-            dataset_cfg=config.dataset,
-            seed=seeds[batch_index],
-            attempt=attempt,
-            device=device,
-        )
-
-        if config.dataset.task == "classification" and not _classification_split_valid(
-            y_train_local,
-            y_test_local,
-        ):
-            continue
-
-        x_train_local = x_train_local.to(device=device, dtype=dtype)
-        x_test_local = x_test_local.to(device=device, dtype=dtype)
-        y_dtype = torch.int64 if config.dataset.task == "classification" else dtype
-        y_train_local = y_train_local.to(device=device, dtype=y_dtype)
-        y_test_local = y_test_local.to(device=device, dtype=y_dtype)
-
-        class_structure: dict[str, Any] | None = None
-        n_classes: int | None = None
-        if config.dataset.task == "classification":
-            class_structure = _classification_class_structure(
-                y_train=y_train_local,
-                y_test=y_test_local,
-                n_classes_sampled=int(layout.n_classes),
+        try:
+            results[batch_index] = _finalize_processed_bundle(
+                config,
+                layout,
+                seed=seeds[batch_index],
+                attempt=attempt,
+                attempts_used=attempts_used,
+                device=device,
+                requested_device=requested_device,
+                resolved_device=resolved_device,
+                device_fallback_reason=device_fallback_reason,
+                x_train=x_train[local_index],
+                y_train=y_train[local_index],
+                x_test=x_test[local_index],
+                y_test=y_test[local_index],
+                feature_types=context.feature_types,
+                feature_index_map=context.feature_index_map,
+                aux_meta=aux_meta_batch[batch_index],
+                config_payload=context.config_payload,
+                shift_metadata=context.shift_metadata,
+                noise_runtime_selection=noise_runtime_selection,
+                dtype=dtype,
             )
-            n_classes = int(class_structure["n_classes_realized"])
-
-        filter_metadata = aux_meta_batch[batch_index].get("filter", {})
-        if isinstance(filter_metadata, dict):
-            filter_metadata = dict(filter_metadata)
-        else:
-            filter_metadata = {"mode": "deferred", "status": "not_run"}
-
-        metadata = copy.deepcopy(context.metadata_template)
-        metadata.update(
-            {
-                "device": device,
-                "requested_device": str(requested_device),
-                "resolved_device": str(resolved_device),
-                "device_fallback_reason": device_fallback_reason,
-                "n_classes": n_classes,
-                "seed": int(seeds[batch_index]),
-                "attempt_used": int(attempt),
-                "filter": filter_metadata,
-                "noise_distribution": dict(noise_distribution),
-                "generation_attempts": {
-                    "total_attempts": int(attempts_used),
-                    "retry_count": int(max(0, attempts_used - 1)),
-                    "filter_attempts": 0,
-                    "filter_rejections": 0,
-                    "filter_rejection_rate": None,
-                },
-            }
-        )
-        if missingness_summary is not None:
-            metadata["missingness"] = missingness_summary
-        if class_structure is not None:
-            metadata["class_structure"] = class_structure
-
-        results[batch_index] = DatasetBundle(
-            X_train=x_train_local,
-            y_train=y_train_local,
-            X_test=x_test_local,
-            y_test=y_test_local,
-            feature_types=list(context.feature_types),
-            metadata=metadata,
-            runtime_metrics={},
-        )
+        except ValueError as exc:
+            if str(exc) == "invalid_class_split":
+                continue
+            raise
 
     return results
 
@@ -338,35 +455,25 @@ def _finalize_generated_tensors(
 ) -> DatasetBundle:
     """Finalize one raw `x`/`y` pair into the standard dataset bundle contract."""
 
-    split_postprocess_generator = torch.Generator(device="cpu")
-    split_postprocess_generator.manual_seed(_split_permutation_seed(seed, attempt))
-
-    if config.dataset.task == "classification":
-        try:
-            train_idx_cpu, test_idx_cpu = _stratified_split_indices(
-                y.to(device="cpu"),
-                n_train,
-                split_postprocess_generator,
-                "cpu",
-            )
-        except ValueError as exc:
-            if str(exc).startswith("infeasible_stratified_split"):
-                raise ValueError("invalid_class_split") from exc
-            raise
-        train_idx = train_idx_cpu.to(device=x.device)
-        test_idx = test_idx_cpu.to(device=x.device)
-        x_train_t, x_test_t = x[train_idx], x[test_idx]
-        y_train_t, y_test_t = y[train_idx], y[test_idx]
-    else:
-        order_cpu = torch.randperm(
-            x.shape[0],
+    split_postprocess_generator = _make_split_postprocess_generator(seed, attempt)
+    try:
+        train_idx_cpu, test_idx_cpu = _resolve_split_indices(
+            y,
+            task=config.dataset.task,
+            n_train=n_train,
             generator=split_postprocess_generator,
-            device="cpu",
         )
-        order = order_cpu.to(device=x.device)
-        x, y = x[order], y[order]
-        x_train_t, x_test_t = x[:n_train], x[n_train:]
-        y_train_t, y_test_t = y[:n_train], y[n_train:]
+    except ValueError as exc:
+        if str(exc).startswith("infeasible_stratified_split"):
+            raise ValueError("invalid_class_split") from exc
+        raise
+
+    x_train_t, y_train_t, x_test_t, y_test_t = _split_raw_tensors(
+        x,
+        y,
+        train_idx_cpu=train_idx_cpu,
+        test_idx_cpu=test_idx_cpu,
+    )
 
     x_train, y_train, x_test, y_test, feature_types, feature_index_map = postprocess_dataset(
         x_train_t,
@@ -380,85 +487,34 @@ def _finalize_generated_tensors(
         return_feature_index_map=True,
         preserve_feature_schema=preserve_feature_schema,
     )
-    x_train, x_test, missingness_summary = inject_missingness(
-        x_train,
-        x_test,
-        dataset_cfg=config.dataset,
-        seed=seed,
-        attempt=attempt,
-        device=device,
-    )
-
-    if config.dataset.task == "classification" and not _classification_split_valid(y_train, y_test):
-        raise ValueError("invalid_class_split")
-
-    x_train = x_train.to(device=device, dtype=dtype)
-    x_test = x_test.to(device=device, dtype=dtype)
-    y_dtype = torch.int64 if config.dataset.task == "classification" else dtype
-    y_train = y_train.to(device=device, dtype=y_dtype)
-    y_test = y_test.to(device=device, dtype=y_dtype)
-    class_structure: dict[str, Any] | None = None
-    n_classes: int | None = None
-    if config.dataset.task == "classification":
-        class_structure = _classification_class_structure(
-            y_train=y_train,
-            y_test=y_test,
-            n_classes_sampled=int(layout.n_classes),
-        )
-        n_classes = int(class_structure["n_classes_realized"])
     shift_metadata = _build_shift_metadata(
         shift_params=shift_params,
         function_family_mix=config.mechanism.function_family_mix,
     )
-    filter_metadata = aux_meta.get("filter", {})
-    if isinstance(filter_metadata, dict):
-        filter_metadata = dict(filter_metadata)
-    else:
-        filter_metadata = {"mode": "deferred", "status": "not_run"}
-
-    metadata = {
-        "backend": "torch",
-        "device": device,
-        "requested_device": str(requested_device),
-        "resolved_device": str(resolved_device),
-        "device_fallback_reason": device_fallback_reason,
-        "compute_backend": "torch_appendix_full",
-        "n_features": int(x_train.shape[1]),
-        "n_categorical_features": int(sum(1 for t in feature_types if t == "cat")),
-        "n_classes": n_classes,
-        "graph_nodes": int(layout.graph_nodes),
-        "graph_edges": int(layout.graph_edges),
-        "graph_depth_nodes": int(layout.graph_depth_nodes),
-        "graph_edge_density": float(layout.graph_edge_density),
-        "lineage": _build_lineage_metadata(layout, feature_index_map=feature_index_map),
-        "seed": seed,
-        "attempt_used": attempt,
-        "filter": filter_metadata,
-        "shift": shift_metadata,
-        "noise_distribution": _build_noise_distribution_metadata(noise_runtime_selection),
-        "generation_attempts": {
-            "total_attempts": int(attempts_used),
-            "retry_count": int(max(0, attempts_used - 1)),
-            "filter_attempts": 0,
-            "filter_rejections": 0,
-            "filter_rejection_rate": None,
-        },
-        "config": _config_payload_for_metadata(
-            config,
-            n_train=n_train,
-            n_test=n_test,
-        ),
-    }
-    if missingness_summary is not None:
-        metadata["missingness"] = missingness_summary
-    if class_structure is not None:
-        metadata["class_structure"] = class_structure
-    return DatasetBundle(
-        X_train=x_train,
+    config_payload = _config_payload_for_metadata(
+        config,
+        n_train=n_train,
+        n_test=n_test,
+    )
+    return _finalize_processed_bundle(
+        config,
+        layout,
+        seed=seed,
+        attempt=attempt,
+        attempts_used=attempts_used,
+        device=device,
+        requested_device=requested_device,
+        resolved_device=resolved_device,
+        device_fallback_reason=device_fallback_reason,
+        x_train=x_train,
         y_train=y_train,
-        X_test=x_test,
+        x_test=x_test,
         y_test=y_test,
         feature_types=feature_types,
-        metadata=metadata,
-        runtime_metrics={},
+        feature_index_map=feature_index_map,
+        aux_meta=aux_meta,
+        config_payload=config_payload,
+        shift_metadata=shift_metadata,
+        noise_runtime_selection=noise_runtime_selection,
+        dtype=dtype,
     )

--- a/src/dagzoo/postprocess/postprocess.py
+++ b/src/dagzoo/postprocess/postprocess.py
@@ -28,53 +28,107 @@ def _remove_constant_columns(
     return x[:, keep], kept_types, keep_indices
 
 
-def _clip_and_standardize(x: torch.Tensor, feature_types: list[str]) -> torch.Tensor:
-    """Clip numeric outliers and standardize numeric columns."""
+def _clip_and_standardize_rows(x: torch.Tensor, feature_types: list[str]) -> torch.Tensor:
+    """Clip numeric outliers and standardize numeric columns along the row axis."""
 
     out = x.clone()
     numeric_indices = [i for i, t in enumerate(feature_types) if t != "cat"]
     if not numeric_indices:
         return out
 
-    # Standardize all numeric columns in one batched pass.
     numeric_index = torch.tensor(numeric_indices, device=out.device, dtype=torch.long)
-    numeric = out.index_select(dim=1, index=numeric_index)
+    feature_dim = out.ndim - 1
+    row_dim = out.ndim - 2
+    numeric = out.index_select(dim=feature_dim, index=numeric_index)
     quantiles = torch.quantile(
         numeric.float(),
         torch.tensor([0.01, 0.99], device=numeric.device),
-        dim=0,
+        dim=row_dim,
     )
-    lo = quantiles[0].unsqueeze(0)
-    hi = quantiles[1].unsqueeze(0)
+    lo = quantiles[0].unsqueeze(row_dim)
+    hi = quantiles[1].unsqueeze(row_dim)
     numeric = torch.clamp(numeric, lo, hi)
-    mu = torch.mean(numeric, dim=0, keepdim=True)
-    sd = torch.std(numeric, dim=0, correction=0, keepdim=True).clamp_min(1e-6)
-    out[:, numeric_index] = (numeric - mu) / sd
+    mu = torch.mean(numeric, dim=row_dim, keepdim=True)
+    sd = torch.std(numeric, dim=row_dim, correction=0, keepdim=True).clamp_min(1e-6)
+    out.index_copy_(feature_dim, numeric_index, (numeric - mu) / sd)
     return out
+
+
+def _clip_and_standardize(x: torch.Tensor, feature_types: list[str]) -> torch.Tensor:
+    """Clip numeric outliers and standardize numeric columns."""
+
+    return _clip_and_standardize_rows(x, feature_types)
 
 
 def _clip_and_standardize_batch(x: torch.Tensor, feature_types: list[str]) -> torch.Tensor:
     """Clip numeric outliers and standardize numeric columns for one dataset batch."""
 
-    out = x.clone()
-    numeric_indices = [i for i, t in enumerate(feature_types) if t != "cat"]
-    if not numeric_indices:
-        return out
+    return _clip_and_standardize_rows(x, feature_types)
 
-    numeric_index = torch.tensor(numeric_indices, device=out.device, dtype=torch.long)
-    numeric = out.index_select(dim=2, index=numeric_index)
+
+def _postprocess_feature_splits(
+    x_train: torch.Tensor,
+    x_test: torch.Tensor,
+    feature_types: list[str],
+    *,
+    generator: torch.Generator | None,
+    preserve_feature_schema: bool,
+) -> tuple[torch.Tensor, torch.Tensor, list[str], list[int]]:
+    """Postprocess feature tensors for both scalar and fixed-schema batched flows."""
+
+    row_dim = x_train.ndim - 2
+    x_all = torch.cat([x_train, x_test], dim=row_dim).to(torch.float32)
+    if preserve_feature_schema:
+        feature_types_out = list(feature_types)
+        feature_index_map = [int(i) for i in range(int(x_all.shape[-1]))]
+    else:
+        if x_all.ndim != 2:
+            raise ValueError("Constant-column removal is only supported for unbatched features.")
+        x_all, feature_types_out, feature_index_map = _remove_constant_columns(x_all, feature_types)
+
+    x_all = _clip_and_standardize_rows(x_all, feature_types_out)
+
+    if not preserve_feature_schema:
+        if generator is None:
+            raise ValueError("generator is required when preserve_feature_schema is False.")
+        perm_cpu = torch.randperm(x_all.shape[-1], generator=generator, device="cpu")
+        perm_list = [int(i) for i in perm_cpu.tolist()]
+        perm = perm_cpu.to(device=x_all.device)
+        x_all = x_all.index_select(dim=x_all.ndim - 1, index=perm)
+        feature_types_out = [feature_types_out[i] for i in perm_list]
+        feature_index_map = [feature_index_map[i] for i in perm_list]
+
+    n_train = int(x_train.shape[row_dim])
+    n_test = int(x_test.shape[row_dim])
+    x_train_p = x_all.narrow(row_dim, 0, n_train)
+    x_test_p = x_all.narrow(row_dim, n_train, n_test)
+    return x_train_p, x_test_p, feature_types_out, feature_index_map
+
+
+def _postprocess_regression_targets(
+    y_train: torch.Tensor,
+    y_test: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Clip and standardize regression targets for scalar or batched inputs."""
+
+    row_dim = y_train.ndim - 1
+    y_all = torch.cat([y_train, y_test], dim=row_dim).to(torch.float32)
     quantiles = torch.quantile(
-        numeric.float(),
-        torch.tensor([0.01, 0.99], device=numeric.device),
-        dim=1,
+        y_all.float(),
+        torch.tensor([0.01, 0.99], device=y_all.device),
+        dim=row_dim,
     )
-    lo = quantiles[0].unsqueeze(1)
-    hi = quantiles[1].unsqueeze(1)
-    numeric = torch.clamp(numeric, lo, hi)
-    mu = torch.mean(numeric, dim=1, keepdim=True)
-    sd = torch.std(numeric, dim=1, correction=0, keepdim=True).clamp_min(1e-6)
-    out[:, :, numeric_index] = (numeric - mu) / sd
-    return out
+    lo = quantiles[0].unsqueeze(row_dim)
+    hi = quantiles[1].unsqueeze(row_dim)
+    y_all = torch.clamp(y_all, lo, hi)
+    mu = torch.mean(y_all, dim=row_dim, keepdim=True)
+    sd = torch.std(y_all, dim=row_dim, correction=0, keepdim=True).clamp_min(1e-6)
+    y_all = (y_all - mu) / sd
+    n_train = int(y_train.shape[row_dim])
+    n_test = int(y_test.shape[row_dim])
+    y_train_p = y_all.narrow(row_dim, 0, n_train)
+    y_test_p = y_all.narrow(row_dim, n_train, n_test)
+    return y_train_p, y_test_p
 
 
 def _has_at_least_two_classes(y: torch.Tensor) -> bool:
@@ -82,6 +136,33 @@ def _has_at_least_two_classes(y: torch.Tensor) -> bool:
 
     y_i64 = y.to(torch.int64)
     return bool(torch.min(y_i64) != torch.max(y_i64))
+
+
+def _postprocess_classification_labels(
+    y_train: torch.Tensor,
+    y_test: torch.Tensor,
+    generator: torch.Generator,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Remap classification labels into dense space with deterministic permutation."""
+
+    n_train = int(y_train.shape[0])
+    y_all_original = torch.cat([y_train, y_test], dim=0).to(torch.int64)
+    classes, inverse = torch.unique(y_all_original, sorted=True, return_inverse=True)
+    y_all_original_dense = inverse.to(torch.int64)
+
+    perm_dense_cpu = torch.randperm(classes.numel(), generator=generator, device="cpu")
+    perm_dense = perm_dense_cpu.to(device=inverse.device)
+    y_all_permuted_dense = perm_dense[inverse].to(torch.int64)
+    y_train_candidate = y_all_permuted_dense[:n_train]
+    y_test_candidate = y_all_permuted_dense[n_train:]
+
+    if not _has_at_least_two_classes(y_train_candidate) or not _has_at_least_two_classes(
+        y_test_candidate
+    ):
+        y_all_dense = y_all_original_dense
+    else:
+        y_all_dense = y_all_permuted_dense
+    return y_all_dense[:n_train], y_all_dense[n_train:]
 
 
 @overload
@@ -142,66 +223,28 @@ def postprocess_dataset(
     """
     _ = device
 
-    x_all = torch.cat([x_train, x_test], dim=0).to(torch.float32)
-    if preserve_feature_schema:
-        feature_types = list(feature_types)
-        feature_index_map = [int(i) for i in range(x_all.shape[1])]
-    else:
-        x_all, feature_types, feature_index_map = _remove_constant_columns(x_all, feature_types)
-    x_all = _clip_and_standardize(x_all, feature_types)
-
-    if not preserve_feature_schema:
-        # Keep permutation RNG on CPU while applying it on the feature tensor device.
-        perm_cpu = torch.randperm(x_all.shape[1], generator=generator, device="cpu")
-        perm_list = [int(i) for i in perm_cpu.tolist()]
-        perm = perm_cpu.to(device=x_all.device)
-        x_all = x_all[:, perm]
-        feature_types = [feature_types[i] for i in perm_list]
-        feature_index_map = [feature_index_map[i] for i in perm_list]
-
-    n_train = x_train.shape[0]
-    x_train_p = x_all[:n_train]
-    x_test_p = x_all[n_train:]
+    x_train_p, x_test_p, feature_types, feature_index_map = _postprocess_feature_splits(
+        x_train,
+        x_test,
+        feature_types,
+        generator=generator,
+        preserve_feature_schema=preserve_feature_schema,
+    )
 
     if task == "regression":
-        y_all = torch.cat([y_train, y_test], dim=0).to(torch.float32)
-        q = torch.quantile(y_all.float(), torch.tensor([0.01, 0.99], device=y_all.device))
-        lo, hi = q[0], q[1]
-        y_all = torch.clamp(y_all, lo, hi)
-        mu = torch.mean(y_all)
-        sd = torch.std(y_all, correction=0).clamp_min(1e-6)
-        y_all = (y_all - mu) / sd
+        y_train_p, y_test_p = _postprocess_regression_targets(y_train, y_test)
         if return_feature_index_map:
             return (
                 x_train_p,
-                y_all[:n_train],
+                y_train_p,
                 x_test_p,
-                y_all[n_train:],
+                y_test_p,
                 feature_types,
                 feature_index_map,
             )
-        return x_train_p, y_all[:n_train], x_test_p, y_all[n_train:], feature_types
+        return x_train_p, y_train_p, x_test_p, y_test_p, feature_types
 
-    y_all_original = torch.cat([y_train, y_test], dim=0).to(torch.int64)
-    classes, inverse = torch.unique(y_all_original, sorted=True, return_inverse=True)
-    y_all_original_dense = inverse.to(torch.int64)
-
-    # Apply a class-id permutation directly in dense label space.
-    perm_dense_cpu = torch.randperm(classes.numel(), generator=generator, device="cpu")
-    perm_dense = perm_dense_cpu.to(device=inverse.device)
-    y_all_permuted_dense = perm_dense[inverse].to(torch.int64)
-    y_train_candidate = y_all_permuted_dense[:n_train]
-    y_test_candidate = y_all_permuted_dense[n_train:]
-
-    if not _has_at_least_two_classes(y_train_candidate) or not _has_at_least_two_classes(
-        y_test_candidate
-    ):
-        # Fall back to original labels if permutation collapses effective class diversity.
-        y_all_dense = y_all_original_dense
-    else:
-        y_all_dense = y_all_permuted_dense
-    y_train_p = y_all_dense[:n_train]
-    y_test_p = y_all_dense[n_train:]
+    y_train_p, y_test_p = _postprocess_classification_labels(y_train, y_test, generator)
 
     if return_feature_index_map:
         return x_train_p, y_train_p, x_test_p, y_test_p, feature_types, feature_index_map
@@ -229,53 +272,30 @@ def postprocess_fixed_schema_batch(
             "postprocess_generator_states must align with the leading batch dimension."
         )
 
-    n_train = int(x_train.shape[1])
-    x_all = torch.cat([x_train, x_test], dim=1).to(torch.float32)
-    x_all = _clip_and_standardize_batch(x_all, feature_types)
-    x_train_p = x_all[:, :n_train, :]
-    x_test_p = x_all[:, n_train:, :]
+    x_train_p, x_test_p, _feature_types, _feature_index_map = _postprocess_feature_splits(
+        x_train,
+        x_test,
+        feature_types,
+        generator=None,
+        preserve_feature_schema=True,
+    )
 
     if task == "regression":
-        y_all = torch.cat([y_train, y_test], dim=1).to(torch.float32)
-        quantiles = torch.quantile(
-            y_all.float(),
-            torch.tensor([0.01, 0.99], device=y_all.device),
-            dim=1,
-        )
-        lo = quantiles[0].unsqueeze(1)
-        hi = quantiles[1].unsqueeze(1)
-        y_all = torch.clamp(y_all, lo, hi)
-        mu = torch.mean(y_all, dim=1, keepdim=True)
-        sd = torch.std(y_all, dim=1, correction=0, keepdim=True).clamp_min(1e-6)
-        y_all = (y_all - mu) / sd
-        return x_train_p, y_all[:, :n_train], x_test_p, y_all[:, n_train:]
+        y_train_p, y_test_p = _postprocess_regression_targets(y_train, y_test)
+        return x_train_p, y_train_p, x_test_p, y_test_p
 
     y_train_batches: list[torch.Tensor] = []
     y_test_batches: list[torch.Tensor] = []
     for batch_index, generator_state in enumerate(postprocess_generator_states):
         generator = torch.Generator(device="cpu")
         generator.set_state(generator_state)
-        y_all_original = torch.cat([y_train[batch_index], y_test[batch_index]], dim=0).to(
-            torch.int64
+        y_train_p, y_test_p = _postprocess_classification_labels(
+            y_train[batch_index],
+            y_test[batch_index],
+            generator,
         )
-        classes, inverse = torch.unique(y_all_original, sorted=True, return_inverse=True)
-        y_all_original_dense = inverse.to(torch.int64)
-
-        perm_dense_cpu = torch.randperm(classes.numel(), generator=generator, device="cpu")
-        perm_dense = perm_dense_cpu.to(device=inverse.device)
-        y_all_permuted_dense = perm_dense[inverse].to(torch.int64)
-        y_train_candidate = y_all_permuted_dense[:n_train]
-        y_test_candidate = y_all_permuted_dense[n_train:]
-
-        if not _has_at_least_two_classes(y_train_candidate) or not _has_at_least_two_classes(
-            y_test_candidate
-        ):
-            y_all_dense = y_all_original_dense
-        else:
-            y_all_dense = y_all_permuted_dense
-
-        y_train_batches.append(y_all_dense[:n_train])
-        y_test_batches.append(y_all_dense[n_train:])
+        y_train_batches.append(y_train_p)
+        y_test_batches.append(y_test_p)
 
     return x_train_p, torch.stack(y_train_batches), x_test_p, torch.stack(y_test_batches)
 


### PR DESCRIPTION
## Summary
- unify scalar and fixed-schema batched finalization around shared split, metadata, and bundle-construction helpers
- collapse scalar and batched postprocess logic onto shared feature and target primitives while preserving current behavior
- keep the public dataset artifact and metadata contract unchanged

## Testing
- ./.venv/bin/python -m pytest tests/test_postprocess.py tests/test_generate.py -q
- ./.venv/bin/python -m pytest tests/test_benchmark_throughput.py tests/test_benchmark_suite.py -q
- ./.venv/bin/python -m ruff check src/dagzoo/postprocess/postprocess.py src/dagzoo/core/generation_runtime.py tests/test_postprocess.py tests/test_generate.py
- ./.venv/bin/python -m ruff format --check src/dagzoo/postprocess/postprocess.py src/dagzoo/core/generation_runtime.py tests/test_postprocess.py tests/test_generate.py
- ./.venv/bin/python -m mypy src

Closes #173