### PR TITLE
feat(bench): surface filter accepted-throughput story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ contains imported legacy history, so date order is not strictly monotonic:
 `0.3.0` records the older `cauchy-generator -> dagzoo` rename, while `0.5.0`
 records the later `dagsynth -> dagzoo` rename on the current release line.
 
+## [0.8.2] - 2026-03-10
+
+### Changed
+
+- Benchmark preset results now expose
+  `filter_accepted_datasets_per_minute` so accepted-corpus throughput is a
+  first-class metric alongside filter-stage throughput and dataset-level
+  acceptance yield.
+- Newly saved benchmark baselines now persist
+  `filter_accepted_datasets_per_minute` in the default gating metric set, so
+  `--baseline` and `--fail-on-regression` catch accepted-corpus throughput
+  regressions by default.
+- Added a public filter-enabled smoke benchmark preset and documented the
+  canonical benchmark command plus the summary fields to inspect for accepted
+  throughput and acceptance/rejection yield.
+
 ## [0.8.1] - 2026-03-10
 
 ### Changed

--- a/configs/preset_filter_benchmark_smoke.yaml
+++ b/configs/preset_filter_benchmark_smoke.yaml
@@ -1,0 +1,50 @@
+seed: 1
+
+dataset:
+  task: classification
+  n_train: 128
+  n_test: 32
+  n_features_min: 8
+  n_features_max: 16
+  n_classes_min: 8
+  n_classes_max: 16
+
+graph:
+  n_nodes_min: 8
+  n_nodes_max: 12
+
+runtime:
+  device: cpu
+
+output:
+  out_dir: benchmarks/results/smoke_filter
+  shard_size: 16
+  compression: zstd
+
+diagnostics:
+  enabled: false
+
+benchmark:
+  preset_name: filter_smoke
+  suite: smoke
+  num_datasets: 20
+  warmup_datasets: 0
+  warn_threshold_pct: 10.0
+  fail_threshold_pct: 20.0
+  collect_memory: false
+  collect_reproducibility: false
+  reproducibility_num_datasets: 1
+  latency_num_samples: 5
+  presets:
+    filter_smoke:
+      device: cpu
+      num_datasets: 20
+      warmup_datasets: 0
+
+filter:
+  enabled: true
+  n_estimators: 6
+  max_depth: 3
+  threshold: 0.95
+  max_attempts: 3
+  n_jobs: -1

--- a/docs/features/benchmark-guardrails.md
+++ b/docs/features/benchmark-guardrails.md
@@ -44,6 +44,14 @@ ______________________________________________________________________
 
 ```bash
 dagzoo benchmark \
+  --config configs/preset_filter_benchmark_smoke.yaml \
+  --preset custom \
+  --suite smoke \
+  --hardware-policy none \
+  --no-memory \
+  --out-dir benchmarks/results/smoke_filter
+
+dagzoo benchmark \
   --config configs/preset_missingness_mar.yaml \
   --preset custom \
   --suite smoke \
@@ -64,6 +72,39 @@ dagzoo benchmark \
   --no-memory \
   --out-dir benchmarks/results/smoke_noise_guardrails
 ```
+
+______________________________________________________________________
+
+## Filter-enabled benchmark workflow
+
+Use the filter smoke preset when you want one canonical CPU benchmark run that
+surfaces filter-stage throughput, accepted-corpus throughput, and acceptance
+yield together:
+
+```bash
+dagzoo benchmark \
+  --config configs/preset_filter_benchmark_smoke.yaml \
+  --preset custom \
+  --suite smoke \
+  --hardware-policy none \
+  --no-memory \
+  --out-dir benchmarks/results/smoke_filter
+```
+
+Inspect these `summary.json` preset-result fields first:
+
+- `filter_datasets_per_minute`
+- `filter_accepted_datasets_per_minute`
+- `filter_accepted_datasets_measured`
+- `filter_rejected_datasets_measured`
+- `filter_acceptance_rate_dataset_level`
+- `filter_rejection_rate_dataset_level`
+- `filter_rejection_rate_attempt_level`
+- `filter_retry_dataset_rate`
+
+The CLI preset line prints the same headline values as `filter/min`,
+`filter_accepted/min`, `filter_accept_dataset_pct`, and
+`filter_reject_dataset_pct`.
 
 ______________________________________________________________________
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -183,11 +183,22 @@ gating.
 
 ```bash
 dagzoo benchmark --suite smoke --preset cpu --out-dir benchmarks/results/smoke_cpu
+
+dagzoo benchmark \
+  --config configs/preset_filter_benchmark_smoke.yaml \
+  --preset custom \
+  --suite smoke \
+  --hardware-policy none \
+  --no-memory \
+  --out-dir benchmarks/results/smoke_filter
 ```
 
 `--device` is a single-preset override. When you run multiple `--preset`
 values in one command, set device selection in each preset/config instead of
 passing a shared CLI device override.
