### PR TITLE
feat(dev): add dependency-aware repo tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ env/
 
 # Test / lint / type-check caches and coverage
 .pytest_cache/
+.testmondata
 .mypy_cache/
 .ruff_cache/
 .coverage

--- a/.importlinter
+++ b/.importlinter
@@ -1,0 +1,29 @@
+[importlinter]
+root_package = dagzoo
+
+[importlinter:contract:core_product_surface]
+name = dagzoo.core does not depend on product entrypoints
+type = forbidden
+source_modules =
+    dagzoo.core
+forbidden_modules =
+    dagzoo.cli
+    dagzoo.bench
+    dagzoo.diagnostics
+
+[importlinter:contract:library_product_surface]
+name = dagzoo libraries do not depend on product entrypoints
+type = forbidden
+source_modules =
+    dagzoo.functions
+    dagzoo.converters
+    dagzoo.sampling
+    dagzoo.io
+    dagzoo.filtering
+    dagzoo.graph
+    dagzoo.linalg
+    dagzoo.postprocess
+forbidden_modules =
+    dagzoo.cli
+    dagzoo.bench
+    dagzoo.diagnostics

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,15 @@ repos:
     types: [markdown]
     exclude: ^(WORKFLOW\.md|docs/transforms.md|site/)
     pass_filenames: true
+  - id: deptry
+    name: deptry
+    entry: ./.venv/bin/deptry .
+    language: system
+    pass_filenames: false
+    files: ^(pyproject\.toml|src/dagzoo/)
+  - id: release-contract
+    name: release contract
+    entry: ./.venv/bin/python scripts/dev.py contract --files
+    language: system
+    pass_filenames: true
+    files: ^(src/dagzoo/(cli\.py|config\.py|core/(config_resolution|metadata|dataset|fixed_layout_runtime)\.py|io/.*)|configs/.*|pyproject\.toml|CHANGELOG\.md)$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,4 @@
 - We prefer shared utility packages over hand-rolled helpers to keep invariants centralized
 - We don’t probe data “YOLO-style”—we validate boundaries or rely on typed SDKs
 - Prior to declaring a branch ready for review, run /review and resolve all issues found
