### PR TITLE
refactor(generate): replace split string sentinels

### DIFF
--- a/src/dagzoo/core/fixed_layout_runtime.py
+++ b/src/dagzoo/core/fixed_layout_runtime.py
@@ -51,7 +51,12 @@ from dagzoo.core.noise_runtime import (
     _resolve_noise_runtime_selection,
 )
 from dagzoo.core.shift import resolve_shift_runtime_params
-from dagzoo.core.validation import _classification_split_valid, _stratified_split_indices
+from dagzoo.core.validation import (
+    InvalidClassSplitError,
+    InfeasibleStratifiedSplitError,
+    _classification_split_valid,
+    _stratified_split_indices,
+)
 from dagzoo.rng import SeedManager, offset_seed32
 from dagzoo.types import DatasetBundle
 
@@ -402,10 +407,8 @@ def _raw_classification_labels_support_split(
             split_generator,
             "cpu",
         )
-    except ValueError as exc:
-        if str(exc).startswith("infeasible_stratified_split"):
-            return False
-        raise
+    except InfeasibleStratifiedSplitError:
+        return False
     return _classification_split_valid(labels[train_idx_cpu], labels[test_idx_cpu])
 
 
@@ -675,11 +678,9 @@ def _generate_fixed_layout_bundle_with_retries(
                 dtype=dtype,
                 preserve_feature_schema=preserve_feature_schema,
             )