+
+For filter-enabled benchmark flows, inspect accepted-corpus throughput together
+with dataset-level accept/reject yield in the benchmark summary artifacts.
 
 Detailed guide: [Benchmark Workflows and Guardrails](features/benchmark-guardrails.md)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dagzoo"
-version = "0.8.1"
+version = "0.8.2"
 description = "High-performance synthetic tabular data generator"
 readme = "README.md"
 license = "MIT"

--- a/src/dagzoo/bench/baseline.py
+++ b/src/dagzoo/bench/baseline.py
@@ -14,6 +14,7 @@ DEFAULT_GATING_METRICS = (
     "generation_datasets_per_minute",
     "write_datasets_per_minute",
     "filter_datasets_per_minute",
+    "filter_accepted_datasets_per_minute",
 )
 
 

--- a/src/dagzoo/bench/metrics.py
+++ b/src/dagzoo/bench/metrics.py
@@ -20,6 +20,7 @@ HIGHER_IS_BETTER_METRICS = frozenset(
         "generation_datasets_per_minute",
         "write_datasets_per_minute",
         "filter_datasets_per_minute",
+        "filter_accepted_datasets_per_minute",
         "filter_acceptance_rate_dataset_level",
     }
 )

--- a/src/dagzoo/bench/report.py
+++ b/src/dagzoo/bench/report.py
@@ -52,8 +52,8 @@ def _build_preset_table(preset_results: list[dict[str, Any]]) -> list[str]:
     """Create a markdown table summarizing per-preset performance metrics."""
 
     lines = [
-        "| Preset | Rows | Mode | Device | Backend | Datasets/min | Gen/min | Write/min | Filter/min | Repro | Workload | Filter Reject % (attempt) | Filter Accept % (dataset) | Filter Reject % (dataset) | Filter Retry % (dataset) | Elapsed (s) | Latency p95 (ms) | Peak RSS (MB) | Diagnostics | Missingness | Lineage | Shift | Noise |",
-        "|---|---:|---|---|---:|---:|---:|---:|---:|---|---|---:|---:|---:|---:|---:|---:|---:|---|---|---|---|---|",
+        "| Preset | Rows | Mode | Device | Backend | Datasets/min | Gen/min | Write/min | Filter/min | Filter Accepted/min | Repro | Workload | Filter Reject % (attempt) | Filter Accept % (dataset) | Filter Reject % (dataset) | Filter Retry % (dataset) | Elapsed (s) | Latency p95 (ms) | Peak RSS (MB) | Diagnostics | Missingness | Lineage | Shift | Noise |",
+        "|---|---:|---|---|---:|---:|---:|---:|---:|---:|---|---|---:|---:|---:|---:|---:|---:|---:|---|---|---|---|---|",
     ]
     for result in preset_results:
         diagnostics_state = "on" if bool(result.get("diagnostics_enabled")) else "off"
@@ -84,6 +84,7 @@ def _build_preset_table(preset_results: list[dict[str, Any]]) -> list[str]:
             f"{_format_float(result.get('generation_datasets_per_minute'), 2)} | "
             f"{_format_float(result.get('write_datasets_per_minute'), 2)} | "
             f"{_format_float(result.get('filter_datasets_per_minute'), 2)} | "