+- Canonical local verification is `./scripts/dev verify quick`; use `./scripts/dev impact` when you need a dependency-aware ripple check before broader refactors

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Examples in this README assume a repo checkout (so `configs/*.yaml` is available
 ```bash
 uv sync --group dev
 source .venv/bin/activate
+./scripts/dev doctor all
 ```
 
 Install the packaged CLI globally when you do not need repo presets/config files:
@@ -140,6 +141,13 @@ dagzoo filter --help
 dagzoo benchmark --help
 ```
 
+Local repo workflow before review:
+
+```bash
+./scripts/dev impact
+./scripts/dev verify quick
+```
+
 ## Features
 
 - Diagnostics: exposes per-dataset artifacts so you can verify coverage, inspect drift, and debug generation outcomes.
@@ -181,6 +189,8 @@ node execution and quality filtering.
 
 See [docs/development/codebase-navigation.md](docs/development/codebase-navigation.md)
 for the full module map with file paths and descriptions.
+See [docs/development/module-dependency-map.md](docs/development/module-dependency-map.md)
+for the generated dependency graph and change-impact hotspots.
 
 ## Python API
 

--- a/docs/development/codebase-navigation.md
+++ b/docs/development/codebase-navigation.md
@@ -4,6 +4,14 @@ The project is organized into functional modules that manage the lifecycle
 of a synthetic dataset, from configuration and causal graph sampling to
 node execution and quality filtering.
 
+For dependency-aware ripple analysis, see
+[`module-dependency-map.md`](module-dependency-map.md). It complements this file
+with a generated package graph plus hotspot reverse-dependency summaries. For
+example, changes in `src/dagzoo/core/execution_semantics.py` currently cascade
+into `fixed_layout_batched.py`, `node_pipeline.py`, converter modules, function
+modules, and then outward into `fixed_layout_runtime.py`, benchmarks, and CLI
+surfaces.
+
 ## 1. Entry Points & Orchestration
 
 The high-level logic that bridges CLI/API requests to the canonical generation

--- a/docs/development/module-dependency-map.md
+++ b/docs/development/module-dependency-map.md
@@ -1,0 +1,111 @@
+# Module Dependency Map
+
+This file is generated from imports under `src/dagzoo`.
+Run `./scripts/dev deps --write-docs` after changing internal module edges.
+
+## Package Dependency DAG
+
+The package graph below collapses strongly connected components so the result stays acyclic.
+
+- `dagzoo` depends on `dagzoo.config`, `dagzoo.hardware`, `dagzoo.hardware_policy`, `dagzoo.types`, `dagzoo.core`, `dagzoo.functions`, `dagzoo.postprocess`, `dagzoo.sampling`
+- `dagzoo.__main__` depends on `dagzoo.cli`
+- `dagzoo.cli` depends on `dagzoo.bench`, `dagzoo.config`, `dagzoo.filtering`, `dagzoo.hardware`, `dagzoo.hardware_policy`, `dagzoo.io`, `dagzoo.rng`, `dagzoo.diagnostics`, `dagzoo.diagnostics_targets`, `dagzoo.core`, `dagzoo.functions`, `dagzoo.postprocess`, `dagzoo.sampling`
+- `dagzoo.bench` depends on `dagzoo.config`, `dagzoo.filtering`, `dagzoo.hardware`, `dagzoo.hardware_policy`, `dagzoo.io`, `dagzoo.math_utils`, `dagzoo.rng`, `dagzoo.types`, `dagzoo.diagnostics`, `dagzoo.diagnostics_targets`, `dagzoo.core`, `dagzoo.functions`, `dagzoo.postprocess`, `dagzoo.sampling`
+- `dagzoo.converters` depends on `dagzoo.rng`, `dagzoo.core`, `dagzoo.functions`, `dagzoo.postprocess`, `dagzoo.sampling`
+- `dagzoo.linalg` depends on `dagzoo.math_utils`, `dagzoo.core`, `dagzoo.functions`, `dagzoo.postprocess`, `dagzoo.sampling`
+- `dagzoo.diagnostics`, `dagzoo.diagnostics_targets` depends on `dagzoo.config`, `dagzoo.math_utils`, `dagzoo.types`, `dagzoo.core`, `dagzoo.functions`, `dagzoo.postprocess`, `dagzoo.sampling`
+- `dagzoo.core`, `dagzoo.functions`, `dagzoo.postprocess`, `dagzoo.sampling` depends on `dagzoo.config`, `dagzoo.filtering`, `dagzoo.graph`, `dagzoo.hardware`, `dagzoo.hardware_policy`, `dagzoo.io`, `dagzoo.math_utils`, `dagzoo.rng`, `dagzoo.types`
+- `dagzoo.filtering` depends on `dagzoo.config`, `dagzoo.io`, `dagzoo.math_utils`, `dagzoo.rng`
+- `dagzoo.graph` has no internal package dependencies
+- `dagzoo.hardware_policy` depends on `dagzoo.config`, `dagzoo.hardware`
+- `dagzoo.config` depends on `dagzoo.math_utils`, `dagzoo.rng`
+- `dagzoo.hardware` has no internal package dependencies
+- `dagzoo.io` depends on `dagzoo.math_utils`, `dagzoo.types`
+- `dagzoo.math_utils` has no internal package dependencies
+- `dagzoo.rng` has no internal package dependencies
+- `dagzoo.types` has no internal package dependencies
+
+## Change-Impact Hotspots
+
+The sections below list direct importers and full transitive downstream modules.
+Use them to predict which runtime paths are likely to move when a hot module changes.
+
+### `dagzoo.core.execution_semantics`
+
+- Path: `src/dagzoo/core/execution_semantics.py`
+- Imports: `dagzoo.core.fixed_layout_plan_types`, `dagzoo.core.layout_types`, `dagzoo.core.shift`, `dagzoo.functions.activations`, `dagzoo.math_utils`, `dagzoo.rng`
+- Direct downstream modules: `dagzoo.converters.categorical`, `dagzoo.converters.numeric`, `dagzoo.core.fixed_layout_batched`, `dagzoo.core.node_pipeline`, `dagzoo.diagnostics.effective_diversity`, `dagzoo.functions.multi`, `dagzoo.functions.random_functions`, `dagzoo.sampling.random_points`
+- Transitive downstream modules: `dagzoo`, `dagzoo.__main__`, `dagzoo.bench`, `dagzoo.bench.collectors`, `dagzoo.bench.guardrails`, `dagzoo.bench.micro`, `dagzoo.bench.suite`, `dagzoo.bench.throughput`, `dagzoo.cli`, `dagzoo.converters`, `dagzoo.converters.categorical`, `dagzoo.converters.numeric`, `dagzoo.core`, `dagzoo.core.dataset`, `dagzoo.core.fixed_layout`, `dagzoo.core.fixed_layout_batched`, `dagzoo.core.fixed_layout_runtime`, `dagzoo.core.layout`, `dagzoo.core.node_pipeline`, `dagzoo.diagnostics.effective_diversity`, `dagzoo.functions.multi`, `dagzoo.functions.random_functions`, `dagzoo.sampling.random_points`
+- Downstream package areas: `dagzoo.bench`, `dagzoo.cli`, `dagzoo.converters`, `dagzoo.diagnostics`, `dagzoo.functions`, `dagzoo.sampling`
+
+### `dagzoo.core.fixed_layout_batched`
+
+- Path: `src/dagzoo/core/fixed_layout_batched.py`
+- Imports: `dagzoo.config`, `dagzoo.core.execution_semantics`, `dagzoo.core.fixed_layout_plan_types`, `dagzoo.core.layout`, `dagzoo.core.layout_types`, `dagzoo.core.trees`, `dagzoo.functions`, `dagzoo.functions.activations`, `dagzoo.rng`, `dagzoo.sampling.noise`
+- Direct downstream modules: `dagzoo.converters.categorical`, `dagzoo.converters.numeric`, `dagzoo.core.fixed_layout`, `dagzoo.core.fixed_layout_runtime`, `dagzoo.core.node_pipeline`, `dagzoo.diagnostics.effective_diversity`, `dagzoo.functions.multi`, `dagzoo.functions.random_functions`, `dagzoo.sampling.random_points`
+- Transitive downstream modules: `dagzoo`, `dagzoo.__main__`, `dagzoo.bench`, `dagzoo.bench.collectors`, `dagzoo.bench.guardrails`, `dagzoo.bench.micro`, `dagzoo.bench.suite`, `dagzoo.bench.throughput`, `dagzoo.cli`, `dagzoo.converters`, `dagzoo.converters.categorical`, `dagzoo.converters.numeric`, `dagzoo.core`, `dagzoo.core.dataset`, `dagzoo.core.fixed_layout`, `dagzoo.core.fixed_layout_batched`, `dagzoo.core.fixed_layout_runtime`, `dagzoo.core.layout`, `dagzoo.core.node_pipeline`, `dagzoo.diagnostics.effective_diversity`, `dagzoo.functions.multi`, `dagzoo.functions.random_functions`, `dagzoo.sampling.random_points`
+- Downstream package areas: `dagzoo.bench`, `dagzoo.cli`, `dagzoo.converters`, `dagzoo.diagnostics`, `dagzoo.functions`, `dagzoo.sampling`
+
+### `dagzoo.core.fixed_layout_runtime`
+
+- Path: `src/dagzoo/core/fixed_layout_runtime.py`
+- Imports: `dagzoo.config`, `dagzoo.core.fixed_layout`, `dagzoo.core.fixed_layout_batched`, `dagzoo.core.fixed_layout_plan_types`, `dagzoo.core.generation_context`, `dagzoo.core.generation_runtime`, `dagzoo.core.layout`, `dagzoo.core.layout_types`, `dagzoo.core.noise_runtime`, `dagzoo.core.shift`, `dagzoo.core.validation`, `dagzoo.rng`, `dagzoo.types`
+- Direct downstream modules: `dagzoo.bench.suite`, `dagzoo.cli`, `dagzoo.core.dataset`
+- Transitive downstream modules: `dagzoo`, `dagzoo.__main__`, `dagzoo.bench`, `dagzoo.bench.collectors`, `dagzoo.bench.guardrails`, `dagzoo.bench.micro`, `dagzoo.bench.suite`, `dagzoo.bench.throughput`, `dagzoo.cli`, `dagzoo.core`, `dagzoo.core.dataset`, `dagzoo.diagnostics.effective_diversity`
+- Downstream package areas: `dagzoo.bench`, `dagzoo.cli`, `dagzoo.diagnostics`
+
+### `dagzoo.core.layout`
+
+- Path: `src/dagzoo/core/layout.py`
+- Imports: `dagzoo.config`, `dagzoo.core.layout_types`, `dagzoo.core.node_pipeline`, `dagzoo.core.shift`, `dagzoo.functions._rng_helpers`, `dagzoo.graph`, `dagzoo.rng`, `dagzoo.sampling`
+- Direct downstream modules: `dagzoo.core.fixed_layout_batched`, `dagzoo.core.fixed_layout_runtime`
+- Transitive downstream modules: `dagzoo`, `dagzoo.__main__`, `dagzoo.bench`, `dagzoo.bench.collectors`, `dagzoo.bench.guardrails`, `dagzoo.bench.micro`, `dagzoo.bench.suite`, `dagzoo.bench.throughput`, `dagzoo.cli`, `dagzoo.converters`, `dagzoo.converters.categorical`, `dagzoo.converters.numeric`, `dagzoo.core`, `dagzoo.core.dataset`, `dagzoo.core.fixed_layout`, `dagzoo.core.fixed_layout_batched`, `dagzoo.core.fixed_layout_runtime`, `dagzoo.core.layout`, `dagzoo.core.node_pipeline`, `dagzoo.diagnostics.effective_diversity`, `dagzoo.functions.multi`, `dagzoo.functions.random_functions`, `dagzoo.sampling.random_points`
+- Downstream package areas: `dagzoo.bench`, `dagzoo.cli`, `dagzoo.converters`, `dagzoo.diagnostics`, `dagzoo.functions`, `dagzoo.sampling`
+
+### `dagzoo.core.node_pipeline`
+
+- Path: `src/dagzoo/core/node_pipeline.py`
+- Imports: `dagzoo.core.execution_semantics`, `dagzoo.core.fixed_layout_batched`, `dagzoo.core.fixed_layout_plan_types`, `dagzoo.core.layout_types`, `dagzoo.rng`, `dagzoo.sampling.noise`
+- Direct downstream modules: `dagzoo.bench.micro`, `dagzoo.core.layout`
+- Transitive downstream modules: `dagzoo`, `dagzoo.__main__`, `dagzoo.bench`, `dagzoo.bench.collectors`, `dagzoo.bench.guardrails`, `dagzoo.bench.micro`, `dagzoo.bench.suite`, `dagzoo.bench.throughput`, `dagzoo.cli`, `dagzoo.converters`, `dagzoo.converters.categorical`, `dagzoo.converters.numeric`, `dagzoo.core`, `dagzoo.core.dataset`, `dagzoo.core.fixed_layout`, `dagzoo.core.fixed_layout_batched`, `dagzoo.core.fixed_layout_runtime`, `dagzoo.core.layout`, `dagzoo.core.node_pipeline`, `dagzoo.diagnostics.effective_diversity`, `dagzoo.functions.multi`, `dagzoo.functions.random_functions`, `dagzoo.sampling.random_points`
+- Downstream package areas: `dagzoo.bench`, `dagzoo.cli`, `dagzoo.converters`, `dagzoo.diagnostics`, `dagzoo.functions`, `dagzoo.sampling`
+
+### `dagzoo.core.dataset`
+
+- Path: `src/dagzoo/core/dataset.py`
+- Imports: `dagzoo.config`, `dagzoo.core.fixed_layout_runtime`, `dagzoo.rng`, `dagzoo.types`
+- Direct downstream modules: `dagzoo`, `dagzoo.bench.guardrails`, `dagzoo.bench.micro`, `dagzoo.bench.suite`, `dagzoo.bench.throughput`, `dagzoo.cli`, `dagzoo.core`, `dagzoo.diagnostics.effective_diversity`
+- Transitive downstream modules: `dagzoo`, `dagzoo.__main__`, `dagzoo.bench`, `dagzoo.bench.collectors`, `dagzoo.bench.guardrails`, `dagzoo.bench.micro`, `dagzoo.bench.suite`, `dagzoo.bench.throughput`, `dagzoo.cli`, `dagzoo.core`, `dagzoo.diagnostics.effective_diversity`
+- Downstream package areas: `dagzoo.bench`, `dagzoo.cli`, `dagzoo.diagnostics`
+
+### `dagzoo.core.config_resolution`
+
+- Path: `src/dagzoo/core/config_resolution.py`
+- Imports: `dagzoo.config`, `dagzoo.hardware`, `dagzoo.hardware_policy`
+- Direct downstream modules: `dagzoo.bench.suite`, `dagzoo.cli`
+- Transitive downstream modules: `dagzoo.__main__`, `dagzoo.bench`, `dagzoo.bench.suite`, `dagzoo.cli`
+- Downstream package areas: `dagzoo.bench`, `dagzoo.cli`
+
+### `dagzoo.core.generation_runtime`
+
+- Path: `src/dagzoo/core/generation_runtime.py`
+- Imports: `dagzoo.config`, `dagzoo.core.layout_types`, `dagzoo.core.metadata`, `dagzoo.core.noise_runtime`, `dagzoo.core.shift`, `dagzoo.core.validation`, `dagzoo.postprocess.postprocess`, `dagzoo.rng`, `dagzoo.types`
+- Direct downstream modules: `dagzoo.core.fixed_layout_runtime`
+- Transitive downstream modules: `dagzoo`, `dagzoo.__main__`, `dagzoo.bench`, `dagzoo.bench.collectors`, `dagzoo.bench.guardrails`, `dagzoo.bench.micro`, `dagzoo.bench.suite`, `dagzoo.bench.throughput`, `dagzoo.cli`, `dagzoo.core`, `dagzoo.core.dataset`, `dagzoo.core.fixed_layout_runtime`, `dagzoo.diagnostics.effective_diversity`
+- Downstream package areas: `dagzoo.bench`, `dagzoo.cli`, `dagzoo.diagnostics`
+
+### `dagzoo.config`
+
+- Path: `src/dagzoo/config.py`
+- Imports: `dagzoo.math_utils`, `dagzoo.rng`
+- Direct downstream modules: `dagzoo`, `dagzoo.bench.guardrails`, `dagzoo.bench.micro`, `dagzoo.bench.stage_metrics`, `dagzoo.bench.suite`, `dagzoo.bench.throughput`, `dagzoo.cli`, `dagzoo.core.config_resolution`, `dagzoo.core.dataset`, `dagzoo.core.fixed_layout`, `dagzoo.core.fixed_layout_batched`, `dagzoo.core.fixed_layout_runtime`, `dagzoo.core.generation_context`, `dagzoo.core.generation_runtime`, `dagzoo.core.layout`, `dagzoo.core.noise_runtime`, `dagzoo.core.shift`, `dagzoo.diagnostics.effective_diversity`, `dagzoo.diagnostics_targets`, `dagzoo.filtering.deferred_filter`, `dagzoo.hardware_policy`, `dagzoo.postprocess.postprocess`, `dagzoo.sampling.missingness`, `dagzoo.sampling.noise`
+- Transitive downstream modules: `dagzoo`, `dagzoo.__main__`, `dagzoo.bench`, `dagzoo.bench.collectors`, `dagzoo.bench.guardrails`, `dagzoo.bench.micro`, `dagzoo.bench.stage_metrics`, `dagzoo.bench.suite`, `dagzoo.bench.throughput`, `dagzoo.cli`, `dagzoo.converters`, `dagzoo.converters.categorical`, `dagzoo.converters.numeric`, `dagzoo.core`, `dagzoo.core.config_resolution`, `dagzoo.core.dataset`, `dagzoo.core.execution_semantics`, `dagzoo.core.fixed_layout`, `dagzoo.core.fixed_layout_batched`, `dagzoo.core.fixed_layout_runtime`, `dagzoo.core.generation_context`, `dagzoo.core.generation_runtime`, `dagzoo.core.layout`, `dagzoo.core.metadata`, `dagzoo.core.metrics_torch`, `dagzoo.core.node_pipeline`, `dagzoo.core.noise_runtime`, `dagzoo.core.shift`, `dagzoo.diagnostics`, `dagzoo.diagnostics.coverage`, `dagzoo.diagnostics.effective_diversity`, `dagzoo.diagnostics.metrics`, `dagzoo.diagnostics_targets`, `dagzoo.filtering`, `dagzoo.filtering.deferred_filter`, `dagzoo.functions.multi`, `dagzoo.functions.random_functions`, `dagzoo.hardware_policy`, `dagzoo.linalg`, `dagzoo.linalg.random_matrices`, `dagzoo.postprocess`, `dagzoo.postprocess.postprocess`, `dagzoo.sampling`, `dagzoo.sampling.missingness`, `dagzoo.sampling.noise`, `dagzoo.sampling.random_points`, `dagzoo.sampling.random_weights`
+- Downstream package areas: `dagzoo.bench`, `dagzoo.cli`, `dagzoo.converters`, `dagzoo.core`, `dagzoo.diagnostics`, `dagzoo.diagnostics_targets`, `dagzoo.filtering`, `dagzoo.functions`, `dagzoo.hardware_policy`, `dagzoo.linalg`, `dagzoo.postprocess`, `dagzoo.sampling`
+
+### `dagzoo.io.lineage_schema`
+
+- Path: `src/dagzoo/io/lineage_schema.py`
+- Imports: none
+- Direct downstream modules: `dagzoo.core.metadata`, `dagzoo.io`, `dagzoo.io.parquet_writer`
+- Transitive downstream modules: `dagzoo`, `dagzoo.__main__`, `dagzoo.bench`, `dagzoo.bench.collectors`, `dagzoo.bench.guardrails`, `dagzoo.bench.micro`, `dagzoo.bench.stage_metrics`, `dagzoo.bench.suite`, `dagzoo.bench.throughput`, `dagzoo.cli`, `dagzoo.core`, `dagzoo.core.dataset`, `dagzoo.core.fixed_layout_runtime`, `dagzoo.core.generation_runtime`, `dagzoo.core.metadata`, `dagzoo.core.metrics_torch`, `dagzoo.diagnostics`, `dagzoo.diagnostics.coverage`, `dagzoo.diagnostics.effective_diversity`, `dagzoo.diagnostics.metrics`, `dagzoo.diagnostics_targets`, `dagzoo.filtering`, `dagzoo.filtering.deferred_filter`, `dagzoo.io`, `dagzoo.io.parquet_writer`
+- Downstream package areas: `dagzoo.bench`, `dagzoo.cli`, `dagzoo.core`, `dagzoo.diagnostics`, `dagzoo.diagnostics_targets`, `dagzoo.filtering`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,16 @@ dagzoo = "dagzoo.cli:main"
 
 [dependency-groups]
 dev = [
+  "deptry>=0.23",
+  "import-linter>=2.3",
   "mdformat>=0.7",
   "mdformat-gfm>=0.4",
   "mypy>=1.11",
   "pre-commit>=3.8",
   "pytest>=8.0",
   "pytest-cov>=6.0",
+  "pytest-testmon>=2.1",
+  "pytest-xdist>=3.6",
   "ruff>=0.6",
   "types-PyYAML",
   "vulture>=2.14",
@@ -61,3 +65,12 @@ show_missing = true
 python_version = "3.13"
 warn_unused_configs = true
 ignore_missing_imports = true
+
+[tool.deptry]
+known_first_party = ["dagzoo"]
+extend_exclude = [
+  "^tests/",
+  "^scripts/",
+  "^docs/",
+  "^site/",
+]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,6 +4,19 @@ Run these wrappers and helper scripts from the repo root. CLI-oriented entries
 typically use `uv run dagzoo ...`; docs and maintenance helpers are invoked
 directly.
 
+## Developer CLI
+
+- `./scripts/dev doctor [code|docs|all]`
+  - Verifies local toolchain prerequisites for repo work.
+- `./scripts/dev deps [--scope package|hybrid|full] [--format text|json] [--write-docs] [--check]`
+  - Builds the repo dependency graph and can refresh the checked-in docs snapshot.
+- `./scripts/dev impact [--source working-tree|--base <git-ref>] [--files ...] [--format text|json]`
+  - Classifies changed files and shows dependency-aware downstream impact.
+- `./scripts/dev contract [--source working-tree|--base <git-ref>] [--files ...] [--strict]`
+  - Enforces version/changelog expectations for likely user-facing changes.
+- `./scripts/dev verify quick|code|docs|bench|full [--dry-run] [--incremental] [--parallel]`
+  - Canonical local verification entrypoint for normal code, docs, and benchmark work.
+
 ## Scripts
 
 - `scripts/generate-from-config.sh [config] [num_datasets] [device] [out_dir] [seed]`
@@ -44,6 +57,14 @@ directly.
 ## Examples
 
 ```bash
+./scripts/dev doctor all
+./scripts/dev impact
+./scripts/dev impact --files src/dagzoo/core/execution_semantics.py
+./scripts/dev deps --write-docs
+./scripts/dev verify quick
+./scripts/dev verify code --incremental
+./scripts/dev verify docs
+./scripts/dev verify bench
 ./scripts/generate-default.sh
 ./scripts/generate-default.sh 50 cpu data/run_cpu_50
 ./scripts/generate-h100.sh 500 cuda data/run_h100_500 123

--- a/scripts/dev
+++ b/scripts/dev
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec ./.venv/bin/python scripts/dev.py "$@"

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from devlib.common import DOCS_DEP_MAP_PATH, DevToolError, repo_relative  # noqa: E402
+from devlib.contract import evaluate_release_contract, render_contract_result  # noqa: E402
+from devlib.deps import (  # noqa: E402
+    build_import_graph,
+    dependency_docs_are_current,
+    render_scope_json,
+    render_scope_text,
+    write_dependency_docs,
+)
+from devlib.doctor import doctor_passed, render_doctor_results, run_doctor  # noqa: E402
+from devlib.impact import (  # noqa: E402
+    build_impact_report,
+    detect_changed_files,
+    render_json as render_impact_json,
+    render_text as render_impact_text,
+)
+from devlib.verify import build_verify_plan, execute_verify_plan  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="./scripts/dev")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    doctor_parser = subparsers.add_parser("doctor")
+    doctor_parser.add_argument("mode", choices=("code", "docs", "all"), nargs="?", default="all")
+
+    deps_parser = subparsers.add_parser("deps")
+    deps_parser.add_argument("--scope", choices=("package", "hybrid", "full"), default="hybrid")
+    deps_parser.add_argument("--format", choices=("text", "json"), default="text")
+    deps_parser.add_argument("--write-docs", action="store_true")
+    deps_parser.add_argument("--check", action="store_true")
+
+    impact_parser = subparsers.add_parser("impact")
+    _add_change_source_args(impact_parser)
+    impact_parser.add_argument("--format", choices=("text", "json"), default="text")
+
+    contract_parser = subparsers.add_parser("contract")
+    _add_change_source_args(contract_parser)
+    contract_parser.add_argument("--strict", action="store_true")
+
+    verify_parser = subparsers.add_parser("verify")
+    verify_parser.add_argument("mode", choices=("quick", "code", "docs", "bench", "full"))
+    _add_change_source_args(verify_parser)
+    verify_parser.add_argument("--dry-run", action="store_true")
+    verify_parser.add_argument("--incremental", action="store_true")
+    verify_parser.add_argument("--parallel", action="store_true")
+
+    return parser
+
+
+def _add_change_source_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--source", choices=("working-tree", "base"), default="working-tree")
+    parser.add_argument("--base")
+    parser.add_argument("--files", nargs="*")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "doctor":
+            results = run_doctor(args.mode)
+            print(render_doctor_results(results), end="")
+            return 0 if doctor_passed(results) else 1
+
+        if args.command == "deps":
+            graph = build_import_graph()
+            if args.write_docs:
+                write_dependency_docs(graph)
+                print(f"wrote {repo_relative(DOCS_DEP_MAP_PATH)}")
+            if args.check:
+                if not dependency_docs_are_current(graph):
+                    print(
+                        "dependency map docs are stale; run `./scripts/dev deps --write-docs`.",
+                        file=sys.stderr,
+                    )
+                    return 1
+                if not args.write_docs:
+                    print("dependency map docs are current.")
+                return 0
+            if args.write_docs:
+                return 0
+            rendered = (
+                render_scope_json(graph, args.scope)
+                if args.format == "json"
+                else render_scope_text(graph, args.scope)
+            )
+            print(rendered, end="")
+            return 0
+
+        if args.command == "impact":
+            changed_files = detect_changed_files(
+                source="working-tree" if args.source == "working-tree" else "base",
+                base=args.base,
+                files=args.files,
+            )
+            report = build_impact_report(changed_files)
+            rendered = (
+                render_impact_json(report) if args.format == "json" else render_impact_text(report)
+            )
+            print(rendered, end="")
+            return 0
+
+        if args.command == "contract":
+            changed_files = detect_changed_files(
+                source="working-tree" if args.source == "working-tree" else "base",
+                base=args.base,
+                files=args.files,
+            )
+            report = build_impact_report(changed_files)
+            result = evaluate_release_contract(report, strict=args.strict)
+            print(render_contract_result(result), end="")
+            return 0 if result.ok else 1
+
+        if args.command == "verify":
+            plan = build_verify_plan(
+                mode=args.mode,
+                source="working-tree" if args.source == "working-tree" else "base",
+                base=args.base,
+                files=args.files,
+                incremental=args.incremental,
+                parallel=args.parallel,
+            )
+            print(execute_verify_plan(plan, dry_run=args.dry_run), end="")
+            return 0
+    except DevToolError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    parser.error("unreachable")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/devlib/__init__.py
+++ b/scripts/devlib/__init__.py
@@ -1,0 +1,1 @@
+"""Repo-local developer tooling helpers."""

