### PR TITLE
feat(filter): speed up deferred replay and add yield telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ contains imported legacy history, so date order is not strictly monotonic:
 `0.3.0` records the older `cauchy-generator -> dagzoo` rename, while `0.5.0`
 records the later `dagsynth -> dagzoo` rename on the current release line.
 
+## [0.8.1] - 2026-03-10
+
+### Changed
+
+- Fixed deferred-filter packed-split replay so one Parquet record batch can
+  contain adjacent datasets with different feature widths without raising a
+  false ragged-shape error.
+- Benchmark preset results now replace the misleading
+  `accepted_datasets_measured` field with explicit filter-stage dataset-yield
+  telemetry: accepted count, rejected count, acceptance rate, and rejection
+  rate. CLI and markdown benchmark summaries now print the new dataset-level
+  filter accept/reject percentages alongside the existing attempt-level filter
+  rejection pressure metrics.
+
 ## [0.8.0] - 2026-03-10
 
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dagzoo"
-version = "0.8.0"
+version = "0.8.1"
 description = "High-performance synthetic tabular data generator"
 readme = "README.md"
 license = "MIT"

--- a/src/dagzoo/bench/metrics.py
+++ b/src/dagzoo/bench/metrics.py
@@ -20,6 +20,7 @@ HIGHER_IS_BETTER_METRICS = frozenset(
         "generation_datasets_per_minute",
         "write_datasets_per_minute",
         "filter_datasets_per_minute",
+        "filter_acceptance_rate_dataset_level",
     }
 )
 LOWER_IS_BETTER_METRICS = frozenset(
@@ -30,6 +31,7 @@ LOWER_IS_BETTER_METRICS = frozenset(
         "peak_rss_mb",
         "peak_cuda_allocated_mb",
         "peak_cuda_reserved_mb",
+        "filter_rejection_rate_dataset_level",
         "filter_rejection_rate_attempt_level",
         "filter_retry_dataset_rate",
         "retry_dataset_rate",

--- a/src/dagzoo/bench/report.py
+++ b/src/dagzoo/bench/report.py
@@ -52,8 +52,8 @@ def _build_preset_table(preset_results: list[dict[str, Any]]) -> list[str]:
     """Create a markdown table summarizing per-preset performance metrics."""
 
     lines = [
-        "| Preset | Rows | Mode | Device | Backend | Datasets/min | Gen/min | Write/min | Filter/min | Repro | Workload | Filter Reject % (attempt) | Filter Retry % (dataset) | Elapsed (s) | Latency p95 (ms) | Peak RSS (MB) | Diagnostics | Missingness | Lineage | Shift | Noise |",
-        "|---|---:|---|---|---:|---:|---:|---:|---:|---|---|---:|---:|---:|---:|---:|---|---|---|---|---|",
+        "| Preset | Rows | Mode | Device | Backend | Datasets/min | Gen/min | Write/min | Filter/min | Repro | Workload | Filter Reject % (attempt) | Filter Accept % (dataset) | Filter Reject % (dataset) | Filter Retry % (dataset) | Elapsed (s) | Latency p95 (ms) | Peak RSS (MB) | Diagnostics | Missingness | Lineage | Shift | Noise |",
+        "|---|---:|---|---|---:|---:|---:|---:|---:|---|---|---:|---:|---:|---:|---:|---:|---:|---|---|---|---|---|",
     ]
     for result in preset_results:
         diagnostics_state = "on" if bool(result.get("diagnostics_enabled")) else "off"
@@ -87,6 +87,8 @@ def _build_preset_table(preset_results: list[dict[str, Any]]) -> list[str]:
             f"{_format_match(result.get('reproducibility_match'))} | "
             f"{_format_match(result.get('reproducibility_workload_match'))} | "
             f"{_format_percent(result.get('filter_rejection_rate_attempt_level'), 2)} | "
+            f"{_format_percent(result.get('filter_acceptance_rate_dataset_level'), 2)} | "
+            f"{_format_percent(result.get('filter_rejection_rate_dataset_level'), 2)} | "
             f"{_format_percent(result.get('filter_retry_dataset_rate'), 2)} | "
             f"{_format_float(result.get('elapsed_seconds'), 3)} | "
             f"{_format_float(result.get('latency_p95_ms'), 2)} | "

--- a/src/dagzoo/bench/stage_metrics.py
+++ b/src/dagzoo/bench/stage_metrics.py
@@ -9,11 +9,10 @@ import time
 from typing import Any
 
 import numpy as np
-import torch
 
 from dagzoo.bench.constants import SECONDS_PER_MINUTE
 from dagzoo.config import GeneratorConfig
-from dagzoo.filtering import apply_extra_trees_filter
+from dagzoo.filtering.extra_trees_filter import _apply_extra_trees_filter_numpy
 from dagzoo.io.parquet_writer import write_packed_parquet_shards_stream
 from dagzoo.math_utils import to_numpy as _to_numpy
 from dagzoo.rng import SEED32_MAX
@@ -41,7 +40,9 @@ class FilterStageMeasurement:
 
     datasets_per_minute: float
     filter_attempts_total: int
+    filter_accepted_datasets: int
     filter_rejections_total: int
+    filter_rejected_datasets: int
 
 
 def measure_write_datasets_per_minute(
@@ -98,10 +99,13 @@ def measure_filter_stage_metrics(
         return FilterStageMeasurement(
             datasets_per_minute=0.0,
             filter_attempts_total=0,
+            filter_accepted_datasets=0,
             filter_rejections_total=0,
+            filter_rejected_datasets=0,
         )
 
     attempts_total = 0
+    accepted_total = 0
     rejections_total = 0
     start = time.perf_counter()
     for idx, bundle in enumerate(bundles):
@@ -121,9 +125,9 @@ def measure_filter_stage_metrics(
             y_all = y_all.astype("float32", copy=False)
 
         attempts_total += 1
-        accepted, _details = apply_extra_trees_filter(
-            torch.from_numpy(x_all),
-            torch.from_numpy(y_all),
+        accepted, _details = _apply_extra_trees_filter_numpy(
+            x_all,
+            y_all,
             task=str(config.dataset.task),
             seed=_coerce_bundle_seed(bundle, fallback_seed=config.seed + idx),
             n_estimators=int(config.filter.n_estimators),
@@ -135,7 +139,9 @@ def measure_filter_stage_metrics(
             threshold=float(config.filter.threshold),
             n_jobs=int(config.filter.n_jobs),
         )
-        if not bool(accepted):
+        if bool(accepted):
+            accepted_total += 1
+        else:
             rejections_total += 1
 
     elapsed = max(0.0, time.perf_counter() - start)
@@ -143,7 +149,9 @@ def measure_filter_stage_metrics(
     return FilterStageMeasurement(
         datasets_per_minute=float(dpm),
         filter_attempts_total=int(attempts_total),
+        filter_accepted_datasets=int(accepted_total),
         filter_rejections_total=int(rejections_total),
+        filter_rejected_datasets=int(rejections_total),
     )
 
 

--- a/src/dagzoo/bench/suite.py
+++ b/src/dagzoo/bench/suite.py
@@ -562,16 +562,31 @@ def run_preset_benchmark(
     filter_rejections_total = int(throughput_pressure_summary["filter_rejections_total"])
     filter_retry_dataset_count = int(throughput_pressure_summary["filter_retry_dataset_count"])
     filter_retry_dataset_denominator = int(throughput_pressure_summary["datasets_seen"])
+    filter_accepted_datasets_measured = 0
+    filter_rejected_datasets_measured = 0
     if filter_stage_measurement is not None:
         filter_attempts_total = int(filter_stage_measurement.filter_attempts_total)
         filter_rejections_total = int(filter_stage_measurement.filter_rejections_total)
         filter_retry_dataset_count = int(filter_stage_measurement.filter_rejections_total)
         filter_retry_dataset_denominator = int(stage_sample_datasets)
-
-    accepted_datasets_measured = int(throughput_pressure_summary["datasets_seen"])
+        filter_accepted_datasets_measured = int(filter_stage_measurement.filter_accepted_datasets)
+        filter_rejected_datasets_measured = int(filter_stage_measurement.filter_rejected_datasets)
     filter_rejection_rate_attempt_level = (
         float(filter_rejections_total) / float(filter_attempts_total)
         if filter_attempts_total > 0
+        else None
+    )
+    filter_dataset_yield_total = (
+        filter_accepted_datasets_measured + filter_rejected_datasets_measured
+    )
+    filter_acceptance_rate_dataset_level = (
+        float(filter_accepted_datasets_measured) / float(filter_dataset_yield_total)
+        if filter_dataset_yield_total > 0
+        else None
+    )
+    filter_rejection_rate_dataset_level = (
+        float(filter_rejected_datasets_measured) / float(filter_dataset_yield_total)
+        if filter_dataset_yield_total > 0
         else None
     )
     filter_retry_dataset_rate = (
@@ -605,13 +620,16 @@ def run_preset_benchmark(
     result["filter_datasets_per_minute"] = float(filter_dpm) if filter_dpm is not None else None
     result["stage_sample_datasets"] = int(stage_sample_datasets)
     result["filter_stage_enabled"] = filter_stage_enabled
-    result["accepted_datasets_measured"] = accepted_datasets_measured
     result["total_attempts"] = int(throughput_pressure_summary["attempts_total"])
     result["mean_attempts_per_dataset"] = mean_attempts_per_dataset
     result["retry_dataset_count"] = int(throughput_pressure_summary["retry_dataset_count"])
     result["retry_dataset_rate"] = throughput_pressure_summary["retry_dataset_rate"]
     result["filter_attempts_total"] = int(filter_attempts_total)
     result["filter_rejections_total"] = int(filter_rejections_total)
+    result["filter_accepted_datasets_measured"] = int(filter_accepted_datasets_measured)
+    result["filter_rejected_datasets_measured"] = int(filter_rejected_datasets_measured)
+    result["filter_acceptance_rate_dataset_level"] = filter_acceptance_rate_dataset_level
+    result["filter_rejection_rate_dataset_level"] = filter_rejection_rate_dataset_level
     result["filter_rejection_rate_attempt_level"] = filter_rejection_rate_attempt_level
     result["filter_retry_dataset_count"] = filter_retry_dataset_count
     result["filter_retry_dataset_rate"] = filter_retry_dataset_rate

--- a/src/dagzoo/cli.py
+++ b/src/dagzoo/cli.py
@@ -934,11 +934,23 @@ def _print_preset_result_line(result: dict[str, Any]) -> None:
         else " filter/min=-"
     )
     filter_reject_ratio = result.get("filter_rejection_rate_attempt_level")
+    filter_accept_dataset_ratio = result.get("filter_acceptance_rate_dataset_level")
+    filter_reject_dataset_ratio = result.get("filter_rejection_rate_dataset_level")
     filter_retry_ratio = result.get("filter_retry_dataset_rate")
     filter_reject_hint = (
         f" filter_reject_attempt_pct={float(filter_reject_ratio) * 100.0:.2f}"
         if isinstance(filter_reject_ratio, (int, float))
         else " filter_reject_attempt_pct=-"
+    )
+    filter_accept_dataset_hint = (
+        f" filter_accept_dataset_pct={float(filter_accept_dataset_ratio) * 100.0:.2f}"
+        if isinstance(filter_accept_dataset_ratio, (int, float))
+        else " filter_accept_dataset_pct=-"
+    )
+    filter_reject_dataset_hint = (
+        f" filter_reject_dataset_pct={float(filter_reject_dataset_ratio) * 100.0:.2f}"
+        if isinstance(filter_reject_dataset_ratio, (int, float))
+        else " filter_reject_dataset_pct=-"
     )
     filter_retry_hint = (
         f" filter_retry_dataset_pct={float(filter_retry_ratio) * 100.0:.2f}"
@@ -959,7 +971,8 @@ def _print_preset_result_line(result: dict[str, Any]) -> None:
         f"backend={result.get('hardware_backend')} "
         f"datasets/min={float(result.get('datasets_per_minute', 0.0)):.2f} "
         f"{latency_hint}"
-        f"{stage_hint}{filter_stage_hint}{filter_reject_hint}{filter_retry_hint}"
+        f"{stage_hint}{filter_stage_hint}{filter_reject_hint}"
+        f"{filter_accept_dataset_hint}{filter_reject_dataset_hint}{filter_retry_hint}"
         f"{diagnostics_hint}{missingness_hint}{lineage_hint}{shift_hint}{noise_hint}"
     )
 

--- a/src/dagzoo/filtering/deferred_filter.py
+++ b/src/dagzoo/filtering/deferred_filter.py
@@ -13,7 +13,7 @@ import time
 from typing import Any, TextIO
 
 from dagzoo.config import FilterConfig
-from dagzoo.filtering.extra_trees_filter import apply_extra_trees_filter
+from dagzoo.filtering.extra_trees_filter import _apply_extra_trees_filter_numpy
 from dagzoo.io.parquet_writer import (
     _PackedShardState,
     _close_packed_shard_handles,
@@ -26,7 +26,6 @@ from dagzoo.math_utils import sanitize_json as _sanitize_json
 from dagzoo.rng import SEED32_MAX, SEED32_MIN
 
 import numpy as np
-import torch
 
 
 MANIFEST_FILENAME = "filter_manifest.ndjson"
@@ -123,14 +122,24 @@ def _iter_metadata_records(path: Path) -> Iterator[dict[str, Any]]:
 def _build_packed_split_dataset(
     *,
     dataset_index: int,
-    x_rows: list[Any],
-    y_rows: list[Any],
+    x_chunks: list[np.ndarray],
+    y_chunks: list[np.ndarray],
     split_path: Path,
 ) -> _PackedSplitDataset:
     """Convert one accumulated packed split group into NumPy arrays."""
 
-    x_np = np.asarray(x_rows, dtype=np.float32)
-    y_np = np.asarray(y_rows)
+    if not x_chunks:
+        x_np = np.empty((0, 0), dtype=np.float32)
+    elif len(x_chunks) == 1:
+        x_np = np.asarray(x_chunks[0], dtype=np.float32, copy=False)
+    else:
+        x_np = np.concatenate(x_chunks, axis=0).astype(np.float32, copy=False)
+    if not y_chunks:
+        y_np = np.empty((0,), dtype=np.float32)
+    elif len(y_chunks) == 1:
+        y_np = np.asarray(y_chunks[0])
+    else:
+        y_np = np.concatenate(y_chunks, axis=0)
     if x_np.ndim != 2:
         raise ValueError(
             "Invalid packed feature shape while replaying deferred filter: "
@@ -139,6 +148,41 @@ def _build_packed_split_dataset(
     if y_np.ndim != 1:
         y_np = np.asarray(y_np).reshape(-1)
     return _PackedSplitDataset(dataset_index=dataset_index, x=x_np, y=y_np)
+
+
+def _packed_feature_column_to_numpy_matrix(
+    *,
+    feature_column: Any,
+    split_path: Path,
+    dataset_index: int,
+) -> np.ndarray:
+    """Convert one packed list column batch into a dense 2D NumPy matrix."""
+
+    offsets = np.asarray(feature_column.offsets.to_numpy(zero_copy_only=False), dtype=np.int64)
+    n_rows = max(0, int(offsets.shape[0] - 1))
+    if n_rows == 0:
+        return np.empty((0, 0), dtype=np.float32)
+
+    base_offset = int(offsets[0])
+    normalized_offsets = offsets - base_offset
+    row_widths = np.diff(normalized_offsets)
+    if row_widths.size == 0:
+        return np.empty((0, 0), dtype=np.float32)
+    expected_width = int(row_widths[0])
+    if np.any(row_widths != expected_width):
+        raise ValueError(
+            "Invalid packed feature shape while replaying deferred filter: "
+            f"split={split_path} dataset_index={dataset_index} shape=ragged"
+        )
+
+    total_values = int(normalized_offsets[-1])
+    values = np.asarray(
+        feature_column.values.slice(base_offset, total_values).to_numpy(zero_copy_only=False),
+        dtype=np.float32,
+    )
+    if expected_width == 0:
+        return np.empty((n_rows, 0), dtype=np.float32)
+    return values.reshape(n_rows, expected_width)
 
 
 def _iter_packed_split_datasets(split_path: Path) -> Iterator[_PackedSplitDataset]:
@@ -156,24 +200,29 @@ def _iter_packed_split_datasets(split_path: Path) -> Iterator[_PackedSplitDatase
 
     current_dataset_index: int | None = None
     expected_row_index = 0
-    x_rows: list[Any] = []
-    y_rows: list[Any] = []
+    x_chunks: list[np.ndarray] = []
+    y_chunks: list[np.ndarray] = []
 
     for batch in parquet_file.iter_batches(columns=["dataset_index", "row_index", "x", "y"]):
-        dataset_indices = batch.column(0).to_pylist()
-        row_indices = batch.column(1).to_pylist()
-        batch_x_rows = batch.column(2).to_pylist()
-        batch_y_rows = batch.column(3).to_pylist()
+        dataset_indices = np.asarray(batch.column(0).to_numpy(zero_copy_only=False), dtype=np.int64)
+        if dataset_indices.size == 0:
+            continue
+        row_indices = np.asarray(batch.column(1).to_numpy(zero_copy_only=False), dtype=np.int64)
+        feature_column = batch.column(2)
+        batch_y_rows = np.asarray(batch.column(3).to_numpy(zero_copy_only=False))
 
-        for dataset_index_raw, row_index_raw, x_row, y_row in zip(
-            dataset_indices,
-            row_indices,
-            batch_x_rows,
-            batch_y_rows,
-            strict=True,
-        ):
-            dataset_index = int(dataset_index_raw)
-            row_index = int(row_index_raw)
+        group_starts = np.concatenate(
+            (np.array([0], dtype=np.int64), np.flatnonzero(np.diff(dataset_indices) != 0) + 1)
+        )
+        group_ends = np.concatenate(
+            (group_starts[1:], np.array([dataset_indices.size], dtype=np.int64))
+        )
+
+        for start_raw, end_raw in zip(group_starts, group_ends, strict=True):
+            start = int(start_raw)
+            end = int(end_raw)
+            dataset_index = int(dataset_indices[start])
+            group_row_indices = row_indices[start:end]
 
             if current_dataset_index is None:
                 current_dataset_index = dataset_index
@@ -187,31 +236,49 @@ def _iter_packed_split_datasets(split_path: Path) -> Iterator[_PackedSplitDatase
             elif dataset_index != current_dataset_index:
                 yield _build_packed_split_dataset(
                     dataset_index=current_dataset_index,
-                    x_rows=x_rows,
-                    y_rows=y_rows,
+                    x_chunks=x_chunks,
+                    y_chunks=y_chunks,
                     split_path=split_path,
                 )
                 current_dataset_index = dataset_index
                 expected_row_index = 0
-                x_rows = []
-                y_rows = []
+                x_chunks = []
+                y_chunks = []
 
-            if row_index != expected_row_index:
+            expected_last_row_index = expected_row_index + int(group_row_indices.size) - 1
+            group_is_contiguous = bool(
+                group_row_indices.size == 0
+                or (
+                    int(group_row_indices[0]) == expected_row_index
+                    and int(group_row_indices[-1]) == expected_last_row_index
+                    and (
+                        group_row_indices.size == 1 or bool(np.all(np.diff(group_row_indices) == 1))
+                    )
+                )
+            )
+            if not group_is_contiguous:
+                actual_row_index = int(group_row_indices[0]) if group_row_indices.size > 0 else -1
                 raise ValueError(
                     "Packed split rows must have contiguous row_index values starting at 0: "
                     f"split={split_path} dataset_index={dataset_index} "
-                    f"expected_row_index={expected_row_index} got={row_index}"
+                    f"expected_row_index={expected_row_index} got={actual_row_index}"
                 )
 
-            x_rows.append(x_row)
-            y_rows.append(y_row)
-            expected_row_index += 1
+            group_x_rows = _packed_feature_column_to_numpy_matrix(
+                feature_column=feature_column.slice(start, end - start),
+                split_path=split_path,
+                dataset_index=dataset_index,
+            )
+
+            x_chunks.append(group_x_rows)
+            y_chunks.append(batch_y_rows[start:end])
+            expected_row_index += int(group_row_indices.size)
 
     if current_dataset_index is not None:
         yield _build_packed_split_dataset(
             dataset_index=current_dataset_index,
-            x_rows=x_rows,
-            y_rows=y_rows,
+            x_chunks=x_chunks,
+            y_chunks=y_chunks,
             split_path=split_path,
         )
 
@@ -320,13 +387,10 @@ def _filter_dataset(
     y_dtype = np.int64 if task == "classification" else np.float32
     y_all = y_all.astype(y_dtype, copy=False)
 
-    x_t = torch.from_numpy(x_all)
-    y_t = torch.from_numpy(y_all)
-
     start = time.perf_counter()
-    accepted, details = apply_extra_trees_filter(
-        x_t,
-        y_t,
+    accepted, details = _apply_extra_trees_filter_numpy(
+        x_all,
+        y_all,
         task=task,
         seed=seed,
         n_estimators=filter_cfg.n_estimators,

--- a/src/dagzoo/filtering/extra_trees_filter.py
+++ b/src/dagzoo/filtering/extra_trees_filter.py
@@ -136,9 +136,9 @@ def _oob_valid_mask_from_samples(estimators_samples: Any, *, n_rows: int) -> np.
     return oob_vote_counts > 0
 
 
-def apply_extra_trees_filter(
-    x: torch.Tensor,
-    y: torch.Tensor,
+def _apply_extra_trees_filter_numpy(
+    x: np.ndarray,
+    y: np.ndarray,
     *,
     task: str,
     seed: int,
@@ -151,7 +151,7 @@ def apply_extra_trees_filter(
     threshold: float = 0.95,
     n_jobs: int = -1,
 ) -> tuple[bool, dict[str, Any]]:
-    """Apply CPU ExtraTrees filtering with OOB bootstrap win-ratio scoring."""
+    """Apply CPU ExtraTrees filtering from NumPy arrays."""
 
     seed = validate_seed32(seed, field_name="seed")
     if n_estimators < 1:
@@ -169,31 +169,33 @@ def apply_extra_trees_filter(
     if n_jobs == 0 or n_jobs < -1:
         raise ValueError(f"n_jobs must be -1 or an integer >= 1, got {n_jobs}")
 
-    x_cpu = x.detach().to(device="cpu", dtype=torch.float32)
-    if x_cpu.ndim != 2:
-        raise ValueError(f"x must be rank-2 [n_rows, n_features], got shape {tuple(x_cpu.shape)}")
-    n_rows = int(x_cpu.shape[0])
-    n_features = int(x_cpu.shape[1])
+    x_np = np.asarray(x, dtype=np.float32)
+    if x_np.ndim != 2:
+        raise ValueError(f"x must be rank-2 [n_rows, n_features], got shape {tuple(x_np.shape)}")
+    x_np = np.ascontiguousarray(x_np)
+    n_rows = int(x_np.shape[0])
+    n_features = int(x_np.shape[1])
     m_try = _resolve_max_features(max_features, n_features, task)
 
     if task == "classification":
-        y_raw = y.detach().to(device="cpu", dtype=torch.int64).view(-1)
-        unique_labels, y_dense = torch.unique(y_raw, sorted=True, return_inverse=True)
-        n_classes = int(unique_labels.numel())
+        y_raw = np.asarray(y, dtype=np.int64).reshape(-1)
+        unique_labels, y_dense = np.unique(y_raw, return_inverse=True)
+        n_classes = int(unique_labels.size)
         class_count: int | None = n_classes
-        y_target = torch.nn.functional.one_hot(y_dense, num_classes=n_classes).to(torch.float32)
+        y_target = np.eye(n_classes, dtype=np.float32)[y_dense]
     elif task == "regression":
         class_count = None
-        y_target = y.detach().to(device="cpu", dtype=torch.float32)
+        y_target = np.asarray(y, dtype=np.float32)
         if y_target.ndim == 1:
-            y_target = y_target.unsqueeze(1)
+            y_target = y_target.reshape(-1, 1)
     else:
         raise ValueError(f"Unsupported task '{task}'.")
 
-    if int(y_target.shape[0]) != n_rows:
+    y_np = np.ascontiguousarray(y_target, dtype=np.float32)
+    if int(y_np.shape[0]) != n_rows:
         raise ValueError(
             "x/y row-count mismatch in filter: "
-            f"x has {n_rows} rows, y has {int(y_target.shape[0])} rows."
+            f"x has {n_rows} rows, y has {int(y_np.shape[0])} rows."
         )
 
     threshold_details = _resolve_threshold_diagnostics(
@@ -202,9 +204,6 @@ def apply_extra_trees_filter(
         class_count=class_count,
     )
     effective_threshold = float(threshold_details["threshold_effective"])
-
-    x_np = np.asarray(x_cpu.numpy(), dtype=np.float32)
-    y_np = np.asarray(y_target.numpy(), dtype=np.float32)
     max_leaf_nodes_model = int(max_leaf_nodes) if max_leaf_nodes is not None else None
     min_samples_split_override: int | None = None
     if max_leaf_nodes_model == 1:
@@ -277,3 +276,41 @@ def apply_extra_trees_filter(
         "n_jobs": int(n_jobs),
         **threshold_details,
     }
+
+
+def apply_extra_trees_filter(
+    x: torch.Tensor,
+    y: torch.Tensor,
+    *,
+    task: str,
+    seed: int,
+    n_estimators: int = 25,
+    max_depth: int = 6,
+    min_samples_leaf: int = 1,
+    max_leaf_nodes: int | None = None,
+    max_features: str | int | float = "auto",
+    n_bootstrap: int = 200,
+    threshold: float = 0.95,
+    n_jobs: int = -1,
+) -> tuple[bool, dict[str, Any]]:
+    """Apply CPU ExtraTrees filtering with OOB bootstrap win-ratio scoring."""
+
+    x_np = np.asarray(x.detach().to(device="cpu", dtype=torch.float32).numpy(), dtype=np.float32)
+    if task == "classification":
+        y_np = np.asarray(y.detach().to(device="cpu", dtype=torch.int64).view(-1).numpy())
+    else:
+        y_np = np.asarray(y.detach().to(device="cpu", dtype=torch.float32).numpy())
+    return _apply_extra_trees_filter_numpy(
+        x_np,
+        y_np,
+        task=task,
+        seed=seed,
+        n_estimators=n_estimators,
+        max_depth=max_depth,
+        min_samples_leaf=min_samples_leaf,
+        max_leaf_nodes=max_leaf_nodes,
+        max_features=max_features,
+        n_bootstrap=n_bootstrap,
+        threshold=threshold,
+        n_jobs=n_jobs,
+    )

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -40,6 +40,11 @@ def test_benchmark_cli_writes_json(tmp_path) -> None:
     assert float(profile["generation_datasets_per_minute"]) >= 0.0
     assert float(profile["write_datasets_per_minute"]) >= 0.0
     assert profile["filter_datasets_per_minute"] is None
+    assert "accepted_datasets_measured" not in profile
+    assert profile["filter_accepted_datasets_measured"] == 0
+    assert profile["filter_rejected_datasets_measured"] == 0
+    assert profile["filter_acceptance_rate_dataset_level"] is None
+    assert profile["filter_rejection_rate_dataset_level"] is None
     assert profile["filter_rejection_rate_attempt_level"] is None
     assert profile["filter_retry_dataset_rate"] is None
     lineage_guardrails = profile["lineage_guardrails"]
@@ -488,6 +493,8 @@ def test_print_preset_result_line_includes_stage_and_filter_rejection_metrics(ca
             "generation_datasets_per_minute": 124.0,
             "write_datasets_per_minute": 80.0,
             "filter_datasets_per_minute": 60.0,
+            "filter_acceptance_rate_dataset_level": 0.75,
+            "filter_rejection_rate_dataset_level": 0.25,
             "filter_rejection_rate_attempt_level": 0.125,
             "filter_retry_dataset_rate": 0.25,
             "latency_p95_ms": 4.2,
@@ -498,6 +505,8 @@ def test_print_preset_result_line_includes_stage_and_filter_rejection_metrics(ca
     assert "write/min=80.00" in output
     assert "filter/min=60.00" in output
     assert "filter_reject_attempt_pct=12.50" in output
+    assert "filter_accept_dataset_pct=75.00" in output
+    assert "filter_reject_dataset_pct=25.00" in output
     assert "filter_retry_dataset_pct=25.00" in output
 
 

--- a/tests/test_benchmark_regression.py
+++ b/tests/test_benchmark_regression.py
@@ -1,3 +1,5 @@
+import pytest
+
 from dagzoo.bench.baseline import (
     build_baseline_payload,
     compare_summary_to_baseline,
@@ -8,6 +10,12 @@ from dagzoo.bench.metrics import degradation_percent, percent_change
 def test_percent_change_and_degradation_direction() -> None:
     assert percent_change(90.0, 100.0) == -10.0
     assert degradation_percent("datasets_per_minute", 90.0, 100.0) == 10.0
+    assert degradation_percent("filter_acceptance_rate_dataset_level", 0.6, 0.8) == pytest.approx(
+        25.0
+    )
+    assert degradation_percent("filter_rejection_rate_dataset_level", 0.3, 0.2) == pytest.approx(
+        50.0
+    )
     assert degradation_percent("elapsed_seconds", 110.0, 100.0) == 10.0
 
 

--- a/tests/test_benchmark_stage_metrics.py
+++ b/tests/test_benchmark_stage_metrics.py
@@ -123,14 +123,16 @@ def test_filter_stage_metric_replays_filter_and_reports_counts(
         replay_seeds.append(int(_kwargs["seed"]))
         return bool(int(_kwargs["seed"]) % 2), {"n_valid_oob": 128}
 
-    monkeypatch.setattr("dagzoo.bench.stage_metrics.apply_extra_trees_filter", _stub_filter)
+    monkeypatch.setattr("dagzoo.bench.stage_metrics._apply_extra_trees_filter_numpy", _stub_filter)
     bundles = [
         _bundle(metadata={"seed": 11, "dataset_seed": 21}),
         _bundle(metadata={"seed": 12, "dataset_seed": 22}),
     ]
     measurement = measure_filter_stage_metrics(bundles, config=cfg)
     assert measurement.filter_attempts_total == 2
+    assert measurement.filter_accepted_datasets == 1
     assert measurement.filter_rejections_total == 1
+    assert measurement.filter_rejected_datasets == 1
     assert measurement.datasets_per_minute > 0.0
     assert replay_seeds == [21, 22]
     assert measure_filter_datasets_per_minute(bundles, config=cfg) > 0.0
@@ -147,11 +149,13 @@ def test_filter_stage_metric_returns_zero_when_disabled(
         calls["count"] += 1
         return True, {}
 
-    monkeypatch.setattr("dagzoo.bench.stage_metrics.apply_extra_trees_filter", _stub_filter)
+    monkeypatch.setattr("dagzoo.bench.stage_metrics._apply_extra_trees_filter_numpy", _stub_filter)
     measurement = measure_filter_stage_metrics([_bundle(metadata={})], config=cfg)
     assert measurement.datasets_per_minute == 0.0
     assert measurement.filter_attempts_total == 0
+    assert measurement.filter_accepted_datasets == 0
     assert measurement.filter_rejections_total == 0
+    assert measurement.filter_rejected_datasets == 0
     assert calls["count"] == 0
 
 
@@ -167,7 +171,7 @@ def test_filter_stage_metric_uses_fallback_seed_when_missing(
         replay_seeds.append(int(_kwargs["seed"]))
         return True, {}
 
-    monkeypatch.setattr("dagzoo.bench.stage_metrics.apply_extra_trees_filter", _stub_filter)
+    monkeypatch.setattr("dagzoo.bench.stage_metrics._apply_extra_trees_filter_numpy", _stub_filter)
     _ = measure_filter_stage_metrics(
         [
             _bundle(metadata={}),
@@ -189,7 +193,7 @@ def test_filter_stage_metric_falls_back_to_legacy_seed_when_dataset_seed_missing
         replay_seeds.append(int(_kwargs["seed"]))
         return True, {}
 
-    monkeypatch.setattr("dagzoo.bench.stage_metrics.apply_extra_trees_filter", _stub_filter)
+    monkeypatch.setattr("dagzoo.bench.stage_metrics._apply_extra_trees_filter_numpy", _stub_filter)
     _ = measure_filter_stage_metrics(
         [
             _bundle(metadata={"seed": 41}),

--- a/tests/test_benchmark_suite.py
+++ b/tests/test_benchmark_suite.py
@@ -183,13 +183,17 @@ def test_run_benchmark_suite_smoke_single_profile() -> None:
     assert result["write_datasets_per_minute"] >= 0.0
     assert result["filter_datasets_per_minute"] is None
     assert result["filter_stage_enabled"] is False
+    assert "accepted_datasets_measured" not in result
     assert result["filter_rejection_rate_attempt_level"] is None
+    assert result["filter_acceptance_rate_dataset_level"] is None
+    assert result["filter_rejection_rate_dataset_level"] is None
     assert result["filter_retry_dataset_rate"] is None
     assert result["filter_attempts_total"] == 0
     assert result["filter_rejections_total"] == 0
+    assert result["filter_accepted_datasets_measured"] == 0
+    assert result["filter_rejected_datasets_measured"] == 0
     assert result["stage_sample_datasets"] >= 1
-    assert result["accepted_datasets_measured"] >= 1
-    assert result["total_attempts"] >= result["accepted_datasets_measured"]
+    assert result["total_attempts"] >= result["stage_sample_datasets"]
     assert result["mean_attempts_per_dataset"] >= 1.0
     assert result["estimated_attempts_per_minute"] >= result["generation_datasets_per_minute"]
     assert result["latency_p95_ms"] >= 0
@@ -358,7 +362,9 @@ def test_run_benchmark_suite_emits_stage_and_filter_pressure_metrics(
             datasets_per_minute=float(len(bundles)) * 20.0
             + float(config.filter.n_estimators) * 0.0,
             filter_attempts_total=3,
+            filter_accepted_datasets=2,
             filter_rejections_total=1,
+            filter_rejected_datasets=1,
         ),
     )
     monkeypatch.setattr(
@@ -387,7 +393,7 @@ def test_run_benchmark_suite_emits_stage_and_filter_pressure_metrics(
     assert result["write_datasets_per_minute"] == pytest.approx(20.0)
     assert result["filter_datasets_per_minute"] == pytest.approx(40.0)
     assert result["filter_stage_enabled"] is True
-    assert result["accepted_datasets_measured"] == 2
+    assert "accepted_datasets_measured" not in result
     assert result["total_attempts"] == 3
     assert result["mean_attempts_per_dataset"] == pytest.approx(1.5)
     assert result["estimated_attempts_per_minute"] == pytest.approx(180.0)
@@ -395,6 +401,10 @@ def test_run_benchmark_suite_emits_stage_and_filter_pressure_metrics(
     assert result["retry_dataset_rate"] == pytest.approx(0.5)
     assert result["filter_attempts_total"] == 3
     assert result["filter_rejections_total"] == 1
+    assert result["filter_accepted_datasets_measured"] == 2
+    assert result["filter_rejected_datasets_measured"] == 1
+    assert result["filter_acceptance_rate_dataset_level"] == pytest.approx(2.0 / 3.0)
+    assert result["filter_rejection_rate_dataset_level"] == pytest.approx(1.0 / 3.0)
     assert result["filter_rejection_rate_attempt_level"] == pytest.approx(1.0 / 3.0)
     assert result["filter_retry_dataset_count"] == 1
     assert result["filter_retry_dataset_rate"] == pytest.approx(0.5)
@@ -548,7 +558,9 @@ def test_run_benchmark_suite_filter_enabled_uses_filter_disabled_generation_conf
         lambda bundles, *, config: SimpleNamespace(
             datasets_per_minute=float(len(bundles)) * 10.0 + float(config.filter.n_jobs) * 0.0,
             filter_attempts_total=int(len(bundles)),
+            filter_accepted_datasets=int(len(bundles)),
             filter_rejections_total=0,
+            filter_rejected_datasets=0,
         ),
     )
 
@@ -650,7 +662,9 @@ def test_run_benchmark_suite_filter_retry_rate_uses_stage_sample_denominator_whe
             datasets_per_minute=float(len(bundles)) * 20.0
             + float(config.filter.n_estimators) * 0.0,
             filter_attempts_total=int(len(bundles)),
+            filter_accepted_datasets=max(0, int(len(bundles)) - 1),
             filter_rejections_total=1,
+            filter_rejected_datasets=1,
         ),
     )
     monkeypatch.setattr(
@@ -675,10 +689,14 @@ def test_run_benchmark_suite_filter_retry_rate_uses_stage_sample_denominator_whe
     )
 
     result = summary["preset_results"][0]
-    assert result["accepted_datasets_measured"] == 4
+    assert "accepted_datasets_measured" not in result
     assert result["stage_sample_datasets"] == 2
     assert result["filter_attempts_total"] == 2
     assert result["filter_rejections_total"] == 1
+    assert result["filter_accepted_datasets_measured"] == 1
+    assert result["filter_rejected_datasets_measured"] == 1
+    assert result["filter_acceptance_rate_dataset_level"] == pytest.approx(0.5)
+    assert result["filter_rejection_rate_dataset_level"] == pytest.approx(0.5)
     assert result["filter_retry_dataset_count"] == 1
     assert result["filter_retry_dataset_rate"] == pytest.approx(0.5)
 
@@ -1610,6 +1628,10 @@ def test_write_suite_markdown_profile_table_includes_shift_and_noise_columns(
                 "peak_rss_mb": 10.0,
                 "reproducibility_match": True,
                 "reproducibility_workload_match": False,
+                "filter_acceptance_rate_dataset_level": 0.75,
+                "filter_rejection_rate_attempt_level": 0.25,
+                "filter_rejection_rate_dataset_level": 0.25,
+                "filter_retry_dataset_rate": 0.25,
                 "diagnostics_enabled": False,
                 "missingness_guardrails": {"enabled": False},
                 "lineage_guardrails": {"enabled": False},
@@ -1625,7 +1647,9 @@ def test_write_suite_markdown_profile_table_includes_shift_and_noise_columns(
     assert "| Noise |" in text
     assert "| Repro |" in text
     assert "| Workload |" in text
+    assert "Filter Accept % (dataset)" in text
     assert "Filter Reject % (attempt)" in text
+    assert "Filter Reject % (dataset)" in text
     assert "Filter Retry % (dataset)" in text
     assert "match" in text
     assert "mismatch" in text

--- a/tests/test_deferred_filter.py
+++ b/tests/test_deferred_filter.py
@@ -3,7 +3,7 @@ import json
 import numpy as np
 import pytest
 
-from dagzoo.filtering.deferred_filter import run_deferred_filter
+from dagzoo.filtering.deferred_filter import _iter_packed_split_datasets, run_deferred_filter
 from dagzoo.io.parquet_writer import write_packed_parquet_shards_stream
 from dagzoo.types import DatasetBundle
 
@@ -87,6 +87,89 @@ def _write_split_table(
     pyarrow_parquet.write_table(table, path, compression="zstd")
 
 
+def test_iter_packed_split_datasets_handles_dataset_split_across_record_batches(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pyarrow = pytest.importorskip("pyarrow")
+
+    table = pyarrow.table(
+        {
+            "dataset_index": pyarrow.array([0, 0, 0, 1, 1], type=pyarrow.int64()),
+            "row_index": pyarrow.array([0, 1, 2, 0, 1], type=pyarrow.int64()),
+            "x": pyarrow.array(
+                [[0.0, 0.5], [1.0, 1.5], [2.0, 2.5], [3.0, 3.5], [4.0, 4.5]],
+                type=pyarrow.list_(pyarrow.float32()),
+            ),
+            "y": pyarrow.array([0, 1, 0, 1, 0], type=pyarrow.int64()),
+        }
+    )
+    batches = [
+        table.slice(0, 2).to_batches()[0],
+        table.slice(2, 1).to_batches()[0],
+        table.slice(3, 2).to_batches()[0],
+    ]
+
+    class _FakeParquetFile:
+        def __init__(self, _path) -> None:
+            self.schema_arrow = table.schema
+
+        def iter_batches(self, *, columns):
+            assert columns == ["dataset_index", "row_index", "x", "y"]
+            return iter(batches)
+
+    monkeypatch.setattr("dagzoo.filtering.deferred_filter.pq.ParquetFile", _FakeParquetFile)
+
+    split_path = tmp_path / "train.parquet"
+    datasets = list(_iter_packed_split_datasets(split_path))
+
+    assert [dataset.dataset_index for dataset in datasets] == [0, 1]
+    assert datasets[0].x.shape == (3, 2)
+    assert datasets[0].y.tolist() == [0, 1, 0]
+    assert np.allclose(datasets[0].x[:, 0], np.array([0.0, 1.0, 2.0], dtype=np.float32))
+    assert datasets[1].x.shape == (2, 2)
+    assert datasets[1].y.tolist() == [1, 0]
+
+
+def test_iter_packed_split_datasets_handles_mixed_feature_widths_within_record_batch(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pyarrow = pytest.importorskip("pyarrow")
+
+    table = pyarrow.table(
+        {
+            "dataset_index": pyarrow.array([0, 0, 1, 1], type=pyarrow.int64()),
+            "row_index": pyarrow.array([0, 1, 0, 1], type=pyarrow.int64()),
+            "x": pyarrow.array(
+                [[0.0, 0.5], [1.0, 1.5], [2.0, 2.5, 2.75], [3.0, 3.5, 3.75]],
+                type=pyarrow.list_(pyarrow.float32()),
+            ),
+            "y": pyarrow.array([0, 1, 1, 0], type=pyarrow.int64()),
+        }
+    )
+    batches = table.to_batches(max_chunksize=4)
+
+    class _FakeParquetFile:
+        def __init__(self, _path) -> None:
+            self.schema_arrow = table.schema
+
+        def iter_batches(self, *, columns):
+            assert columns == ["dataset_index", "row_index", "x", "y"]
+            return iter(batches)
+
+    monkeypatch.setattr("dagzoo.filtering.deferred_filter.pq.ParquetFile", _FakeParquetFile)
+
+    split_path = tmp_path / "train.parquet"
+    datasets = list(_iter_packed_split_datasets(split_path))
+
+    assert [dataset.dataset_index for dataset in datasets] == [0, 1]
+    assert datasets[0].x.shape == (2, 2)
+    assert datasets[0].y.tolist() == [0, 1]
+    assert datasets[1].x.shape == (2, 3)
+    assert datasets[1].y.tolist() == [1, 0]
+
+
 def test_run_deferred_filter_writes_manifest_and_summary(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
@@ -106,7 +189,9 @@ def test_run_deferred_filter_writes_manifest_and_summary(
             details["reason"] = "below_threshold"
         return accepted, details
 
-    monkeypatch.setattr("dagzoo.filtering.deferred_filter.apply_extra_trees_filter", _stub_filter)
+    monkeypatch.setattr(
+        "dagzoo.filtering.deferred_filter._apply_extra_trees_filter_numpy", _stub_filter
+    )
 
     result = run_deferred_filter(in_dir=in_dir, out_dir=out_dir)
     assert result.total_datasets == 2
@@ -150,7 +235,9 @@ def test_run_deferred_filter_writes_curated_output_for_accepted_only(
         accepted = bool(seed % 2)
         return accepted, {"wins_ratio": 1.0 if accepted else 0.0, "n_valid_oob": 128}
 
-    monkeypatch.setattr("dagzoo.filtering.deferred_filter.apply_extra_trees_filter", _stub_filter)
+    monkeypatch.setattr(
+        "dagzoo.filtering.deferred_filter._apply_extra_trees_filter_numpy", _stub_filter
+    )
 
     result = run_deferred_filter(in_dir=in_dir, out_dir=out_dir, curated_out_dir=curated_out)
     assert result.curated_accepted_datasets == 2
@@ -177,7 +264,7 @@ def test_run_deferred_filter_requires_embedded_filter_config(
     _ = write_packed_parquet_shards_stream(bundles, in_dir, shard_size=1, compression="zstd")
 
     monkeypatch.setattr(
-        "dagzoo.filtering.deferred_filter.apply_extra_trees_filter",
+        "dagzoo.filtering.deferred_filter._apply_extra_trees_filter_numpy",
         lambda *_args, **_kwargs: (True, {"wins_ratio": 1.0, "n_valid_oob": 128}),
     )
 
@@ -205,7 +292,9 @@ def test_run_deferred_filter_prefers_dataset_seed_when_present(
         replay_seeds.append(int(_kwargs["seed"]))
         return True, {"wins_ratio": 1.0, "n_valid_oob": 128}
 
-    monkeypatch.setattr("dagzoo.filtering.deferred_filter.apply_extra_trees_filter", _stub_filter)
+    monkeypatch.setattr(
+        "dagzoo.filtering.deferred_filter._apply_extra_trees_filter_numpy", _stub_filter
+    )
 
     result = run_deferred_filter(in_dir=in_dir, out_dir=out_dir)
 
@@ -255,7 +344,7 @@ def test_run_deferred_filter_rejects_extra_split_rows_beyond_metadata(
     _write_ndjson_records(metadata_path, [records[0]])
 
     monkeypatch.setattr(
-        "dagzoo.filtering.deferred_filter.apply_extra_trees_filter",
+        "dagzoo.filtering.deferred_filter._apply_extra_trees_filter_numpy",
         lambda *_args, **_kwargs: (True, {"wins_ratio": 1.0, "n_valid_oob": 128}),
     )
 
@@ -329,7 +418,7 @@ def test_run_deferred_filter_rejects_non_monotonic_split_rows(
     )
 
     monkeypatch.setattr(
-        "dagzoo.filtering.deferred_filter.apply_extra_trees_filter",
+        "dagzoo.filtering.deferred_filter._apply_extra_trees_filter_numpy",
         lambda *_args, **_kwargs: (True, {"wins_ratio": 1.0, "n_valid_oob": 128}),
     )
 
@@ -363,7 +452,7 @@ def test_run_deferred_filter_rejects_lineage_symlinks_during_curated_copy(
         pytest.skip("symlinks unavailable in this environment")
 
     monkeypatch.setattr(
-        "dagzoo.filtering.deferred_filter.apply_extra_trees_filter",
+        "dagzoo.filtering.deferred_filter._apply_extra_trees_filter_numpy",
         lambda *_args, **_kwargs: (True, {"wins_ratio": 1.0, "n_valid_oob": 128}),
     )
 
@@ -399,7 +488,7 @@ def test_run_deferred_filter_cleans_up_curated_output_after_split_exhaustion_fai
     _write_ndjson_records(metadata_path, [records[0]])
 
     monkeypatch.setattr(
-        "dagzoo.filtering.deferred_filter.apply_extra_trees_filter",
+        "dagzoo.filtering.deferred_filter._apply_extra_trees_filter_numpy",
         lambda *_args, **_kwargs: (True, {"wins_ratio": 1.0, "n_valid_oob": 128}),
     )
 

--- a/tests/test_extra_trees_filter.py
+++ b/tests/test_extra_trees_filter.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from dagzoo.filtering import apply_extra_trees_filter
+from dagzoo.filtering.extra_trees_filter import _apply_extra_trees_filter_numpy
 
 
 def _make_regression_data(
@@ -76,6 +77,44 @@ def test_extra_trees_filter_is_deterministic_for_fixed_seed() -> None:
     assert details_a["n_valid_oob"] == details_b["n_valid_oob"]
     assert details_a["backend"] == "extra_trees_cpu"
     assert int(details_a["n_jobs"]) == -1
+
+
+@pytest.mark.parametrize("task", ["classification", "regression"])
+def test_extra_trees_filter_numpy_helper_matches_torch_wrapper(task: str) -> None:
+    if task == "classification":
+        x, y = _make_classification_data(seed=141)
+    else:
+        x, y = _make_regression_data(seed=141)
+
+    accepted_torch, details_torch = apply_extra_trees_filter(
+        x,
+        y,
+        task=task,
+        seed=123,
+        n_estimators=8,
+        max_depth=5,
+        min_samples_leaf=2,
+        n_bootstrap=24,
+        threshold=0.5,
+        n_jobs=1,
+    )
+    x_np = x.detach().cpu().numpy()
+    y_np = y.detach().cpu().numpy()
+    accepted_numpy, details_numpy = _apply_extra_trees_filter_numpy(
+        x_np,
+        y_np,
+        task=task,
+        seed=123,
+        n_estimators=8,
+        max_depth=5,
+        min_samples_leaf=2,
+        n_bootstrap=24,
+        threshold=0.5,
+        n_jobs=1,
+    )
+
+    assert accepted_numpy == accepted_torch
+    assert details_numpy == details_torch
 
 
 def test_extra_trees_filter_handles_non_divisible_bootstrap_chunks() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -125,7 +125,7 @@ wheels = [
 
 [[package]]
 name = "dagzoo"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- speed up deferred-filter shard replay by batching packed split decoding per dataset and reusing a NumPy-native Extra Trees helper
- fix replay for valid Parquet record batches that contain adjacent datasets with different feature widths
- replace benchmark accepted_datasets_measured with explicit filter accepted/rejected dataset yield telemetry and surface it in CLI/report output

## Testing
- ./.venv/bin/python -m pytest tests/test_deferred_filter.py tests/test_benchmark_stage_metrics.py tests/test_benchmark_suite.py tests/test_benchmark_cli.py tests/test_extra_trees_filter.py tests/test_benchmark_regression.py
- ./scripts/dev verify quick
- uv run dagzoo benchmark --config configs/benchmark_filter_test.yaml --preset custom --suite standard --hardware-policy none --no-memory --out-dir /tmp/bl148_filter_bench_after_fix

## Contract Changes
- benchmark preset-result JSON removes accepted_datasets_measured
- benchmark preset-result JSON adds filter_accepted_datasets_measured, filter_rejected_datasets_measured, filter_acceptance_rate_dataset_level, and filter_rejection_rate_dataset_level
- version bumped to 0.8.1 with matching changelog entry

Linear: BL-148