+            f"{_format_float(result.get('filter_accepted_datasets_per_minute'), 2)} | "
             f"{_format_match(result.get('reproducibility_match'))} | "
             f"{_format_match(result.get('reproducibility_workload_match'))} | "
             f"{_format_percent(result.get('filter_rejection_rate_attempt_level'), 2)} | "

--- a/src/dagzoo/bench/suite.py
+++ b/src/dagzoo/bench/suite.py
@@ -584,6 +584,11 @@ def run_preset_benchmark(
         if filter_dataset_yield_total > 0
         else None
     )
+    filter_accepted_datasets_per_minute = (
+        float(filter_dpm) * float(filter_acceptance_rate_dataset_level)
+        if filter_dpm is not None and filter_acceptance_rate_dataset_level is not None
+        else None
+    )
     filter_rejection_rate_dataset_level = (
         float(filter_rejected_datasets_measured) / float(filter_dataset_yield_total)
         if filter_dataset_yield_total > 0
@@ -618,6 +623,7 @@ def run_preset_benchmark(
     result["generation_datasets_per_minute"] = generation_dpm
     result["write_datasets_per_minute"] = float(write_dpm)
     result["filter_datasets_per_minute"] = float(filter_dpm) if filter_dpm is not None else None
+    result["filter_accepted_datasets_per_minute"] = filter_accepted_datasets_per_minute
     result["stage_sample_datasets"] = int(stage_sample_datasets)
     result["filter_stage_enabled"] = filter_stage_enabled
     result["total_attempts"] = int(throughput_pressure_summary["attempts_total"])

--- a/src/dagzoo/cli.py
+++ b/src/dagzoo/cli.py
@@ -933,6 +933,12 @@ def _print_preset_result_line(result: dict[str, Any]) -> None:
         if isinstance(filter_stage_dpm, (int, float))
         else " filter/min=-"
     )
+    filter_accept_stage_dpm = result.get("filter_accepted_datasets_per_minute")
+    filter_accept_stage_hint = (
+        f" filter_accepted/min={float(filter_accept_stage_dpm):.2f}"
+        if isinstance(filter_accept_stage_dpm, (int, float))
+        else " filter_accepted/min=-"
+    )
     filter_reject_ratio = result.get("filter_rejection_rate_attempt_level")
     filter_accept_dataset_ratio = result.get("filter_acceptance_rate_dataset_level")
     filter_reject_dataset_ratio = result.get("filter_rejection_rate_dataset_level")
@@ -971,7 +977,7 @@ def _print_preset_result_line(result: dict[str, Any]) -> None:
         f"backend={result.get('hardware_backend')} "
         f"datasets/min={float(result.get('datasets_per_minute', 0.0)):.2f} "
         f"{latency_hint}"
-        f"{stage_hint}{filter_stage_hint}{filter_reject_hint}"
+        f"{stage_hint}{filter_stage_hint}{filter_accept_stage_hint}{filter_reject_hint}"
         f"{filter_accept_dataset_hint}{filter_reject_dataset_hint}{filter_retry_hint}"
         f"{diagnostics_hint}{missingness_hint}{lineage_hint}{shift_hint}{noise_hint}"
     )

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -40,6 +40,7 @@ def test_benchmark_cli_writes_json(tmp_path) -> None:
     assert float(profile["generation_datasets_per_minute"]) >= 0.0
     assert float(profile["write_datasets_per_minute"]) >= 0.0
     assert profile["filter_datasets_per_minute"] is None
+    assert profile["filter_accepted_datasets_per_minute"] is None
     assert "accepted_datasets_measured" not in profile
     assert profile["filter_accepted_datasets_measured"] == 0
     assert profile["filter_rejected_datasets_measured"] == 0