--- a/scripts/devlib/common.py
+++ b/scripts/devlib/common.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import shutil
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src" / "dagzoo"
+DOCS_DEP_MAP_PATH = REPO_ROOT / "docs" / "development" / "module-dependency-map.md"
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    label: str
+    argv: tuple[str, ...]
+
+
+class DevToolError(RuntimeError):
+    """Raised for developer tooling failures with user-facing messages."""
+
+
+def repo_relative(path: Path) -> str:
+    try:
+        return path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def python_tool(tool_name: str) -> str:
+    candidate = REPO_ROOT / ".venv" / "bin" / tool_name
+    if candidate.exists():
+        return str(candidate)
+    return tool_name
+
+
+def venv_python() -> Path:
+    return REPO_ROOT / ".venv" / "bin" / "python"
+
+
+def run_command(command: CommandSpec) -> None:
+    result = subprocess.run(command.argv, cwd=REPO_ROOT, check=False)
+    if result.returncode != 0:
+        raise DevToolError(f"{command.label} failed with exit code {result.returncode}.")
+
+
+def format_command(argv: tuple[str, ...]) -> str:
+    return " ".join(argv)
+
+
+def tool_exists(tool_name: str) -> bool:
+    return shutil.which(tool_name) is not None

--- a/scripts/devlib/contract.py
+++ b/scripts/devlib/contract.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .impact import ImpactReport
+
+
+@dataclass(frozen=True)
+class ContractResult:
+    ok: bool
+    warnings: tuple[str, ...]
+    errors: tuple[str, ...]
+
+
+def evaluate_release_contract(report: ImpactReport, *, strict: bool = False) -> ContractResult:
+    changed = set(report.changed_files)
+    version_changed = "pyproject.toml" in changed
+    changelog_changed = "CHANGELOG.md" in changed
+    has_release_risk = "release-risk" in report.tags
+    python_code_changed = any(path.startswith("src/dagzoo/") for path in changed)
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    if has_release_risk and not (version_changed and changelog_changed):
+        errors.append(
+            "release-risk changes require updates to both `pyproject.toml` and `CHANGELOG.md`."
+        )
+    elif python_code_changed and not (version_changed and changelog_changed):
+        warnings.append(
+            "Internal-only refactors may skip a version bump, but user-facing behavior, schema, CLI, "
+            "or artifact changes may not."
+        )
+        if strict:
+            errors.append(
+                "strict release-contract mode treats missing `pyproject.toml`/`CHANGELOG.md` updates as a failure."
+            )
+
+    return ContractResult(
+        ok=not errors,
+        warnings=tuple(warnings),
+        errors=tuple(errors),
+    )
+
+
+def render_contract_result(result: ContractResult) -> str:
+    lines: list[str] = []
+    lines.extend(f"warning: {warning}" for warning in result.warnings)
+    lines.extend(f"error: {error}" for error in result.errors)
+    if not lines:
+        lines.append("release contract checks passed.")
+    return "\n".join(lines) + "\n"