-        except ValueError as exc:
-            if str(exc) == "invalid_class_split":
-                last_error = "invalid_class_split"
-                continue
-            raise
+        except InvalidClassSplitError:
+            last_error = "invalid_class_split"
+            continue
 
     raise ValueError(
         "Failed to generate a valid fixed-layout dataset after "

--- a/src/dagzoo/core/generation_runtime.py
+++ b/src/dagzoo/core/generation_runtime.py
@@ -17,7 +17,12 @@ from dagzoo.core.noise_runtime import (
     _build_noise_distribution_metadata,
 )
 from dagzoo.core.shift import ShiftRuntimeParams
-from dagzoo.core.validation import _classification_split_valid, _stratified_split_indices
+from dagzoo.core.validation import (
+    InvalidClassSplitError,
+    InfeasibleStratifiedSplitError,
+    _classification_split_valid,
+    _stratified_split_indices,
+)
 from dagzoo.postprocess.postprocess import (
     inject_missingness,
     postprocess_dataset,
@@ -275,7 +280,7 @@ def _finalize_processed_bundle(
     )
 
     if config.dataset.task == "classification" and not _classification_split_valid(y_train, y_test):
-        raise ValueError("invalid_class_split")
+        raise InvalidClassSplitError("invalid_class_split")
 
     x_train = x_train.to(device=device, dtype=dtype)
     x_test = x_test.to(device=device, dtype=dtype)
@@ -359,10 +364,8 @@ def _finalize_generated_chunk_preserve_schema(
                 n_train=n_train,
                 generator=split_postprocess_generator,
             )
-        except ValueError as exc:
-            if str(exc).startswith("infeasible_stratified_split"):
-                continue
-            raise
+        except InfeasibleStratifiedSplitError:
+            continue
 
         valid_positions.append(int(batch_index))
         train_idx_cpu_list.append(train_idx_cpu)
@@ -424,10 +427,8 @@ def _finalize_generated_chunk_preserve_schema(
                 noise_runtime_selection=noise_runtime_selection,
                 dtype=dtype,
             )
-        except ValueError as exc:
-            if str(exc) == "invalid_class_split":
-                continue
-            raise
+        except InvalidClassSplitError:
+            continue
 
     return results
 
@@ -463,10 +464,8 @@ def _finalize_generated_tensors(
             n_train=n_train,
             generator=split_postprocess_generator,
         )
-    except ValueError as exc:
-        if str(exc).startswith("infeasible_stratified_split"):
-            raise ValueError("invalid_class_split") from exc
-        raise
+    except InfeasibleStratifiedSplitError as exc:
+        raise InvalidClassSplitError("invalid_class_split") from exc
 
     x_train_t, y_train_t, x_test_t, y_test_t = _split_raw_tensors(
         x,

--- a/src/dagzoo/core/validation.py
+++ b/src/dagzoo/core/validation.py
@@ -7,6 +7,14 @@ import math
 import torch
 
 
+class InfeasibleStratifiedSplitError(ValueError):
+    """Raised when a classification split cannot satisfy stratification constraints."""
+
+
+class InvalidClassSplitError(ValueError):
+    """Raised when a classification split violates emitted bundle invariants."""
+
+
 def _stratified_split_indices(
     y: torch.Tensor,
     n_train: int,
@@ -17,13 +25,13 @@ def _stratified_split_indices(
 
     For classification tasks this keeps class balance close to proportional and
     ensures classes with at least two members appear in both splits. For
-    infeasible combinations, this raises ``ValueError`` with an
-    ``infeasible_stratified_split`` prefix.
+    infeasible combinations, this raises ``InfeasibleStratifiedSplitError``
+    with an ``infeasible_stratified_split`` prefix.
     """
     n_total = int(y.shape[0])
     n_test = n_total - n_train
     if n_total <= 0 or n_train <= 0 or n_test <= 0:
-        raise ValueError(
+        raise InfeasibleStratifiedSplitError(
             f"infeasible_stratified_split: expected 0 < n_train < n_total, got n_train={n_train}, n_total={n_total}."
         )
 
@@ -77,7 +85,7 @@ def _stratified_split_indices(
             if not progressed:
                 break
         if deficit > 0:
-            raise ValueError(
+            raise InfeasibleStratifiedSplitError(
                 "infeasible_stratified_split: unable to allocate requested train rows while "
                 f"preserving class constraints (remaining={deficit})."
             )
@@ -98,13 +106,13 @@ def _stratified_split_indices(
             if not progressed:
                 break
         if surplus > 0:
-            raise ValueError(
+            raise InfeasibleStratifiedSplitError(
                 "infeasible_stratified_split: unable to allocate requested test rows while "
                 f"preserving class constraints (remaining={surplus})."
             )
 
     if sum(cls_train_counts) != n_train:
-        raise ValueError(
+        raise InfeasibleStratifiedSplitError(
             "infeasible_stratified_split: train allocation mismatch after rebalance "
             f"(expected={n_train}, actual={sum(cls_train_counts)})."
         )
@@ -118,7 +126,7 @@ def _stratified_split_indices(
     train_idx = torch.cat(train_parts)
     test_idx = torch.cat(test_parts)
     if int(train_idx.shape[0]) != n_train or int(test_idx.shape[0]) != n_test:
-        raise ValueError(
+        raise InfeasibleStratifiedSplitError(
             "infeasible_stratified_split: index cardinality mismatch "
             f"(expected_train={n_train}, actual_train={int(train_idx.shape[0])}, "
             f"expected_test={n_test}, actual_test={int(test_idx.shape[0])})."

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -43,7 +43,7 @@ from dagzoo.core.fixed_layout_plan_types import FixedLayoutExecutionPlan
 from dagzoo.core.layout_types import LayoutPlan
 from dagzoo.core.noise_runtime import NoiseRuntimeSelection
 from dagzoo.core.shift import mechanism_nonlinear_mass, resolve_shift_runtime_params
-from dagzoo.core.validation import _stratified_split_indices
+from dagzoo.core.validation import InfeasibleStratifiedSplitError, _stratified_split_indices
 from dagzoo.io.lineage_schema import (
     LINEAGE_SCHEMA_NAME,
     LINEAGE_SCHEMA_VERSION,
@@ -1715,7 +1715,7 @@ def test_generate_retries_when_stratified_split_is_infeasible(
     def _raise_infeasible_split(
         *_args: object, **_kwargs: object
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        raise ValueError("infeasible_stratified_split: forced for test")
+        raise InfeasibleStratifiedSplitError("infeasible_stratified_split: forced for test")
 
     monkeypatch.setattr(
         "dagzoo.core.generation_runtime._stratified_split_indices",


### PR DESCRIPTION
## Summary
- replace string-matched split retry sentinels with typed internal exceptions
- keep public invalid_class_split failure messaging unchanged at the generation boundary
- update generation tests to inject the typed infeasible stratified split error

## Validation
- ./.venv/bin/ruff check src/dagzoo/core/validation.py src/dagzoo/core/generation_runtime.py src/dagzoo/core/fixed_layout_runtime.py tests/test_generate.py
- ./.venv/bin/pytest tests/test_generate.py -q
- ./.venv/bin/mypy src
- ./.venv/bin/vulture src/dagzoo tests --ignore-names __getattr__
- ./.venv/bin/pytest -q
- ./.venv/bin/pre-commit run --all-files