@@ -160,6 +161,35 @@ def test_benchmark_cli_builtin_cpu_reports_fixed_batched_generation_mode(tmp_pat
     assert all(result["generation_mode"] == "fixed_batched" for result in preset_results)
 
 
+def test_benchmark_cli_filter_smoke_config_reports_accepted_corpus_throughput(tmp_path) -> None:
+    out_dir = tmp_path / "filter_smoke_results"
+    code = main(
+        [
+            "benchmark",
+            "--config",
+            "configs/preset_filter_benchmark_smoke.yaml",
+            "--preset",
+            "custom",
+            "--suite",
+            "smoke",
+            "--hardware-policy",
+            "none",
+            "--no-memory",
+            "--out-dir",
+            str(out_dir),
+        ]
+    )
+    assert code == 0
+    payload = json.loads((out_dir / "summary.json").read_text(encoding="utf-8"))
+    profile = payload["preset_results"][0]
+    assert profile["filter_datasets_per_minute"] is not None
+    assert float(profile["filter_accepted_datasets_per_minute"]) > 0.0
+    assert int(profile["filter_accepted_datasets_measured"]) > 0
+    assert int(profile["filter_rejected_datasets_measured"]) > 0
+    assert 0.0 < float(profile["filter_acceptance_rate_dataset_level"]) < 1.0
+    assert 0.0 < float(profile["filter_rejection_rate_dataset_level"]) < 1.0
+
+
 def test_benchmark_cli_fail_on_regression(tmp_path) -> None:
     baseline_path = tmp_path / "baseline.json"
     baseline_payload = {
@@ -198,6 +228,102 @@ def test_benchmark_cli_fail_on_regression(tmp_path) -> None:
         ]
     )
     assert code == 1