--- a/scripts/devlib/deps.py
+++ b/scripts/devlib/deps.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import ast
+import json
+
+from .common import DOCS_DEP_MAP_PATH, REPO_ROOT, SRC_ROOT, repo_relative
+
+
+HOTSPOT_MODULES = (
+    "dagzoo.core.execution_semantics",
+    "dagzoo.core.fixed_layout_batched",
+    "dagzoo.core.fixed_layout_runtime",
+    "dagzoo.core.layout",
+    "dagzoo.core.node_pipeline",
+    "dagzoo.core.dataset",
+    "dagzoo.core.config_resolution",
+    "dagzoo.core.generation_runtime",
+    "dagzoo.config",
+    "dagzoo.io.lineage_schema",
+)
+
+
+@dataclass(frozen=True)
+class ModuleSummary:
+    imports: tuple[str, ...]
+    direct_importers: tuple[str, ...]
+    transitive_importers: tuple[str, ...]
+    impacted_packages: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ImportGraph:
+    imports: dict[str, tuple[str, ...]]
+    reverse_imports: dict[str, tuple[str, ...]]
+    module_paths: dict[str, str]
+
+    @property
+    def modules(self) -> tuple[str, ...]:
+        return tuple(sorted(self.imports))
+
+    def package_graph(self) -> dict[str, set[str]]:
+        graph: dict[str, set[str]] = {}
+        for module, imports in self.imports.items():
+            package = module_to_package(module)
+            graph.setdefault(package, set())
+            for dependency in imports:
+                dependency_package = module_to_package(dependency)
+                if dependency_package != package:
+                    graph[package].add(dependency_package)
+                    graph.setdefault(dependency_package, set())
+        return graph
+
+    def transitive_importers(self, module: str) -> tuple[str, ...]:
+        visited: set[str] = set()
+        stack = list(self.reverse_imports.get(module, ()))
+        while stack:
+            current = stack.pop()
+            if current in visited:
+                continue
+            visited.add(current)
+            stack.extend(self.reverse_imports.get(current, ()))
+        return tuple(sorted(visited))
+
+    def module_summary(self, module: str) -> ModuleSummary:
+        direct_importers = self.reverse_imports.get(module, ())
+        transitive_importers = self.transitive_importers(module)
+        impacted_packages = sorted(
+            {
+                module_to_package(importer)
+                for importer in transitive_importers
+                if module_to_package(importer)
+                not in {module_to_package(module), "dagzoo", "dagzoo.__main__"}
+            }
+        )
+        return ModuleSummary(
+            imports=self.imports.get(module, ()),
+            direct_importers=direct_importers,
+            transitive_importers=transitive_importers,
+            impacted_packages=tuple(impacted_packages),
+        )
+
+    def module_to_path(self, module: str) -> str | None:
+        return self.module_paths.get(module)
+
+
+def module_to_package(module: str) -> str:
+    parts = module.split(".")
+    if len(parts) <= 2:
+        return module
+    return ".".join(parts[:2])
+
+
+def module_name_for_path(path: Path) -> str:
+    relative = path.relative_to(SRC_ROOT)
+    module = "dagzoo." + ".".join(relative.parts)
+    module = module[:-3] if module.endswith(".py") else module
+    if module.endswith(".__init__"):
+        module = module[:-9]
+    return module
+
+
+def path_to_module(path_str: str) -> str | None:
+    path = REPO_ROOT / path_str
+    if not path.is_relative_to(SRC_ROOT) or path.suffix != ".py":
+        return None
+    return module_name_for_path(path)
+
+
+def build_import_graph() -> ImportGraph:
+    module_paths: dict[str, str] = {}
+    known_modules: set[str] = set()
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        module = module_name_for_path(path)
+        module_paths[module] = repo_relative(path)
+        known_modules.add(module)
+
+    imports: dict[str, tuple[str, ...]] = {}
+    reverse_imports: dict[str, set[str]] = {module: set() for module in known_modules}
+    for module, path_str in module_paths.items():
+        path = REPO_ROOT / path_str
+        module_imports = tuple(sorted(_collect_imports(path, module, known_modules)))
+        imports[module] = module_imports
+        for dependency in module_imports:
+            reverse_imports.setdefault(dependency, set()).add(module)
+
+    return ImportGraph(
+        imports=imports,
+        reverse_imports={key: tuple(sorted(value)) for key, value in reverse_imports.items()},
+        module_paths=module_paths,
+    )
+
+
+def _collect_imports(path: Path, module: str, known_modules: set[str]) -> set[str]:
+    tree = ast.parse(path.read_text())
+    current_package = module if path.name == "__init__.py" else module.rsplit(".", 1)[0]
+    discovered: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                normalized = _normalize_import(alias.name, known_modules)
+                if normalized is not None and normalized != module:
+                    discovered.add(normalized)
+        elif isinstance(node, ast.ImportFrom):
+            for dependency in _normalize_import_from(node, current_package, known_modules):
+                if dependency != module:
+                    discovered.add(dependency)
+    return discovered
+
+
+def _normalize_import(candidate: str, known_modules: set[str]) -> str | None:
+    matches = [
+        module
+        for module in known_modules
+        if candidate == module or candidate.startswith(module + ".")
+    ]
+    if not matches:
+        return None
+    return max(matches, key=len)
+
+
+def _normalize_import_from(
+    node: ast.ImportFrom, current_package: str, known_modules: set[str]
+) -> set[str]:
+    if node.level == 0:
+        base_parts = ()
+    else:
+        current_parts = current_package.split(".")
+        if node.level == 1:
+            base_parts = tuple(current_parts)
+        else:
+            base_parts = tuple(current_parts[: -(node.level - 1)])
+    module_parts = tuple(node.module.split(".")) if node.module else ()
+    base_module = ".".join(base_parts + module_parts)
+    discovered: set[str] = set()
+    if base_module.startswith("dagzoo"):
+        normalized = _normalize_import(base_module, known_modules)
+        if normalized is not None:
+            discovered.add(normalized)
+    for alias in node.names:
+        if alias.name == "*":
+            continue
+        if base_module:
+            child_candidate = f"{base_module}.{alias.name}"
+        else:
+            child_candidate = alias.name
+        normalized_child = _normalize_import(child_candidate, known_modules)
+        if normalized_child is not None:
+            discovered.add(normalized_child)
+    return discovered
+
+
+def strongly_connected_components(graph: dict[str, set[str]]) -> list[tuple[str, ...]]:
+    index = 0
+    indices: dict[str, int] = {}
+    lowlinks: dict[str, int] = {}
+    stack: list[str] = []
+    on_stack: set[str] = set()
+    components: list[tuple[str, ...]] = []
+
+    def visit(node: str) -> None:
+        nonlocal index
+        indices[node] = index
+        lowlinks[node] = index
+        index += 1
+        stack.append(node)
+        on_stack.add(node)
+
+        for dependency in sorted(graph.get(node, ())):
+            if dependency not in indices:
+                visit(dependency)
+                lowlinks[node] = min(lowlinks[node], lowlinks[dependency])
+            elif dependency in on_stack:
+                lowlinks[node] = min(lowlinks[node], indices[dependency])
+
+        if lowlinks[node] != indices[node]:
+            return
+
+        component: list[str] = []
+        while stack:
+            current = stack.pop()
+            on_stack.remove(current)
+            component.append(current)
+            if current == node:
+                break
+        components.append(tuple(sorted(component)))
+
+    for node in sorted(graph):
+        if node not in indices:
+            visit(node)
+    return sorted(components, key=lambda component: (len(component), component))
+
+
+def condensation_graph(
+    graph: dict[str, set[str]],
+) -> tuple[list[tuple[str, ...]], dict[int, set[int]]]:
+    components = strongly_connected_components(graph)
+    index_by_node = {
+        node: component_index
+        for component_index, component in enumerate(components)
+        for node in component
+    }
+    condensed: dict[int, set[int]] = {index: set() for index in range(len(components))}
+    for node, dependencies in graph.items():
+        source_index = index_by_node[node]
+        for dependency in dependencies:
+            target_index = index_by_node[dependency]
+            if source_index != target_index:
+                condensed[source_index].add(target_index)
+    return components, condensed
+
+
+def topological_order(graph: dict[int, set[int]]) -> list[int]:
+    indegree = {node: 0 for node in graph}
+    for dependencies in graph.values():
+        for dependency in dependencies:
+            indegree[dependency] = indegree.get(dependency, 0) + 1
+    ready = sorted(node for node, degree in indegree.items() if degree == 0)
+    order: list[int] = []
+    while ready:
+        node = ready.pop(0)
+        order.append(node)
+        for dependency in sorted(graph.get(node, ())):
+            indegree[dependency] -= 1
+            if indegree[dependency] == 0:
+                ready.append(dependency)
+                ready.sort()
+    return order
+
+
+def package_dag_lines(graph: ImportGraph) -> list[str]:
+    package_graph = graph.package_graph()
+    components, condensed = condensation_graph(package_graph)
+    lines: list[str] = []
+    for component_index in topological_order(condensed):
+        component = components[component_index]
+        label = ", ".join(f"`{name}`" for name in component)
+        dependencies = [
+            ", ".join(f"`{name}`" for name in components[target_index])
+            for target_index in sorted(condensed[component_index])
+        ]
+        if dependencies:
+            lines.append(f"- {label} depends on {', '.join(dependencies)}")
+        else:
+            lines.append(f"- {label} has no internal package dependencies")
+    return lines
+
+
+def hotspot_summaries(
+    graph: ImportGraph, modules: tuple[str, ...] = HOTSPOT_MODULES
+) -> dict[str, ModuleSummary]:
+    return {module: graph.module_summary(module) for module in modules if module in graph.imports}
+
+
+def render_dependency_map_markdown(graph: ImportGraph) -> str:
+    lines = [
+        "# Module Dependency Map",
+        "",
+        "This file is generated from imports under `src/dagzoo`.",
+        "Run `./scripts/dev deps --write-docs` after changing internal module edges.",
+        "",
+        "## Package Dependency DAG",
+        "",
+        "The package graph below collapses strongly connected components so the result stays acyclic.",
+        "",
+        *package_dag_lines(graph),
+        "",
+        "## Change-Impact Hotspots",
+        "",
+        "The sections below list direct importers and full transitive downstream modules.",
+        "Use them to predict which runtime paths are likely to move when a hot module changes.",
+        "",
+    ]
+    for module, summary in hotspot_summaries(graph).items():
+        lines.extend(
+            [
+                f"### `{module}`",
+                "",
+                f"- Path: `{graph.module_to_path(module)}`",
+                f"- Imports: {_inline_list(summary.imports)}",
+                f"- Direct downstream modules: {_inline_list(summary.direct_importers)}",
+                f"- Transitive downstream modules: {_inline_list(summary.transitive_importers)}",
+                f"- Downstream package areas: {_inline_list(summary.impacted_packages)}",
+                "",
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _inline_list(values: tuple[str, ...]) -> str:
+    if not values:
+        return "none"
+    return ", ".join(f"`{value}`" for value in values)
+
+
+def render_scope_text(graph: ImportGraph, scope: str) -> str:
+    if scope == "package":
+        return "\n".join(package_dag_lines(graph)) + "\n"
+    if scope == "full":
+        payload = {
+            module: {
+                "imports": list(graph.imports[module]),
+                "imported_by": list(graph.reverse_imports.get(module, ())),
+            }
+            for module in graph.modules
+        }
+        return json.dumps(payload, indent=2) + "\n"
+    return render_dependency_map_markdown(graph)
+
+
+def render_scope_json(graph: ImportGraph, scope: str) -> str:
+    if scope == "package":
+        payload = {
+            package: sorted(dependencies) for package, dependencies in graph.package_graph().items()
+        }
+        return json.dumps(payload, indent=2) + "\n"
+    if scope == "full":
+        payload = {
+            module: {
+                "imports": list(graph.imports[module]),
+                "imported_by": list(graph.reverse_imports.get(module, ())),
+            }
+            for module in graph.modules
+        }
+        return json.dumps(payload, indent=2) + "\n"
+    payload = {
+        "package_dag": package_dag_lines(graph),
+        "hotspots": {
+            module: {
+                "imports": list(summary.imports),
+                "direct_downstream": list(summary.direct_importers),
+                "transitive_downstream": list(summary.transitive_importers),
+                "downstream_packages": list(summary.impacted_packages),
+            }
+            for module, summary in hotspot_summaries(graph).items()
+        },
+    }
+    return json.dumps(payload, indent=2) + "\n"
+
+
+def write_dependency_docs(graph: ImportGraph) -> str:
+    content = render_dependency_map_markdown(graph)
+    DOCS_DEP_MAP_PATH.write_text(content)
+    return content
+
+
+def dependency_docs_are_current(graph: ImportGraph) -> bool:
+    if not DOCS_DEP_MAP_PATH.exists():
+        return False
+    return DOCS_DEP_MAP_PATH.read_text() == render_dependency_map_markdown(graph)

--- a/scripts/devlib/doctor.py
+++ b/scripts/devlib/doctor.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import shutil
+import subprocess
+
+from .common import REPO_ROOT, venv_python
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str
+
+
+def run_doctor(mode: str) -> tuple[CheckResult, ...]:
+    checks: list[CheckResult] = []
+    if mode in {"code", "all"}:
+        checks.extend(_code_checks())
+    if mode in {"docs", "all"}:
+        checks.extend(_docs_checks())
+    return tuple(checks)
+
+
+def render_doctor_results(results: tuple[CheckResult, ...]) -> str:
+    lines = []
+    for result in results:
+        prefix = "ok" if result.ok else "missing"
+        lines.append(f"{prefix}: {result.name} - {result.detail}")
+    return "\n".join(lines) + "\n"
+
+
+def doctor_passed(results: tuple[CheckResult, ...]) -> bool:
+    return all(result.ok for result in results)
+
+
+def _code_checks() -> list[CheckResult]:
+    python_path = venv_python()
+    checks = [
+        CheckResult(
+            name=".venv",
+            ok=python_path.exists(),
+            detail=f"expected interpreter at {python_path.relative_to(REPO_ROOT)}",
+        ),
+        CheckResult(
+            name="uv",
+            ok=shutil.which("uv") is not None,
+            detail="install uv or ensure it is on PATH",
+        ),
+    ]
+    if python_path.exists():
+        result = subprocess.run(
+            (
+                str(python_path),
+                "-c",
+                "import sys; raise SystemExit(0 if sys.version_info >= (3, 13) else 1)",
+            ),
+            cwd=REPO_ROOT,
+            check=False,
+        )
+        checks.append(
+            CheckResult(
+                name="python>=3.13",
+                ok=result.returncode == 0,
+                detail="repo tooling expects Python 3.13+",
+            )
+        )
+        import_result = subprocess.run(
+            (str(python_path), "-c", "import dagzoo"),
+            cwd=REPO_ROOT,
+            check=False,
+        )
+        checks.append(
+            CheckResult(
+                name="import dagzoo",
+                ok=import_result.returncode == 0,
+                detail="run `uv sync --group dev` if the package is not installed into .venv",
+            )
+        )
+    return checks
+
+
+def _docs_checks() -> list[CheckResult]:
+    return [
+        CheckResult(
+            name="node", ok=shutil.which("node") is not None, detail="required for docs build"
+        ),
+        CheckResult(
+            name="npm", ok=shutil.which("npm") is not None, detail="required for docs dependencies"
+        ),
+        CheckResult(
+            name="go", ok=shutil.which("go") is not None, detail="required for Hugo modules"
+        ),
+        CheckResult(
+            name="hugo", ok=shutil.which("hugo") is not None, detail="required for docs site build"
+        ),
+    ]

--- a/scripts/devlib/impact.py
+++ b/scripts/devlib/impact.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import json
+import subprocess
+
+from .common import REPO_ROOT, repo_relative
+from .deps import ImportGraph, build_import_graph, module_to_package, path_to_module
+
+
+RELEASE_RISK_PATHS = (
+    "src/dagzoo/cli.py",
+    "src/dagzoo/config.py",
+    "src/dagzoo/core/config_resolution.py",
+    "src/dagzoo/core/metadata.py",
+    "src/dagzoo/core/dataset.py",
+    "src/dagzoo/core/fixed_layout_runtime.py",
+    "src/dagzoo/io/",
+    "configs/",
+)
+
+
+ARCHITECTURE_PATH_PREFIXES = (
+    "src/dagzoo/core/",
+    "src/dagzoo/functions/",
+    "src/dagzoo/converters/",
+    "src/dagzoo/sampling/",
+    "src/dagzoo/io/",
+    "src/dagzoo/filtering/",
+)
+
+
+@dataclass(frozen=True)
+class ImpactModuleSummary:
+    module: str
+    direct_downstream: tuple[str, ...]
+    transitive_downstream: tuple[str, ...]
+    downstream_packages: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ImpactReport:
+    changed_files: tuple[str, ...]
+    tags: tuple[str, ...]
+    changed_modules: tuple[str, ...]
+    module_summaries: tuple[ImpactModuleSummary, ...]
+    recommended_modes: tuple[str, ...]
+
+
+def detect_changed_files(
+    *, source: str = "working-tree", base: str | None = None, files: list[str] | None = None
+) -> tuple[str, ...]:
+    if files:
+        return tuple(sorted(dict.fromkeys(_normalize_files(files))))
+    if source == "working-tree":
+        result = subprocess.run(
+            ("git", "status", "--short"),
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr.strip() or "git status failed.")
+        changed_files = []
+        for line in result.stdout.splitlines():
+            if not line:
+                continue
+            changed_files.append(line[3:])
+        return tuple(sorted(dict.fromkeys(changed_files)))
+    if base is None:
+        raise ValueError("base is required when source is not working-tree.")
+    result = subprocess.run(
+        ("git", "diff", "--name-only", f"{base}...HEAD"),
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "git diff failed.")
+    return tuple(sorted(dict.fromkeys(_normalize_files(result.stdout.splitlines()))))
+
+
+def build_impact_report(
+    changed_files: tuple[str, ...], graph: ImportGraph | None = None
+) -> ImpactReport:
+    graph = build_import_graph() if graph is None else graph
+    tags = classify_tags(changed_files)
+    changed_modules = tuple(
+        sorted(module for path in changed_files if (module := path_to_module(path)) is not None)
+    )
+    module_summaries = tuple(
+        ImpactModuleSummary(
+            module=module,
+            direct_downstream=graph.reverse_imports.get(module, ()),
+            transitive_downstream=graph.transitive_importers(module),
+            downstream_packages=tuple(
+                sorted(
+                    {
+                        module_to_package(importer)
+                        for importer in graph.transitive_importers(module)
+                        if module_to_package(importer)
+                        not in {module_to_package(module), "dagzoo", "dagzoo.__main__"}
+                    }
+                )
+            ),
+        )
+        for module in changed_modules
+    )
+    return ImpactReport(
+        changed_files=changed_files,
+        tags=tags,
+        changed_modules=changed_modules,
+        module_summaries=module_summaries,
+        recommended_modes=recommend_modes(tags, module_summaries),
+    )
+
+
+def classify_tags(changed_files: tuple[str, ...]) -> tuple[str, ...]:
+    tags: set[str] = set()
+    for path in changed_files:
+        if (
+            path == "README.md"
+            or path.startswith("docs/")
+            or path.startswith("site/")
+            or path.startswith("scripts/docs/")
+        ):
+            tags.add("docs")
+        if (
+            path.startswith("src/dagzoo/")
+            or path.startswith("tests/")
+            or path
+            in (
+                "pyproject.toml",
+                ".pre-commit-config.yaml",
+            )
+        ):
+            tags.add("code")
+        if (
+            path.startswith("src/dagzoo/bench/")
+            or path.startswith("configs/benchmark")
+            or path.startswith("benchmarks/baselines/")
+            or path.startswith("scripts/benchmark")
+        ):
+            tags.add("bench")
+        if path.startswith(ARCHITECTURE_PATH_PREFIXES):
+            tags.add("architecture")
+        if path.startswith(RELEASE_RISK_PATHS):
+            tags.add("release-risk")
+        if (
+            path.startswith("scripts/")
+            or path.startswith(".github/workflows/")
+            or path == "AGENTS.md"
+        ):
+            tags.add("tooling")
+    return tuple(sorted(tags))
+
+
+def recommend_modes(
+    tags: tuple[str, ...], module_summaries: tuple[ImpactModuleSummary, ...]
+) -> tuple[str, ...]:
+    recommended: list[str] = []
+    impacted_packages = {
+        package for summary in module_summaries for package in summary.downstream_packages
+    }
+    if "docs" in tags and tags == ("docs",):
+        return ("docs",)
+    recommended.append("quick")
+    if "code" in tags:
+        recommended.append("code")
+    if "docs" in tags:
+        recommended.append("docs")
+    if "bench" in tags or "dagzoo.bench" in impacted_packages:
+        recommended.append("bench")
+    return tuple(dict.fromkeys(recommended))
+
+
+def render_text(report: ImpactReport) -> str:
+    lines = [
+        "Changed files:",
+        *[f"- `{path}`" for path in report.changed_files],
+        "",
+        "Tags:",
+        f"- {', '.join(f'`{tag}`' for tag in report.tags) if report.tags else 'none'}",
+        "",
+        "Recommended verify modes:",
+        f"- {', '.join(f'`{mode}`' for mode in report.recommended_modes) if report.recommended_modes else 'none'}",
+    ]
+    if report.module_summaries:
+        lines.extend(["", "Module impact:"])
+        for summary in report.module_summaries:
+            direct = ", ".join(f"`{module}`" for module in summary.direct_downstream) or "none"
+            transitive = (
+                ", ".join(f"`{module}`" for module in summary.transitive_downstream) or "none"
+            )
+            packages = (
+                ", ".join(f"`{package}`" for package in summary.downstream_packages) or "none"
+            )
+            lines.extend(
+                [
+                    f"- `{summary.module}`",
+                    f"  direct downstream: {direct}",
+                    f"  transitive downstream: {transitive}",
+                    f"  downstream packages: {packages}",
+                ]
+            )
+    return "\n".join(lines) + "\n"
+
+
+def render_json(report: ImpactReport) -> str:
+    payload = {
+        "changed_files": list(report.changed_files),
+        "tags": list(report.tags),
+        "recommended_modes": list(report.recommended_modes),
+        "modules": [
+            {
+                "module": summary.module,
+                "direct_downstream": list(summary.direct_downstream),
+                "transitive_downstream": list(summary.transitive_downstream),
+                "downstream_packages": list(summary.downstream_packages),
+            }
+            for summary in report.module_summaries
+        ],
+    }
+    return json.dumps(payload, indent=2) + "\n"
+
+
+def _normalize_files(files: list[str]) -> list[str]:
+    normalized: list[str] = []
+    for file_str in files:
+        if not file_str:
+            continue
+        path = Path(file_str)
+        if path.is_absolute():
+            normalized.append(repo_relative(path))
+        else:
+            normalized.append(path.as_posix())
+    return normalized

--- a/scripts/devlib/verify.py
+++ b/scripts/devlib/verify.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .common import CommandSpec, DevToolError, format_command, python_tool, run_command
+from .contract import evaluate_release_contract, render_contract_result
+from .deps import build_import_graph, dependency_docs_are_current
+from .doctor import doctor_passed, render_doctor_results, run_doctor
+from .impact import ImpactReport, build_impact_report, detect_changed_files
+
+
+@dataclass(frozen=True)
+class VerifyPlan:
+    headline: str
+    commands: tuple[CommandSpec, ...]
+    report: ImpactReport
+
+
+def build_verify_plan(
+    *,
+    mode: str,
+    source: str,
+    base: str | None,
+    files: list[str] | None,
+    incremental: bool,
+    parallel: bool,
+) -> VerifyPlan:
+    changed_files = detect_changed_files(source=source, base=base, files=files)
+    graph = build_import_graph()
+    report = build_impact_report(changed_files, graph=graph)
+    docs_only = bool(report.tags) and set(report.tags).issubset({"docs", "tooling"})
+
+    commands: list[CommandSpec] = []
+    headline = f"verify {mode}"
+    if mode in {"quick", "code", "full"} and not docs_only:
+        commands.extend(_code_quick_commands(report, graph_changed=bool(report.changed_modules)))
+    if mode in {"docs", "full"} or docs_only:
+        commands.extend(_docs_commands())
+    if mode in {"code", "full"} and not docs_only:
+        commands.extend(_pytest_commands(incremental=incremental, parallel=parallel))
+    if mode in {"bench", "full"}:
+        commands.extend(_bench_commands())
+    if mode == "quick" and docs_only:
+        headline = "verify quick (docs-only change set)"
+    return VerifyPlan(headline=headline, commands=tuple(commands), report=report)
+
+
+def execute_verify_plan(plan: VerifyPlan, *, dry_run: bool) -> str:
+    lines = [
+        plan.headline,
+        "recommended modes: "
+        + (", ".join(plan.report.recommended_modes) if plan.report.recommended_modes else "none"),
+    ]
+    code_results = run_doctor("code")
+    needs_code_doctor = any(not command.label.startswith("docs") for command in plan.commands)
+    if needs_code_doctor and not doctor_passed(code_results):
+        raise DevToolError(render_doctor_results(code_results).strip())
+    if "docs" in plan.report.tags:
+        docs_results = run_doctor("docs")
+        if any(command.label.startswith("docs") for command in plan.commands) and not doctor_passed(
+            docs_results
+        ):
+            raise DevToolError(render_doctor_results(docs_results).strip())
+
+    contract_result = evaluate_release_contract(plan.report)
+    if contract_result.warnings:
+        lines.extend(contract_result.warnings)
+    if contract_result.errors:
+        raise DevToolError(render_contract_result(contract_result).strip())
+
+    if any(command.label == "dependency map freshness" for command in plan.commands):
+        if not dependency_docs_are_current(build_import_graph()):
+            raise DevToolError(
+                "dependency map docs are stale; run `./scripts/dev deps --write-docs`."
+            )
+
+    if dry_run:
+        lines.extend(f"dry-run: {format_command(command.argv)}" for command in plan.commands)
+        return "\n".join(lines) + "\n"
+
+    for command in plan.commands:
+        run_command(command)
+    lines.extend(f"ran: {format_command(command.argv)}" for command in plan.commands)
+    return "\n".join(lines) + "\n"
+
+
+def _code_quick_commands(report: ImpactReport, *, graph_changed: bool) -> list[CommandSpec]:
+    commands = [
+        CommandSpec(
+            label="ruff check", argv=(python_tool("ruff"), "check", "src", "tests", "scripts")
+        ),
+        CommandSpec(
+            label="ruff format",
+            argv=(python_tool("ruff"), "format", "--check", "src", "tests", "scripts"),
+        ),
+        CommandSpec(label="mypy", argv=(python_tool("mypy"), "src")),
+        CommandSpec(label="deptry", argv=(python_tool("deptry"), ".")),
+    ]
+    if "architecture" in report.tags:
+        commands.append(CommandSpec(label="import-linter", argv=(python_tool("lint-imports"),)))
+    if graph_changed:
+        commands.append(
+            CommandSpec(label="dependency map freshness", argv=("./scripts/dev", "deps", "--check"))
+        )
+    return commands
+
+
+def _docs_commands() -> list[CommandSpec]:
+    python = python_tool("python")
+    return [
+        CommandSpec(
+            label="docs sync",
+            argv=(python, "scripts/docs/sync_hugo_content.py"),
+        ),
+        CommandSpec(
+            label="docs sync check",
+            argv=(python, "scripts/docs/sync_hugo_content.py", "--check"),
+        ),
+        CommandSpec(
+            label="docs links",
+            argv=(python, "scripts/docs/check_links.py"),
+        ),
+        CommandSpec(
+            label="docs build",
+            argv=("hugo", "--source", "site", "--minify", "--gc", "--destination", "public"),
+        ),
+        CommandSpec(
+            label="docs built links",
+            argv=(python, "scripts/docs/check_built_output_links.py", "site/public"),
+        ),
+    ]
+
+
+def _pytest_commands(*, incremental: bool, parallel: bool) -> list[CommandSpec]:
+    argv = [python_tool("pytest")]
+    if incremental:
+        argv.append("--testmon")
+    argv.append("-q")
+    if parallel:
+        argv.extend(("-n", "auto"))
+    return [CommandSpec(label="pytest", argv=tuple(argv))]
+
+
+def _bench_commands() -> list[CommandSpec]:
+    return [
+        CommandSpec(
+            label="bench smoke",
+            argv=(
+                python_tool("dagzoo"),
+                "benchmark",
+                "--suite",
+                "smoke",
+                "--preset",
+                "cpu",
+                "--baseline",
+                "benchmarks/baselines/cpu_smoke.json",
+                "--warn-threshold-pct",
+                "10",
+                "--fail-threshold-pct",
+                "20",
+                "--fail-on-regression",
+                "--hardware-policy",
+                "none",
+                "--no-memory",
+                "--out-dir",
+                "benchmarks/results/dev_smoke",
+            ),
+        )
+    ]

--- a/tests/test_dev_tooling.py
+++ b/tests/test_dev_tooling.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_ROOT = REPO_ROOT / "scripts"
+
+
+def _import_dev_module(module_name: str):
+    if str(SCRIPTS_ROOT) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_ROOT))
+    return importlib.import_module(module_name)
+
+
+def _load_dev_cli():
+    module_name = "repo_dev_cli"
+    script_path = SCRIPTS_ROOT / "dev.py"
+    spec = importlib.util.spec_from_file_location(module_name, script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_dependency_graph_hotspot_captures_execution_semantics_cascade() -> None:
+    deps_module = _import_dev_module("devlib.deps")
+
+    graph = deps_module.build_import_graph()
+    summary = graph.module_summary("dagzoo.core.execution_semantics")
+
+    assert "dagzoo.core.fixed_layout_batched" in summary.direct_importers
+    assert "dagzoo.core.node_pipeline" in summary.direct_importers
+    assert "dagzoo.functions.random_functions" in summary.direct_importers
+    assert "dagzoo.functions.multi" in summary.direct_importers
+    assert "dagzoo.converters.numeric" in summary.direct_importers
+    assert "dagzoo.converters.categorical" in summary.direct_importers
+    assert "dagzoo.sampling.random_points" in summary.direct_importers
+    assert "dagzoo.core.fixed_layout_runtime" in summary.transitive_importers
+    assert "dagzoo.bench" in summary.impacted_packages
+    assert "dagzoo.cli" in summary.impacted_packages
+
+
+def test_render_dependency_map_includes_hotspot_example() -> None:
+    deps_module = _import_dev_module("devlib.deps")
+
+    content = deps_module.render_dependency_map_markdown(deps_module.build_import_graph())
+
+    assert "## Change-Impact Hotspots" in content
+    assert "### `dagzoo.core.execution_semantics`" in content
+    assert "dagzoo.core.fixed_layout_batched" in content
+    assert "dagzoo.core.fixed_layout_runtime" in content
+
+
+def test_write_dependency_docs_and_check_current(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    deps_module = _import_dev_module("devlib.deps")
+    target = tmp_path / "module-dependency-map.md"
+    monkeypatch.setattr(deps_module, "DOCS_DEP_MAP_PATH", target)
+
+    graph = deps_module.build_import_graph()
+    deps_module.write_dependency_docs(graph)
+
+    assert target.exists()
+    assert deps_module.dependency_docs_are_current(graph) is True
+
+    target.write_text(target.read_text() + "\nextra\n")
+
+    assert deps_module.dependency_docs_are_current(graph) is False
+
+
+def test_impact_report_flags_execution_semantics_as_architecture_and_bench() -> None:
+    impact_module = _import_dev_module("devlib.impact")
+
+    report = impact_module.build_impact_report(("src/dagzoo/core/execution_semantics.py",))
+
+    assert report.tags == ("architecture", "code")
+    assert report.recommended_modes == ("quick", "code", "bench")
+    assert report.module_summaries[0].module == "dagzoo.core.execution_semantics"
+    assert "dagzoo.bench" in report.module_summaries[0].downstream_packages
+
+
+def test_release_contract_requires_version_and_changelog_for_release_risk() -> None:
+    impact_module = _import_dev_module("devlib.impact")
+    contract_module = _import_dev_module("devlib.contract")
+
+    report = impact_module.build_impact_report(("src/dagzoo/cli.py",))
+    result = contract_module.evaluate_release_contract(report)
+
+    assert result.ok is False
+    assert "pyproject.toml" in result.errors[0]
+    assert "CHANGELOG.md" in result.errors[0]
+
+
+def test_release_contract_warns_for_internal_code_change() -> None:
+    impact_module = _import_dev_module("devlib.impact")
+    contract_module = _import_dev_module("devlib.contract")
+
+    report = impact_module.build_impact_report(("src/dagzoo/functions/activations.py",))
+    result = contract_module.evaluate_release_contract(report)
+
+    assert result.ok is True
+    assert result.warnings
+    assert "Internal-only refactors" in result.warnings[0]
+
+
+def test_pyproject_change_alone_does_not_trigger_release_risk_contract() -> None:
+    impact_module = _import_dev_module("devlib.impact")
+    contract_module = _import_dev_module("devlib.contract")
+
+    report = impact_module.build_impact_report(("pyproject.toml",))
+    result = contract_module.evaluate_release_contract(report)
+
+    assert "release-risk" not in report.tags
+    assert result.ok is True
+    assert result.warnings == ()
+
+
+def test_verify_plan_docs_only_uses_docs_commands() -> None:
+    verify_module = _import_dev_module("devlib.verify")
+
+    plan = verify_module.build_verify_plan(
+        mode="quick",
+        source="working-tree",
+        base=None,
+        files=["README.md"],
+        incremental=False,
+        parallel=False,
+    )
+
+    assert plan.headline == "verify quick (docs-only change set)"
+    assert all(command.label.startswith("docs") for command in plan.commands)
+
+
+def test_verify_plan_code_includes_incremental_parallel_pytest_and_architecture_checks() -> None:
+    verify_module = _import_dev_module("devlib.verify")
+
+    plan = verify_module.build_verify_plan(
+        mode="code",
+        source="working-tree",
+        base=None,
+        files=["src/dagzoo/core/layout.py"],
+        incremental=True,
+        parallel=True,
+    )
+
+    labels = [command.label for command in plan.commands]
+    assert "ruff check" in labels
+    assert "mypy" in labels
+    assert "deptry" in labels
+    assert "import-linter" in labels
+    pytest_command = next(command for command in plan.commands if command.label == "pytest")
+    assert "--testmon" in pytest_command.argv
+    assert "-n" in pytest_command.argv
+    assert "auto" in pytest_command.argv
+
+
+def test_verify_execute_dry_run_lists_commands(monkeypatch: pytest.MonkeyPatch) -> None:
+    verify_module = _import_dev_module("devlib.verify")
+    contract_module = _import_dev_module("devlib.contract")
+
+    plan = verify_module.build_verify_plan(
+        mode="quick",
+        source="working-tree",
+        base=None,
+        files=["src/dagzoo/core/layout.py"],
+        incremental=False,
+        parallel=False,
+    )
+
+    monkeypatch.setattr(verify_module, "run_doctor", lambda mode: ())
+    monkeypatch.setattr(verify_module, "doctor_passed", lambda results: True)
+    monkeypatch.setattr(
+        verify_module,
+        "evaluate_release_contract",
+        lambda report: contract_module.ContractResult(ok=True, warnings=(), errors=()),
+    )
+    monkeypatch.setattr(verify_module, "dependency_docs_are_current", lambda graph: True)
+
+    output = verify_module.execute_verify_plan(plan, dry_run=True)
+
+    assert "dry-run:" in output
+    assert "ruff check" in output
+    assert "deptry" in output
+
+
+def test_dev_cli_help_exposes_new_commands(capsys: pytest.CaptureFixture[str]) -> None:
+    module = _load_dev_cli()
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main(["--help"])
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert "doctor" in captured.out
+    assert "deps" in captured.out
+    assert "impact" in captured.out
+    assert "contract" in captured.out
+    assert "verify" in captured.out

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274 },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -125,12 +137,16 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "deptry" },
+    { name = "import-linter" },
     { name = "mdformat" },
     { name = "mdformat-gfm" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-testmon" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "types-pyyaml" },
     { name = "vulture" },
@@ -147,15 +163,41 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "deptry", specifier = ">=0.23" },
+    { name = "import-linter", specifier = ">=2.3" },
     { name = "mdformat", specifier = ">=0.7" },
     { name = "mdformat-gfm", specifier = ">=0.4" },
     { name = "mypy", specifier = ">=1.11" },
     { name = "pre-commit", specifier = ">=3.8" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=6.0" },
+    { name = "pytest-testmon", specifier = ">=2.1" },
+    { name = "pytest-xdist", specifier = ">=3.6" },
     { name = "ruff", specifier = ">=0.6" },
     { name = "types-pyyaml" },
     { name = "vulture", specifier = ">=2.14" },
+]
+
+[[package]]
+name = "deptry"
+version = "0.24.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "packaging" },
+    { name = "requirements-parser" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/aa/5cae0f25a2ac5334d5bd2782a6bcd80eecf184f433ff74b2fb0387cfbbb6/deptry-0.24.0.tar.gz", hash = "sha256:852e88af2087e03cdf9ece6916f3f58b74191ab51cc8074897951bd496ee7dbb", size = 440158 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/5a/c1552996499911b6eabe874a994d9eede58ac3936d7fe7f865857b97c03f/deptry-0.24.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a575880146bab671a62babb9825b85b4f1bda8aeaade4fcb59f9262caf91d6c7", size = 1774138 },
+    { url = "https://files.pythonhosted.org/packages/32/b6/1dcc011fc3e6eec71601569c9de3215530563412b3714fba80dcd1a88ec8/deptry-0.24.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:00ec34b968a13c03a5268ce0211f891ace31851d916415e0a748fae9596c00d5", size = 1677340 },
+    { url = "https://files.pythonhosted.org/packages/4a/e2/af81dfd46b457be9e8ded9472872141777fbda8af661f5d509157b165359/deptry-0.24.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ddfedafafe5cbfce31a50d4ea99d7b9074edcd08b9b94350dc739e2fb6ed7f9", size = 1782740 },
+    { url = "https://files.pythonhosted.org/packages/ab/28/960c311aae084deef57ece41aac13cb359b06ce31b7771139e79c394a1b7/deptry-0.24.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd22fa2dbbdf4b38061ca9504f2a6ce41ec14fa5c9fe9b0b763ccc1275efebd5", size = 1845477 },
+    { url = "https://files.pythonhosted.org/packages/f5/6c/4b972b011a06611e0cf8f4bb6bc04a3d0f9c651950ad9abe320fcbac6983/deptry-0.24.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:0fbe50a2122d79cec53fdfd73a7092c05f316555a1139bcbacf3432572675977", size = 1960410 },
+    { url = "https://files.pythonhosted.org/packages/1b/08/0eac3c72a9fd79a043cc492f3ba350c47a7be2160288353218b2c8c1bf3a/deptry-0.24.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:92bd8d331a5a6f8e6247436bc6fe384bcf86a8d69fe33442d195996fb9b20547", size = 2023832 },
+    { url = "https://files.pythonhosted.org/packages/35/e4/23dcbc505f6f35c70ba68015774cf891ceda080331d7fd6d75e84ada9f73/deptry-0.24.0-cp39-abi3-win_amd64.whl", hash = "sha256:94b354848130d45e16d3a3039ae8177bce33828f62028c4ff8f2e1b04f7182ba", size = 1631631 },
+    { url = "https://files.pythonhosted.org/packages/39/69/6ec1e18e27dd6f80e4fb6c5fc05a6527242ff83b81c0711d0ba470e9a144/deptry-0.24.0-cp39-abi3-win_arm64.whl", hash = "sha256:ea58709e5f3aa77c0737d8fb76166b7703201cf368fbbb14072ccda968b6703a", size = 1550504 },
 ]
 
 [[package]]
