### PR TITLE
test(ci): remove vulture exclusions from test helpers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Dead code
         run: >
           uv run vulture src/dagzoo tests
-          --exclude tests/test_benchmark_suite.py,tests/test_github_to_linear.py,tests/test_seed_harness_backlog.py
           --ignore-names __getattr__
       - name: Test with coverage
         run: >

--- a/tests/test_benchmark_suite.py
+++ b/tests/test_benchmark_suite.py
@@ -13,21 +13,31 @@ from dagzoo.config import GeneratorConfig
 from dagzoo.types import DatasetBundle
 
 
+def _set_attrs(target: object, **attrs: object) -> None:
+    for name, value in attrs.items():
+        setattr(target, name, value)
+
+
 def _tiny_cpu_config() -> GeneratorConfig:
     cfg = GeneratorConfig.from_yaml("configs/default.yaml")
-    cfg.dataset.task = "regression"
-    cfg.runtime.device = "cpu"
-    cfg.dataset.n_train = 32
-    cfg.dataset.n_test = 8
-    cfg.dataset.n_features_min = 8
-    cfg.dataset.n_features_max = 8
-    cfg.graph.n_nodes_min = 2
-    cfg.graph.n_nodes_max = 6
-    cfg.benchmark.num_datasets = 2
-    cfg.benchmark.warmup_datasets = 0
-    cfg.benchmark.latency_num_samples = 2
-    cfg.benchmark.reproducibility_num_datasets = 1
-    cfg.benchmark.preset_name = "cpu_test"
+    _set_attrs(
+        cfg.dataset,
+        task="regression",
+        n_train=32,
+        n_test=8,
+        n_features_min=8,
+        n_features_max=8,
+    )
+    _set_attrs(cfg.runtime, device="cpu")
+    _set_attrs(cfg.graph, n_nodes_min=2, n_nodes_max=6)
+    _set_attrs(
+        cfg.benchmark,
+        num_datasets=2,
+        warmup_datasets=0,
+        latency_num_samples=2,
+        reproducibility_num_datasets=1,
+        preset_name="cpu_test",
+    )
     cfg.benchmark.presets["cpu_test"] = {
         "device": "cpu",
         "num_datasets": 2,
@@ -38,26 +48,30 @@ def _tiny_cpu_config() -> GeneratorConfig:
 
 def _tiny_missingness_cpu_config() -> GeneratorConfig:
     cfg = _tiny_cpu_config()
-    cfg.dataset.missing_rate = 0.25
-    cfg.dataset.missing_mechanism = "mcar"  # type: ignore[assignment]
+    _set_attrs(
+        cfg.dataset,
+        missing_rate=0.25,
+        missing_mechanism="mcar",
+    )
     return cfg
 
 
 def _tiny_shift_cpu_config() -> GeneratorConfig:
     cfg = _tiny_cpu_config()
-    cfg.shift.enabled = True
-    cfg.shift.mode = "mixed"
-    cfg.graph.n_nodes_min = 8
-    cfg.graph.n_nodes_max = 12
+    _set_attrs(cfg.shift, enabled=True, mode="mixed")
+    _set_attrs(cfg.graph, n_nodes_min=8, n_nodes_max=12)
     return cfg
 
 
 def _tiny_noise_cpu_config() -> GeneratorConfig:
     cfg = _tiny_cpu_config()
-    cfg.noise.family = "laplace"
-    cfg.noise.base_scale = 1.0
-    cfg.noise.student_t_df = 6.0
-    cfg.noise.mixture_weights = None
+    _set_attrs(
+        cfg.noise,
+        family="laplace",
+        base_scale=1.0,
+        student_t_df=6.0,
+        mixture_weights=None,
+    )
     return cfg
 
 
@@ -117,7 +131,7 @@ def test_run_benchmark_suite_builtin_cpu_uses_canonical_generation_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cfg = _tiny_cpu_config()
-    cfg.benchmark.preset_name = "cpu"
+    _set_attrs(cfg.benchmark, preset_name="cpu")
     cfg.benchmark.presets["cpu"] = {
         "device": "cpu",
         "num_datasets": 2,
@@ -200,7 +214,7 @@ def test_run_benchmark_suite_emits_stage_and_filter_pressure_metrics(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cfg = _tiny_cpu_config()
-    cfg.filter.enabled = True
+    _set_attrs(cfg.filter, enabled=True)
     spec = PresetRunSpec(key="cpu_test", config=cfg, device="cpu")
 
     def _stub_throughput(
@@ -209,8 +223,8 @@ def test_run_benchmark_suite_emits_stage_and_filter_pressure_metrics(
         num_datasets: int,
         warmup_datasets: int = 10,
         device: str | None = None,
-        fixed_layout_plan=None,
-        fixed_layout_batch_size: int | None = None,
+        _fixed_layout_plan=None,
+        _fixed_layout_batch_size: int | None = None,
         on_bundle=None,
     ):
         _ = warmup_datasets
@@ -319,12 +333,14 @@ def test_run_benchmark_suite_filter_enabled_uses_filter_disabled_generation_conf
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cfg = _tiny_cpu_config()
-    cfg.filter.enabled = True
-    cfg.dataset.missing_rate = 0.25
-    cfg.dataset.missing_mechanism = "mcar"  # type: ignore[assignment]
-    cfg.shift.enabled = True
-    cfg.shift.mode = "mixed"
-    cfg.noise.family = "laplace"
+    _set_attrs(cfg.filter, enabled=True)
+    _set_attrs(
+        cfg.dataset,
+        missing_rate=0.25,
+        missing_mechanism="mcar",
+    )
+    _set_attrs(cfg.shift, enabled=True, mode="mixed")
+    _set_attrs(cfg.noise, family="laplace")
     spec = PresetRunSpec(key="cpu_test", config=cfg, device="cpu")
 
     throughput_filter_flags: list[bool] = []
@@ -339,8 +355,8 @@ def test_run_benchmark_suite_filter_enabled_uses_filter_disabled_generation_conf
         num_datasets: int,
         warmup_datasets: int = 10,
         device: str | None = None,
-        fixed_layout_plan=None,
-        fixed_layout_batch_size: int | None = None,
+        _fixed_layout_plan=None,
+        _fixed_layout_batch_size: int | None = None,
         on_bundle=None,
     ):
         _ = warmup_datasets
@@ -493,8 +509,8 @@ def test_run_benchmark_suite_filter_retry_rate_uses_stage_sample_denominator_whe
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cfg = _tiny_cpu_config()
-    cfg.filter.enabled = True
-    cfg.benchmark.latency_num_samples = 2
+    _set_attrs(cfg.filter, enabled=True)
+    _set_attrs(cfg.benchmark, latency_num_samples=2)
     spec = PresetRunSpec(key="cpu_test", config=cfg, device="cpu")
 
     def _stub_throughput(
@@ -503,8 +519,8 @@ def test_run_benchmark_suite_filter_retry_rate_uses_stage_sample_denominator_whe
         num_datasets: int,
         warmup_datasets: int = 10,
         device: str | None = None,
-        fixed_layout_plan=None,
-        fixed_layout_batch_size: int | None = None,
+        _fixed_layout_plan=None,
+        _fixed_layout_batch_size: int | None = None,
         on_bundle=None,
     ):
         _ = warmup_datasets
@@ -637,8 +653,8 @@ def test_missingness_control_run_uses_equivalent_callback_instrumentation(
         num_datasets: int,
         warmup_datasets: int = 10,
         device: str | None = None,
-        fixed_layout_plan=None,
-        fixed_layout_batch_size: int | None = None,
+        _fixed_layout_plan=None,
+        _fixed_layout_batch_size: int | None = None,
         on_bundle=None,
     ):
         _ = warmup_datasets
@@ -743,8 +759,8 @@ def test_run_benchmark_suite_releases_stage_samples_before_latency(
         num_datasets: int,
         warmup_datasets: int = 10,
         device: str | None = None,
-        fixed_layout_plan=None,
-        fixed_layout_batch_size: int | None = None,
+        _fixed_layout_plan=None,
+        _fixed_layout_batch_size: int | None = None,
         on_bundle=None,
     ):
         _ = warmup_datasets
@@ -860,8 +876,8 @@ def test_run_benchmark_suite_missingness_runtime_guardrail_updates_regression_st
         num_datasets: int,
         warmup_datasets: int = 10,
         device: str | None = None,
-        fixed_layout_plan=None,
-        fixed_layout_batch_size: int | None = None,
+        _fixed_layout_plan=None,
+        _fixed_layout_batch_size: int | None = None,
         on_bundle=None,
     ):
         _ = warmup_datasets
@@ -991,8 +1007,8 @@ def test_run_benchmark_suite_shift_runtime_guardrail_updates_regression_status(
         num_datasets: int,
         warmup_datasets: int = 10,
         device: str | None = None,
-        fixed_layout_plan=None,
-        fixed_layout_batch_size: int | None = None,
+        _fixed_layout_plan=None,
+        _fixed_layout_batch_size: int | None = None,
         on_bundle=None,
     ):
         _ = warmup_datasets
@@ -1104,8 +1120,8 @@ def test_run_benchmark_suite_shift_directional_guardrail_failure_updates_status(
         num_datasets: int,
         warmup_datasets: int = 10,
         device: str | None = None,
-        fixed_layout_plan=None,
-        fixed_layout_batch_size: int | None = None,
+        _fixed_layout_plan=None,
+        _fixed_layout_batch_size: int | None = None,
         on_bundle=None,
     ):
         _ = warmup_datasets
@@ -1239,8 +1255,8 @@ def test_run_benchmark_suite_noise_runtime_guardrail_updates_regression_status(
         num_datasets: int,
         warmup_datasets: int = 10,
         device: str | None = None,
-        fixed_layout_plan=None,
-        fixed_layout_batch_size: int | None = None,
+        _fixed_layout_plan=None,
+        _fixed_layout_batch_size: int | None = None,
         on_bundle=None,
     ):
         _ = warmup_datasets
@@ -1343,8 +1359,8 @@ def test_run_benchmark_suite_noise_metadata_coverage_failure_updates_status(
         num_datasets: int,
         warmup_datasets: int = 10,
         device: str | None = None,
-        fixed_layout_plan=None,
-        fixed_layout_batch_size: int | None = None,
+        _fixed_layout_plan=None,
+        _fixed_layout_batch_size: int | None = None,
         on_bundle=None,
     ):
         _ = warmup_datasets
@@ -1614,7 +1630,7 @@ def test_collect_lineage_guardrails_smoke_suppresses_runtime_issue_at_sample_cap
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cfg = _tiny_cpu_config()
-    cfg.benchmark.latency_num_samples = 6
+    _set_attrs(cfg.benchmark, latency_num_samples=6)
 
     def _stub_generate_batch_iter(
         _config,
@@ -1684,7 +1700,7 @@ def test_collect_lineage_guardrails_emits_runtime_issue_for_standard_suite(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cfg = _tiny_cpu_config()
-    cfg.benchmark.latency_num_samples = 6
+    _set_attrs(cfg.benchmark, latency_num_samples=6)
 
     def _stub_generate_batch_iter(
         _config,

--- a/tests/test_github_to_linear.py
+++ b/tests/test_github_to_linear.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "linear" / "github_to_linear.py"
@@ -168,60 +169,71 @@ def test_mapping_file_load_accepts_legacy_missing_metadata(tmp_path: Path) -> No
     assert mapping.project_slug == "proj"
 
 
-class _FakeGH:
-    def __init__(self, issues: list[object], *, dry_run: bool = False) -> None:
-        self._issues = issues
-        self.dry_run = dry_run
+def _make_fake_gh(issues: list[object], *, dry_run: bool = False) -> SimpleNamespace:
+    issue_list = list(issues)
 
-    def list_issues(self, issue_numbers: set[int] | None = None) -> list[object]:
+    def list_issues(issue_numbers: set[int] | None = None) -> list[object]:
         if issue_numbers is None:
-            return list(self._issues)
-        return [issue for issue in self._issues if issue.number in issue_numbers]
+            return list(issue_list)
+        return [issue for issue in issue_list if issue.number in issue_numbers]
 
-    def create_migration_comment(self, issue_number: int, linear_ref: object) -> None:
-        _ = issue_number
-        _ = linear_ref
+    def create_migration_comment(_issue_number: int, _linear_ref: object) -> None:
+        return None
 
-    def close_issue(self, issue_number: int) -> None:
-        _ = issue_number
+    def close_issue(_issue_number: int) -> None:
+        return None
+
+    return SimpleNamespace(
+        dry_run=dry_run,
+        list_issues=list_issues,
+        create_migration_comment=create_migration_comment,
+        close_issue=close_issue,
+    )
 
 
-class _CheckpointingGH(_FakeGH):
-    def __init__(
-        self,
-        issues: list[object],
-        *,
-        fail_on_comment_issue: int | None = None,
-        fail_on_close_issue: int | None = None,
-        dry_run: bool = False,
-    ) -> None:
-        super().__init__(issues, dry_run=dry_run)
-        self.fail_on_comment_issue = fail_on_comment_issue
-        self.fail_on_close_issue = fail_on_close_issue
-        self.comments: list[int] = []
-        self.closed: list[int] = []
+def _make_checkpointing_gh(
+    issues: list[object],
+    *,
+    fail_on_comment_issue: int | None = None,
+    fail_on_close_issue: int | None = None,
+    dry_run: bool = False,
+) -> SimpleNamespace:
+    issue_list = list(issues)
+    comments: list[int] = []
+    closed: list[int] = []
 
-    def create_migration_comment(self, issue_number: int, linear_ref: object) -> None:
-        _ = linear_ref
-        self.comments.append(issue_number)
-        if self.fail_on_comment_issue == issue_number:
+    def list_issues(issue_numbers: set[int] | None = None) -> list[object]:
+        if issue_numbers is None:
+            return list(issue_list)
+        return [issue for issue in issue_list if issue.number in issue_numbers]
+
+    def create_migration_comment(issue_number: int, _linear_ref: object) -> None:
+        comments.append(issue_number)
+        if fail_on_comment_issue == issue_number:
             raise MODULE.MigrationError(f"comment failed for #{issue_number}")
 
-    def close_issue(self, issue_number: int) -> None:
-        self.closed.append(issue_number)
-        if self.fail_on_close_issue == issue_number:
+    def close_issue(issue_number: int) -> None:
+        closed.append(issue_number)
+        if fail_on_close_issue == issue_number:
             raise MODULE.MigrationError(f"close failed for #{issue_number}")
 
+    return SimpleNamespace(
+        dry_run=dry_run,
+        comments=comments,
+        closed=closed,
+        list_issues=list_issues,
+        create_migration_comment=create_migration_comment,
+        close_issue=close_issue,
+    )
 
-class _FakeLinear:
-    def __init__(self, *, dry_run: bool = False) -> None:
-        self.dry_run = dry_run
-        self.update_calls: list[tuple[str, dict[str, object]]] = []
 
-    def get_project(self, project_slug: str) -> tuple[str, str, str]:
+def _make_fake_linear(*, dry_run: bool = False) -> SimpleNamespace:
+    update_calls: list[tuple[str, dict[str, object]]] = []
+
+    def get_project(_project_slug: str) -> tuple[str, str, str]:
         return ("project-1", "team-1", "DAG")
 
-    def get_team_metadata(self, team_id: str) -> tuple[dict[str, object], dict[str, object]]:
+    def get_team_metadata(_team_id: str) -> tuple[dict[str, object], dict[str, object]]:
         return (
             {
                 "Backlog": MODULE.LinearState(id="state-backlog", name="Backlog", type="backlog"),
@@ -235,21 +247,23 @@ class _FakeLinear:
             {},
         )
 
-    def ensure_workflow_states(self, team_id: str, states: dict[str, object]) -> dict[str, object]:
+    def ensure_workflow_states(
+        _team_id: str,
+        states: dict[str, object],
+    ) -> dict[str, object]:
         return dict(states)
 
     def ensure_labels(
-        self,
-        team_id: str,
+        _team_id: str,
         labels: dict[str, object],
-        label_specs: dict[str, dict[str, str | None]],
+        _label_specs: dict[str, dict[str, str | None]],
     ) -> dict[str, object]:
         return dict(labels)
 
-    def existing_project_issue_map(self, project_id: str) -> dict[int, object]:
+    def existing_project_issue_map(_project_id: str) -> dict[int, object]:
         return {}
 
-    def create_issue(self, input_payload: dict[str, object]) -> object:
+    def create_issue(input_payload: dict[str, object]) -> object:
         issue_suffix = str(input_payload["title"]).split()[-1]
         return MODULE.LinearIssueRef(
             id=f"linear-{issue_suffix}",
@@ -257,13 +271,25 @@ class _FakeLinear:
             url=f"https://linear.app/dagzoo/issue/DAG-{issue_suffix}",
         )
 
-    def update_issue(self, issue_id: str, input_payload: dict[str, object]) -> object:
-        self.update_calls.append((issue_id, dict(input_payload)))
+    def update_issue(issue_id: str, input_payload: dict[str, object]) -> object:
+        update_calls.append((issue_id, dict(input_payload)))
         return MODULE.LinearIssueRef(
             id=issue_id,
             identifier=f"{issue_id}-IDENT",
             url=f"https://linear.app/dagzoo/issue/{issue_id}",
         )
+
+    return SimpleNamespace(
+        dry_run=dry_run,
+        update_calls=update_calls,
+        get_project=get_project,
+        get_team_metadata=get_team_metadata,
+        ensure_workflow_states=ensure_workflow_states,
+        ensure_labels=ensure_labels,
+        existing_project_issue_map=existing_project_issue_map,
+        create_issue=create_issue,
+        update_issue=update_issue,
+    )
 
 
 def test_migrate_issues_dry_run_does_not_persist_mapping(tmp_path: Path) -> None:
@@ -290,8 +316,8 @@ def test_migrate_issues_dry_run_does_not_persist_mapping(tmp_path: Path) -> None
     mapping_path.write_text(json.dumps(original_mapping, indent=2) + "\n")
 
     mapping = MODULE.migrate_issues(
-        gh=_FakeGH([_issue(10)], dry_run=True),
-        linear=_FakeLinear(dry_run=True),
+        gh=_make_fake_gh([_issue(10)], dry_run=True),
+        linear=_make_fake_linear(dry_run=True),
         repo="bensonlee5/dagzoo",
         project_slug="proj",
         mapping_path=mapping_path,
@@ -366,10 +392,10 @@ def test_migrate_issues_preserves_linear_state_after_cutover(tmp_path: Path) -> 
         },
     )
     mapping_path.write_text(mapping.to_json())
-    linear = _FakeLinear()
+    linear = _make_fake_linear()
 
     migrated = MODULE.migrate_issues(
-        gh=_FakeGH([_issue(12, state="CLOSED")]),
+        gh=_make_fake_gh([_issue(12, state="CLOSED")]),
         linear=linear,
         repo="bensonlee5/dagzoo",
         project_slug="proj",
@@ -405,10 +431,10 @@ def test_migrate_issues_updates_state_before_cutover(tmp_path: Path) -> None:
         },
     )
     mapping_path.write_text(mapping.to_json())
-    linear = _FakeLinear()
+    linear = _make_fake_linear()
 
     migrated = MODULE.migrate_issues(
-        gh=_FakeGH([_issue(14, state="CLOSED")]),
+        gh=_make_fake_gh([_issue(14, state="CLOSED")]),
         linear=linear,
         repo="bensonlee5/dagzoo",
         project_slug="proj",
@@ -427,9 +453,9 @@ def test_migrate_issues_backfills_epic_parent_on_subset_rerun(tmp_path: Path) ->
         _issue(145),
     ]
 
-    first_linear = _FakeLinear()
+    first_linear = _make_fake_linear()
     first_migrated = MODULE.migrate_issues(
-        gh=_FakeGH(issues),
+        gh=_make_fake_gh(issues),
         linear=first_linear,
         repo="bensonlee5/dagzoo",
         project_slug="proj",
@@ -440,9 +466,9 @@ def test_migrate_issues_backfills_epic_parent_on_subset_rerun(tmp_path: Path) ->
     assert first_migrated.entry_for(145).parent_github_number == 148
     assert first_linear.update_calls == []
 
-    second_linear = _FakeLinear()
+    second_linear = _make_fake_linear()
     second_migrated = MODULE.migrate_issues(
-        gh=_FakeGH(issues),
+        gh=_make_fake_gh(issues),
         linear=second_linear,
         repo="bensonlee5/dagzoo",
         project_slug="proj",
@@ -486,10 +512,10 @@ def test_migrate_issues_subset_run_does_not_repair_unrelated_parent_links(
         },
     )
     mapping_path.write_text(mapping.to_json())
-    linear = _FakeLinear()
+    linear = _make_fake_linear()
 
     MODULE.migrate_issues(
-        gh=_FakeGH(
+        gh=_make_fake_gh(
             [
                 _issue(148, body="Tracks #145", labels=["epic"]),
                 _issue(145),
@@ -534,7 +560,7 @@ def test_apply_cutover_checkpoints_each_successful_issue(tmp_path: Path) -> None
         },
     )
     mapping_path.write_text(mapping.to_json())
-    gh = _CheckpointingGH(
+    gh = _make_checkpointing_gh(
         [_issue(10), _issue(11)],
         fail_on_comment_issue=11,
     )
@@ -585,7 +611,7 @@ def test_apply_cutover_dry_run_does_not_checkpoint_mapping(tmp_path: Path) -> No
     mapping_path.write_text(mapping.to_json())
 
     MODULE.apply_cutover(
-        gh=_CheckpointingGH([_issue(10)], dry_run=True),
+        gh=_make_checkpointing_gh([_issue(10)], dry_run=True),
         mapping=mapping,
         issue_numbers=None,
         mapping_path=mapping_path,
@@ -617,7 +643,7 @@ def test_apply_cutover_retry_skips_duplicate_comment_after_close_failure(
     )
     mapping_path.write_text(mapping.to_json())
 
-    first_gh = _CheckpointingGH([_issue(10)], fail_on_close_issue=10)
+    first_gh = _make_checkpointing_gh([_issue(10)], fail_on_close_issue=10)
     try:
         MODULE.apply_cutover(
             gh=first_gh,
@@ -642,7 +668,7 @@ def test_apply_cutover_retry_skips_duplicate_comment_after_close_failure(
     assert checkpointed.entry_for(10).cutover_applied_at is not None
     assert checkpointed.entry_for(10).github_state == "OPEN"
 
-    second_gh = _CheckpointingGH([_issue(10)])
+    second_gh = _make_checkpointing_gh([_issue(10)])
     MODULE.apply_cutover(
         gh=second_gh,
         mapping=checkpointed,

--- a/tests/test_seed_harness_backlog.py
+++ b/tests/test_seed_harness_backlog.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -21,13 +22,11 @@ _load_module("github_to_linear", "scripts/linear/github_to_linear.py")
 MODULE = _load_module("seed_harness_backlog", "scripts/linear/seed_harness_backlog.py")
 
 
-class _RecordingLinear:
-    def __init__(self, *, dry_run: bool = False) -> None:
-        self.dry_run = dry_run
-        self.calls: list[tuple[str, dict[str, object]]] = []
+def _make_recording_linear(*, dry_run: bool = False) -> SimpleNamespace:
+    calls: list[tuple[str, dict[str, object]]] = []
 
-    def graphql(self, query: str, variables: dict[str, object]) -> dict[str, object]:
-        self.calls.append((query, dict(variables)))
+    def graphql(query: str, variables: dict[str, object]) -> dict[str, object]:
+        calls.append((query, dict(variables)))
         if "issueLabelCreate" in query:
             input_payload = variables["input"]
             assert isinstance(input_payload, dict)
@@ -66,36 +65,41 @@ class _RecordingLinear:
             }
         raise AssertionError(f"Unexpected GraphQL query: {query}")
 
+    return SimpleNamespace(dry_run=dry_run, calls=calls, graphql=graphql)
 
-class _BootstrapLinear:
-    def __init__(self) -> None:
-        self.dry_run = True
-        self.ensure_states_calls: list[tuple[str, dict[str, object]]] = []
 
-    def get_project(self, project_slug: str) -> tuple[str, str, str]:
-        _ = project_slug
+def _make_bootstrap_linear() -> SimpleNamespace:
+    ensure_states_calls: list[tuple[str, dict[str, object]]] = []
+
+    def get_project(_project_slug: str) -> tuple[str, str, str]:
         return ("project-1", "team-1", "DAG")
 
-    def get_team_metadata(self, team_id: str) -> tuple[dict[str, object], dict[str, object]]:
-        _ = team_id
+    def get_team_metadata(_team_id: str) -> tuple[dict[str, object], dict[str, object]]:
         return ({}, {})
 
     def ensure_workflow_states(
-        self,
         team_id: str,
         states: dict[str, object],
     ) -> dict[str, object]:
-        self.ensure_states_calls.append((team_id, dict(states)))
+        ensure_states_calls.append((team_id, dict(states)))
         return {
             "Backlog": MODULE.LinearState(id="state-backlog", name="Backlog", type="backlog"),
             "Todo": MODULE.LinearState(id="state-todo", name="Todo", type="unstarted"),
         }
 
-    def graphql(self, query: str, variables: dict[str, object]) -> dict[str, object]:
-        _ = variables
+    def graphql(query: str, _variables: dict[str, object]) -> dict[str, object]:
         if "query ProjectIssues" in query:
             return {"issues": {"nodes": []}}
         raise AssertionError(f"Unexpected GraphQL query: {query}")
+
+    return SimpleNamespace(
+        dry_run=True,
+        ensure_states_calls=ensure_states_calls,
+        get_project=get_project,
+        get_team_metadata=get_team_metadata,
+        ensure_workflow_states=ensure_workflow_states,
+        graphql=graphql,
+    )
 
 
 def test_build_ticket_specs_contains_epic_and_audit_ticket() -> None:
@@ -150,7 +154,7 @@ def test_required_label_specs_cover_every_ticket_label() -> None:
 
 
 def test_ensure_labels_provisions_every_required_spec_label_in_dry_run() -> None:
-    linear = _RecordingLinear(dry_run=True)
+    linear = _make_recording_linear(dry_run=True)
 
     labels = MODULE.ensure_labels(
         linear,
@@ -164,7 +168,7 @@ def test_ensure_labels_provisions_every_required_spec_label_in_dry_run() -> None
 
 
 def test_create_or_update_issue_create_keeps_state_and_labels() -> None:
-    linear = _RecordingLinear()
+    linear = _make_recording_linear()
 
     MODULE.create_or_update_issue(
         linear,
@@ -189,7 +193,7 @@ def test_create_or_update_issue_create_keeps_state_and_labels() -> None:
 
 
 def test_create_or_update_issue_rerun_preserves_existing_state_and_labels() -> None:
-    linear = _RecordingLinear()
+    linear = _make_recording_linear()
 
     MODULE.create_or_update_issue(
         linear,
@@ -225,9 +229,9 @@ def test_main_bootstraps_workflow_states_before_seeding(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    linear = _BootstrapLinear()
+    linear = _make_bootstrap_linear()
     monkeypatch.setattr(MODULE, "load_linear_api_key", lambda _path: "test-key")
-    monkeypatch.setattr(MODULE, "LinearClient", lambda *args, **kwargs: linear)
+    monkeypatch.setattr(MODULE, "LinearClient", lambda *_args, **_kwargs: linear)
 
     exit_code = MODULE.main(
         [


### PR DESCRIPTION
## Summary
- replace vulture-opaque class-based test doubles with smaller factory-built fakes in the Linear script tests
- switch benchmark-suite config setup to dynamic attribute helpers and normalize unused stub params so vulture can analyze the file cleanly
- remove the three-file vulture exclusion from CI and keep only the intentional __getattr__ ignore

## Validation
- ./.venv/bin/vulture src/dagzoo tests --ignore-names __getattr__
- .venv/bin/pytest tests/test_benchmark_suite.py tests/test_github_to_linear.py tests/test_seed_harness_backlog.py -q
- ./.venv/bin/pre-commit run --all-files
- .venv/bin/pytest -q