+
+
+def test_benchmark_cli_fail_on_regression_for_filter_accepted_throughput(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    baseline_path = tmp_path / "baseline.json"
+    baseline_payload = {
+        "version": 1,
+        "suite": "smoke",
+        "metrics": ["filter_accepted_datasets_per_minute"],
+        "presets": {
+            "custom": {"filter_accepted_datasets_per_minute": 100.0},
+        },
+    }
+    baseline_path.write_text(json.dumps(baseline_payload), encoding="utf-8")
+
+    summary = {
+        "suite": "smoke",
+        "preset_results": [
+            {
+                "preset_key": "custom",
+                "filter_accepted_datasets_per_minute": 70.0,
+                "datasets_per_minute": 1000.0,
+                "latency_p95_ms": 1.0,
+            }
+        ],
+        "regression": {
+            "status": "fail",
+            "issues": [
+                {
+                    "preset": "custom",
+                    "metric": "filter_accepted_datasets_per_minute",
+                    "current": 70.0,
+                    "baseline": 100.0,
+                    "degradation_pct": 30.0,
+                    "severity": "fail",
+                }
+            ],
+            "hard_fail": True,
+        },
+    }
+
+    calls: list[dict[str, object]] = []
+
+    def _fake_run_benchmark_suite(*args, **kwargs):
+        calls.append(kwargs)
+        return summary
+
+    monkeypatch.setattr("dagzoo.cli.run_benchmark_suite", _fake_run_benchmark_suite)
+
+    code = main(
+        [
+            "benchmark",
+            "--config",
+            "configs/default.yaml",
+            "--preset",
+            "custom",
+            "--suite",
+            "smoke",
+            "--num-datasets",
+            "2",
+            "--warmup",
+            "0",
+            "--hardware-policy",
+            "none",
+            "--no-memory",
+            "--baseline",
+            str(baseline_path),
+            "--warn-threshold-pct",
+            "1",
+            "--fail-threshold-pct",
+            "2",
+            "--fail-on-regression",
+        ]
+    )
+
+    assert code == 1
+    assert calls == [
+        {
+            "suite": "smoke",
+            "warn_threshold_pct": 1.0,
+            "fail_threshold_pct": 2.0,
+            "baseline_payload": baseline_payload,
+            "num_datasets_override": 2,
+            "warmup_override": 0,
+            "collect_memory": False,
+            "collect_reproducibility": False,
+            "collect_diagnostics": False,
+            "diagnostics_root_dir": None,
+            "fail_on_regression": True,
+            "hardware_policy": "none",
+        }
+    ]
+    captured = capsys.readouterr()
+    assert "Regression status=fail issues=1" in captured.out
+    assert "filter_accepted/min=70.00" in captured.out
 
 
 def test_benchmark_cli_diagnostics_emits_artifacts(tmp_path) -> None:
@@ -493,6 +619,7 @@ def test_print_preset_result_line_includes_stage_and_filter_rejection_metrics(ca
             "generation_datasets_per_minute": 124.0,
             "write_datasets_per_minute": 80.0,
             "filter_datasets_per_minute": 60.0,
+            "filter_accepted_datasets_per_minute": 45.0,
             "filter_acceptance_rate_dataset_level": 0.75,
             "filter_rejection_rate_dataset_level": 0.25,
             "filter_rejection_rate_attempt_level": 0.125,
@@ -504,6 +631,7 @@ def test_print_preset_result_line_includes_stage_and_filter_rejection_metrics(ca
     assert "gen/min=124.00" in output
     assert "write/min=80.00" in output
     assert "filter/min=60.00" in output
+    assert "filter_accepted/min=45.00" in output
     assert "filter_reject_attempt_pct=12.50" in output
     assert "filter_accept_dataset_pct=75.00" in output
     assert "filter_reject_dataset_pct=25.00" in output

--- a/tests/test_benchmark_regression.py
+++ b/tests/test_benchmark_regression.py
@@ -10,6 +10,9 @@ from dagzoo.bench.metrics import degradation_percent, percent_change
 def test_percent_change_and_degradation_direction() -> None:
     assert percent_change(90.0, 100.0) == -10.0
     assert degradation_percent("datasets_per_minute", 90.0, 100.0) == 10.0
+    assert degradation_percent("filter_accepted_datasets_per_minute", 60.0, 80.0) == pytest.approx(
+        25.0
+    )
     assert degradation_percent("filter_acceptance_rate_dataset_level", 0.6, 0.8) == pytest.approx(
         25.0
     )
@@ -53,6 +56,46 @@ def test_compare_summary_warn_and_fail() -> None:
     assert fail_result["issues"][0]["severity"] == "fail"
 
 
+def test_compare_summary_warns_on_filter_accepted_throughput_regression() -> None:
+    baseline_summary = {
+        "suite": "standard",
+        "preset_results": [
+            {
+                "preset_key": "cpu",
+                "filter_accepted_datasets_per_minute": 80.0,
+            }
+        ],
+    }
+    baseline = build_baseline_payload(baseline_summary)
+
+    warn_summary = {
+        "suite": "standard",
+        "preset_results": [
+            {
+                "preset_key": "cpu",
+                "filter_accepted_datasets_per_minute": 68.0,
+            }
+        ],
+    }
+    warn_result = compare_summary_to_baseline(
+        warn_summary,
+        baseline,
+        warn_threshold_pct=10.0,
+        fail_threshold_pct=20.0,
+    )
+    assert warn_result["status"] == "warn"
+    assert warn_result["issues"] == [
+        {
+            "preset": "cpu",
+            "metric": "filter_accepted_datasets_per_minute",
+            "current": 68.0,
+            "baseline": 80.0,
+            "degradation_pct": pytest.approx(15.0),
+            "severity": "warn",
+        }
+    ]
+
+
 def test_build_baseline_payload_defaults_include_stage_throughput_metrics() -> None:
     summary = {
         "suite": "standard",
@@ -63,6 +106,7 @@ def test_build_baseline_payload_defaults_include_stage_throughput_metrics() -> N
                 "generation_datasets_per_minute": 110.0,
                 "write_datasets_per_minute": 90.0,
                 "filter_datasets_per_minute": 80.0,
+                "filter_accepted_datasets_per_minute": 60.0,
             }
         ],
     }
@@ -72,5 +116,7 @@ def test_build_baseline_payload_defaults_include_stage_throughput_metrics() -> N
         "generation_datasets_per_minute",
         "write_datasets_per_minute",
         "filter_datasets_per_minute",
+        "filter_accepted_datasets_per_minute",
     ]
     assert payload["presets"]["cpu"]["generation_datasets_per_minute"] == 110.0