@@ -165,6 +207,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047 },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708 },
 ]
 
 [[package]]
@@ -186,12 +237,82 @@ wheels = [
 ]
 
 [[package]]
+name = "grimp"
+version = "3.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/46/79764cfb61a3ac80dadae5d94fb10acdb7800e31fecf4113cf3d345e4952/grimp-3.14.tar.gz", hash = "sha256:645fbd835983901042dae4e1b24fde3a89bf7ac152f9272dd17a97e55cb4f871", size = 830882 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/bd/d12a9c821b79ba31fc52243e564712b64140fc6d011c2bdbb483d9092a12/grimp-3.14-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af8a625554beea84530b98cc471902155b5fc042b42dc47ec846fa3e32b0c615", size = 2178632 },
+    { url = "https://files.pythonhosted.org/packages/96/8c/d6620dbc245149d5a5a7a9342733556ba91a672f358259c0ab31d889b56b/grimp-3.14-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0dd1942ffb419ad342f76b0c3d3d2d7f312b264ddc578179d13ce8d5acec1167", size = 2110288 },
+    { url = "https://files.pythonhosted.org/packages/60/9d/ea51edc4eb295c99786040051c66466bfa235fd1def9f592057b36e03d0f/grimp-3.14-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:537f784ce9b4acf8657f0b9714ab69a6c72ffa752eccc38a5a85506103b1a194", size = 2282197 },
+    { url = "https://files.pythonhosted.org/packages/28/6e/7db27818ced6a797f976ca55d981a3af5c12aec6aeda12d63965847cd028/grimp-3.14-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:78ab18c08770aa005bef67b873bc3946d33f65727e9f3e508155093db5fa57d6", size = 2235720 },
+    { url = "https://files.pythonhosted.org/packages/37/26/0e3bbae4826bd6eaabf404738400414071e73ddb1e65bf487dcce17858c4/grimp-3.14-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:28ca58728c27e7292c99f964e6ece9295c2f9cfdefc37c18dea0679c783ffb6f", size = 2393023 },
+    { url = "https://files.pythonhosted.org/packages/49/f2/7da91db5703da34c7ef4c7cddcbb1a8fc30cd85fe54756eba942c6fb27d8/grimp-3.14-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9b5577de29c6c5ae6e08d4ca0ac361b45dba323aa145796e6b320a6ea35414b7", size = 2571108 },
+    { url = "https://files.pythonhosted.org/packages/25/5e/4d6278f18032c7208696edf8be24a4b5f7fad80acc20ffca737344bcecb5/grimp-3.14-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5d7d1f9f42306f455abcec34db877e4887ff15f2777a43491f7ccbd6936c449b", size = 2358531 },
+    { url = "https://files.pythonhosted.org/packages/24/fb/231c32493161ac82f27af6a56965daefa0ec6030fdaf5b948ddd5d68d000/grimp-3.14-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39bd5c9b7cef59ee30a05535e9cb4cbf45a3c503f22edce34d0aa79362a311a9", size = 2308831 },
+    { url = "https://files.pythonhosted.org/packages/27/70/f6db325bf5efbbebc9c85cad0af865e821a12a0ba58ee309e938cbd5fedf/grimp-3.14-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7fec3116b4f780a1bc54176b19e6b9f2e36e2ef3164b8fc840660566af35df88", size = 2462138 },
+    { url = "https://files.pythonhosted.org/packages/41/2e/cc3fe29cf07f70364018086840c228a190539ab8105147e34588db590792/grimp-3.14-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:0233a35a5bbb23688d63e1736b54415fa9994ace8dfeb7de8514ed9dee212968", size = 2501393 },
+    { url = "https://files.pythonhosted.org/packages/e5/eb/54cada9a726455148da23f64577b5cd164164d23a6449e3fa14551157356/grimp-3.14-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e46b2fef0f1da7e7e2f8129eb93c7e79db716ff7810140a22ce5504e10ed86df", size = 2504514 },
+    { url = "https://files.pythonhosted.org/packages/e8/c7/e6afe4f0652df07e8762f61899d1202b73c22c559c804d0a09e5aab2ff17/grimp-3.14-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3e6d9b50623ee1c3d2a1927ec3f5d408995ea1f92f3e91ed996c908bb40e856f", size = 2514018 },
+    { url = "https://files.pythonhosted.org/packages/75/13/2b8550acc1f010301f02c4fe9664810929fd9277cd032ab608b8534a96fb/grimp-3.14-cp313-cp313-win32.whl", hash = "sha256:fd57c56f5833c99320ec77e8ba5508d56f6fb48ec8032a942f7931cc6ebb80ce", size = 1874922 },
+    { url = "https://files.pythonhosted.org/packages/46/c7/bc9db5a54ef22972cd17d15ad80a8fee274a471bd3f02300405702d29ea5/grimp-3.14-cp313-cp313-win_amd64.whl", hash = "sha256:173307cf881a126fe5120b7bbec7d54384002e3c83dcd8c4df6ce7f0fee07c53", size = 2013705 },
+    { url = "https://files.pythonhosted.org/packages/80/7e/02710bf5e50997168c84ac622b10dd41d35515efd0c67549945ad20996a0/grimp-3.14-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebe29f8f13fbd7c314908ed535183a36e6db71839355b04869b27f23c58fa082", size = 2281868 },
+    { url = "https://files.pythonhosted.org/packages/15/88/2e440c6762cc78bd50582e1b092357d2255f0852ccc6218d8db25170ab31/grimp-3.14-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:073d285b00100153fd86064c7726bb1b6d610df1356d33bb42d3fd8809cb6e72", size = 2230917 },
+    { url = "https://files.pythonhosted.org/packages/a0/bb/2e7dce129b88f07fc525fe5c97f28cfb7ed7b62c59386d39226b4d08969c/grimp-3.14-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f6d6efc37e1728bbfcd881b89467be5f7b046292597b3ebe5f8e44e89ea8b6cb", size = 2571371 },
+    { url = "https://files.pythonhosted.org/packages/b5/2b/8f1be8294af60c953687db7dec25525d87ed9c2aa26b66dcbe5244abaca2/grimp-3.14-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5337d65d81960b712574c41e85b480d4480bbb5c6f547c94e634f6c60d730889", size = 2356980 },
+    { url = "https://files.pythonhosted.org/packages/35/ca/ead91e04b3ddd4774ae74601860ea0f0f21bcf6b970b6769ba9571eb2904/grimp-3.14-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:84a7fea63e352b325daa89b0b7297db411b7f0036f8d710c32f8e5090e1fc3ca", size = 2461540 },
+    { url = "https://files.pythonhosted.org/packages/94/aa/f8a085ff73c37d6e6a37de9f58799a3fea9e16badf267aaef6f11c9a53a3/grimp-3.14-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:d0b19a3726377165fe1f7184a8af317734d80d32b371b6c5578747867ab53c0b", size = 2497925 },
+    { url = "https://files.pythonhosted.org/packages/5a/a3/db3c2d6df07fe74faf5a28fcf3b44fad2831d323ba4a3c2ff66b77a6520c/grimp-3.14-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:9caa4991f530750f88474a3f5ecf6ef9f0d064034889d92db00cfb4ecb78aa24", size = 2501794 },
+    { url = "https://files.pythonhosted.org/packages/e5/de/095f4e3765e7b60425a41e9fbd2b167f8b0acb957cc88c387f631778a09d/grimp-3.14-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:1876efc119b99332a5cc2b08a6bdaada2f0ad94b596f0372a497e2aa8bda4d94", size = 2515203 },
+    { url = "https://files.pythonhosted.org/packages/c6/5f/ee02a3a1237282d324f596a50923bf9d2cb1b1230ef2fef49fb4d3563c2c/grimp-3.14-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3ccf03e65864d6bc7bf1c003c319f5330a7627b3677f31143f11691a088464c2", size = 2177150 },
+    { url = "https://files.pythonhosted.org/packages/f2/64/2a92889e5fc78e8ef5c548e6a5c6fed78b817eeb0253aca586c28108393a/grimp-3.14-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9ecd58fa58a270e7523f8bec9e6452f4fdb9c21e4cd370640829f1e43fa87a69", size = 2109280 },
+    { url = "https://files.pythonhosted.org/packages/69/02/5d0b9ab54821e7fbdeb02f3919fa2cb8b9f0c3869fa6e4b969a5766f0ffa/grimp-3.14-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d75d1f8f7944978b39b08d870315174f1ffcd5123be6ccff8ce90467ace648a", size = 2283367 },
+    { url = "https://files.pythonhosted.org/packages/c2/96/a77c40c92faf7500f42ac019ab8de108b04ffe3db8ec8d6f90416d2322ce/grimp-3.14-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6f70bbb1dd6055d08d29e39a78a11c4118c1778b39d17cd8271e18e213524ca7", size = 2237125 },
+    { url = "https://files.pythonhosted.org/packages/6a/5e/3e1483721c83057bff921cf454dd5ff3e661ae1d2e63150a380382d116c2/grimp-3.14-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0f21b7c003626c902669dc26ede83a91220cf0a81b51b27128370998c2f247b4", size = 2391735 },
+    { url = "https://files.pythonhosted.org/packages/d0/cb/25fad4a174fe672d42f3e5616761a8120a3b03c8e9e2ae3f31159561968a/grimp-3.14-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:80d9f056415c936b45561310296374c4319b5df0003da802c84d2830a103792a", size = 2571388 },
+    { url = "https://files.pythonhosted.org/packages/29/7e/456df7f6a765ce3f160eb32a0f64ed0c1c3cd39b518555dde02087f9b6e4/grimp-3.14-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0332963cd63a45863775d4237e59dedf95455e0a1ea50c356be23100c5fc1d7c", size = 2359637 },
+    { url = "https://files.pythonhosted.org/packages/7c/98/3e5005ef21a4e2243f0da489aba86aaaff0bc11d5240d67113482cba88e0/grimp-3.14-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f4144350d074f2058fe7c89230a26b34296b161f085b0471a692cb2fe27036f", size = 2308335 },
+    { url = "https://files.pythonhosted.org/packages/8a/03/4e055f756946d6f71ab7e9d1f8536a9e476777093dd7a050f40412d1a2b1/grimp-3.14-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e148e67975e92f90a8435b1b4c02180b9a3f3d725b7a188ba63793f1b1e445a0", size = 2463680 },
+    { url = "https://files.pythonhosted.org/packages/26/b9/3c76b7c2e1587e4303a6eff6587c2117c3a7efe1b100cd13d8a4a5613572/grimp-3.14-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1093f7770cb5f3ca6f99fb152f9c949381cc0b078dfdfe598c8ab99abaccda3b", size = 2502808 },
+    { url = "https://files.pythonhosted.org/packages/20/80/ada10b85ad3125ebedea10256d9c568b6bf28339d2f79d2d196a7b94f633/grimp-3.14-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a213f45ec69e9c2b28ffd3ba5ab12cc9859da17083ba4dc39317f2083b618111", size = 2504013 },
+    { url = "https://files.pythonhosted.org/packages/05/45/7c369f749d50b0ceac23cd6874ca4695cc1359a96091c7010301e5c8b619/grimp-3.14-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f003ac3f226d2437a49af0b6036f26edba57f8a32d329275dbde1b2b2a00a56", size = 2515043 },
+    { url = "https://files.pythonhosted.org/packages/5c/32/85135fe83826ce11ae56a340d32a1391b91eed94d25ce7bc318019f735de/grimp-3.14-cp314-cp314-win32.whl", hash = "sha256:eec81be65a18f4b2af014b1e97296cc9ee20d1115529bf70dd7e06f457eac30b", size = 1877509 },
+    { url = "https://files.pythonhosted.org/packages/db/61/e4a2234edecb3bb3cff8963bc4ec5cc482a9e3c54f8df0946d7d90003830/grimp-3.14-cp314-cp314-win_amd64.whl", hash = "sha256:cd3bab6164f1d5e313678f0ab4bf45955afe7f5bdb0f2f481014aa9cca7e81ba", size = 2014364 },
+    { url = "https://files.pythonhosted.org/packages/16/be/3d304443fbf1df4d60c09668846d0c8a605c6c95646226e41d8f5c3254da/grimp-3.14-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b1df33de479be4d620f69633d1876858a8e64a79c07907d47cf3aaf896af057", size = 2281385 },
+    { url = "https://files.pythonhosted.org/packages/fe/13/493e2648dbb83b3fc517ee675e464beb0154551d726053c7982a3138c6a8/grimp-3.14-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07096d4402e9d5a2c59c402ea3d601f4b7f99025f5e32f077468846fc8d3821b", size = 2231470 },
+    { url = "https://files.pythonhosted.org/packages/80/84/e772b302385a6b7ec752c88f84ffe35c33d14076245ae27a635aed9c63a2/grimp-3.14-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:712bc28f46b354316af50c469c77953ba3d6cb4166a62b8fb086436a8b05d301", size = 2571579 },
+    { url = "https://files.pythonhosted.org/packages/69/92/5b23aa7b89c5f4f2cfa636cbeaf33e784378a6b0a823d77a3448670dfacc/grimp-3.14-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:abe2bbef1cf8e27df636c02f60184319f138dee4f3a949405c21a4b491980397", size = 2356545 },
+    { url = "https://files.pythonhosted.org/packages/15/af/bcf2116f4b1c3939ab35f9cdddd9ca59e953e57e9a0ac0c143deaf9f29cc/grimp-3.14-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2f9ae3fabb7a7a8468ddc96acc84ecabd84f168e7ca508ee94d8f32ea9bd5de2", size = 2461022 },
+    { url = "https://files.pythonhosted.org/packages/81/ce/1a076dce6bc22bca4b9ad5d1bbcd7e1023dcf7bf20ea9404c6462d78f049/grimp-3.14-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:efaf11ea73f7f12d847c54a5d6edcbe919e0369dce2d1aabae6c50792e16f816", size = 2498256 },
+    { url = "https://files.pythonhosted.org/packages/45/ea/ac735bed202c1c5c019e611b92d3861779e0cfbe2d20fdb0dec94266d248/grimp-3.14-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e089c9ab8aa755ff5af88c55891727783b4eb6b228e7bdf278e17209d954aa1e", size = 2502056 },
+    { url = "https://files.pythonhosted.org/packages/80/8f/774ce522de6a7e70fbeceeaeb6fbe502f5dfb8365728fb3bb4cb23463da8/grimp-3.14-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a424ad14d5deb56721ac24ab939747f72ab3d378d42e7d1f038317d33b052b77", size = 2515157 },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.17"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/84/376a3b96e5a8d33a7aa2c5b3b31a4b3c364117184bf0b17418055f6ace66/identify-2.6.17.tar.gz", hash = "sha256:f816b0b596b204c9fdf076ded172322f2723cf958d02f9c3587504834c8ff04d", size = 99579 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/66/71c1227dff78aaeb942fed29dd5651f2aec166cc7c9aeea3e8b26a539b7d/identify-2.6.17-py2.py3-none-any.whl", hash = "sha256:be5f8412d5ed4b20f2bd41a65f920990bdccaa6a4a18a08f1eefdcd0bdd885f0", size = 99382 },
+]
+
+[[package]]
+name = "import-linter"
+version = "2.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "grimp" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/66/55b697a17bb15c6cb88d97d73716813f5427281527b90f02cc0a600abc6e/import_linter-2.11.tar.gz", hash = "sha256:5abc3394797a54f9bae315e7242dc98715ba485f840ac38c6d3192c370d0085e", size = 1153682 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/aa/2ed2c89543632ded7196e0d93dcc6c7fe87769e88391a648c4a298ea864a/import_linter-2.11-py3-none-any.whl", hash = "sha256:3dc54cae933bae3430358c30989762b721c77aa99d424f56a08265be0eeaa465", size = 637315 },
 ]
 
 [[package]]
@@ -758,6 +879,32 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-testmon"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/1d/3e4230cc67cd6205bbe03c3527500c0ccaf7f0c78b436537eac71590ee4a/pytest_testmon-2.2.0.tar.gz", hash = "sha256:01f488e955ed0e0049777bee598bf1f647dd524e06f544c31a24e68f8d775a51", size = 23108 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/55/ebb3c2f59fb089f08d00f764830d35780fc4e4c41dffcadafa3264682b65/pytest_testmon-2.2.0-py3-none-any.whl", hash = "sha256:2604ca44a54d61a2e830d9ce828b41a837075e4ebc1f81b148add8e90d34815b", size = 25199 },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396 },
+]
+
+[[package]]
 name = "python-discovery"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -804,6 +951,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923 },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062 },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341 },
+]
+
+[[package]]
+name = "requirements-parser"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/96/fb6dbfebb524d5601d359a47c78fe7ba1eef90fc4096404aa60c9a906fbb/requirements_parser-0.13.0.tar.gz", hash = "sha256:0843119ca2cb2331de4eb31b10d70462e39ace698fd660a915c247d2301a4418", size = 22630 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/60/50fbb6ffb35f733654466f1a90d162bcbea358adc3b0871339254fbc37b2/requirements_parser-0.13.0-py3-none-any.whl", hash = "sha256:2b3173faecf19ec5501971b7222d38f04cb45bb9d87d0ad629ca71e2e62ded14", size = 14782 },
+]
+
+[[package]]
+name = "rich"
+version = "14.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add a repo-local `./scripts/dev` CLI with doctor, deps, impact, contract, and verify commands
- generate and check in a module dependency map so change impact is easier to predict from live imports
- add architecture/dependency guardrails, contributor docs, and tests for the new tooling

## Validation
- ./scripts/dev verify quick
- ./scripts/dev verify docs --files README.md docs/development/codebase-navigation.md docs/development/module-dependency-map.md scripts/README.md AGENTS.md
- ./scripts/dev verify bench
- ./.venv/bin/python -m pytest tests/test_dev_tooling.py tests/test_docs_scripts.py tests/test_cleanup_local_artifacts.py -q
- ./.venv/bin/deptry .
- ./.venv/bin/lint-imports