+    assert payload["presets"]["cpu"]["filter_accepted_datasets_per_minute"] == 60.0

--- a/tests/test_benchmark_suite.py
+++ b/tests/test_benchmark_suite.py
@@ -182,6 +182,7 @@ def test_run_benchmark_suite_smoke_single_profile() -> None:
     assert result["generation_datasets_per_minute"] == pytest.approx(result["datasets_per_minute"])
     assert result["write_datasets_per_minute"] >= 0.0
     assert result["filter_datasets_per_minute"] is None
+    assert result["filter_accepted_datasets_per_minute"] is None
     assert result["filter_stage_enabled"] is False
     assert "accepted_datasets_measured" not in result
     assert result["filter_rejection_rate_attempt_level"] is None
@@ -392,6 +393,7 @@ def test_run_benchmark_suite_emits_stage_and_filter_pressure_metrics(
     assert result["generation_datasets_per_minute"] == pytest.approx(120.0)
     assert result["write_datasets_per_minute"] == pytest.approx(20.0)
     assert result["filter_datasets_per_minute"] == pytest.approx(40.0)
+    assert result["filter_accepted_datasets_per_minute"] == pytest.approx(40.0 * (2.0 / 3.0))
     assert result["filter_stage_enabled"] is True
     assert "accepted_datasets_measured" not in result
     assert result["total_attempts"] == 3
@@ -693,6 +695,7 @@ def test_run_benchmark_suite_filter_retry_rate_uses_stage_sample_denominator_whe
     assert result["stage_sample_datasets"] == 2
     assert result["filter_attempts_total"] == 2
     assert result["filter_rejections_total"] == 1
+    assert result["filter_accepted_datasets_per_minute"] == pytest.approx(20.0)
     assert result["filter_accepted_datasets_measured"] == 1
     assert result["filter_rejected_datasets_measured"] == 1
     assert result["filter_acceptance_rate_dataset_level"] == pytest.approx(0.5)
@@ -1623,6 +1626,7 @@ def test_write_suite_markdown_profile_table_includes_shift_and_noise_columns(
                 "device": "cpu",
                 "hardware_backend": "cpu",
                 "datasets_per_minute": 120.0,
+                "filter_accepted_datasets_per_minute": 90.0,
                 "elapsed_seconds": 1.0,
                 "latency_p95_ms": 4.0,
                 "peak_rss_mb": 10.0,
@@ -1647,6 +1651,7 @@ def test_write_suite_markdown_profile_table_includes_shift_and_noise_columns(
     assert "| Noise |" in text
     assert "| Repro |" in text
     assert "| Workload |" in text
+    assert "Filter Accepted/min" in text
     assert "Filter Accept % (dataset)" in text
     assert "Filter Reject % (attempt)" in text
     assert "Filter Reject % (dataset)" in text

--- a/uv.lock
+++ b/uv.lock
@@ -125,7 +125,7 @@ wheels = [
 
 [[package]]
 name = "dagzoo"
-version = "0.8.1"
+version = "0.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary
- add accepted-corpus throughput as a first-class benchmark metric and surface it in CLI/report outputs
- add a public filter-enabled smoke benchmark preset plus docs for the canonical guardrail workflow
- persist accepted-throughput in default saved baselines so regression gating catches regressions by default

## Testing
- ./.venv/bin/python -m pytest tests/test_benchmark_stage_metrics.py tests/test_benchmark_suite.py tests/test_benchmark_cli.py tests/test_benchmark_regression.py
- ./.venv/bin/python -m pytest tests/test_benchmark_regression.py tests/test_benchmark_cli.py tests/test_benchmark_suite.py
- ./scripts/dev verify quick
- uv run dagzoo benchmark --config configs/preset_filter_benchmark_smoke.yaml --preset custom --suite smoke --hardware-policy none --no-memory --out-dir /tmp/bl149_filter_smoke
