### PR TITLE
Document dagzoo corpus provenance hardening plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ contains imported legacy history, so date order is not strictly monotonic:
 `0.3.0` records the older `cauchy-generator -> dagzoo` rename, while `0.5.0`
 records the later `dagsynth -> dagzoo` rename on the current release line.
 
+## [0.9.9] - 2026-03-14
+
+### Changed
+
+- **BREAKING:** `dagzoo request` handoff manifests now use schema version `2`
+  and add stable request-run and corpus identity, manifest-relative artifact
+  paths, checksum metadata, and explicit curated-corpus defaults for downstream
+  consumers.
+- Request handoff docs now direct portable downstream consumers to the new
+  relative artifact contract and clarify that the accepted-only curated corpus
+  is the canonical training target.
+
 ## [0.9.8] - 2026-03-13
 
 ### Changed

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -89,13 +89,24 @@ entrypoint for consumers such as `tab-foundry`.
 | Key                   | Type   | Description                                                                       |
 | --------------------- | ------ | --------------------------------------------------------------------------------- |
 | `schema_name`         | str    | Exact string `dagzoo_request_handoff_manifest`                                    |
-| `schema_version`      | int    | Exact integer `1`                                                                 |
+| `schema_version`      | int    | Exact integer `2`                                                                 |
+| `identity`            | object | Stable request-run and corpus ids plus source-family tag                          |
 | `request`             | object | Request-file echo with `path` and normalized public `payload`                     |
 | `artifacts`           | object | Absolute paths for the run root, generated output, filtered corpus, and summaries |
+| `artifacts_relative`  | object | Manifest-relative artifact paths for portable downstream consumption              |
+| `checksums`           | object | SHA-256 digests for effective-config and filter artifacts                         |
 | `summary`             | object | Generated / accepted / rejected counts plus acceptance rate                       |
 | `throughput`          | object | Generation-stage and filter-stage elapsed time plus datasets-per-minute context   |
 | `hardware`            | object | Requested/resolved device context plus applied hardware policy                    |
 | `diversity_artifacts` | object | Nullable paths for request-associated diversity report artifacts                  |
+| `defaults`            | object | Canonical downstream-consumption defaults                                         |
+
+Current `identity` keys:
+
+- `source_family`
+- `request_run_id`
+- `generated_corpus_id`
+- `curated_corpus_id`
 
 Current `artifacts` keys:
 
@@ -108,10 +119,34 @@ Current `artifacts` keys:
 - `filter_manifest_path`
 - `filter_summary_path`
 
+Current `artifacts_relative` keys:
+
+- `run_root`
+- `generated_dir`
+- `filter_dir`
+- `filtered_corpus_dir`
+- `effective_config_path`
+- `effective_config_trace_path`
+- `filter_manifest_path`
+- `filter_summary_path`
+
+Current `checksums` keys:
+
+- `effective_config_sha256`
+- `effective_config_trace_sha256`
+- `filter_manifest_sha256`
+- `filter_summary_sha256`
+
 Current `diversity_artifacts` keys:
 
 - `summary_json_path`
 - `summary_md_path`
+
+Current `defaults` keys:
+
+- `recommended_training_corpus`
+- `recommended_training_artifact_key`
+- `curation_policy`
 
 `throughput.generation_stage` and `throughput.filter_stage` report request-run
 wall-clock stage timing from the `dagzoo request` workflow. `filter_summary.json`
@@ -121,6 +156,11 @@ semantics.
 `dagzoo request` does not run a diversity audit automatically, so the
 `diversity_artifacts` values are currently `null` unless a separate workflow
 persists request-associated diversity outputs alongside the run.
+
+Downstream consumers should prefer `artifacts_relative` over absolute-path
+`artifacts` when portability matters, and should treat
+`defaults.recommended_training_corpus=curated` as the canonical accepted-only
+training target.
 
 ______________________________________________________________________
 

--- a/docs/request-file-contract.md
+++ b/docs/request-file-contract.md
@@ -71,19 +71,28 @@ and writes these artifacts:
 corpus handoff. It is a JSON document with:
 
 - `schema_name: dagzoo_request_handoff_manifest`
-- `schema_version: 1`
+- `schema_version: 2`
+- `identity`: stable request-run and corpus identifiers plus source-family tag
 - `request`: request-file echo (`path` plus normalized public `payload`)
 - `artifacts`: absolute paths for the request-run root, generated output,
   filtered corpus, filter summary/manifest, and effective-config artifacts
+- `artifacts_relative`: manifest-relative paths for portable downstream use
+- `checksums`: SHA-256 digests for the effective-config and filter artifacts
 - `summary`: generated / accepted / rejected dataset counts plus acceptance rate
 - `throughput`: generation-stage and filter-stage elapsed time plus
   datasets-per-minute context
 - `hardware`: requested/resolved device context and the applied hardware policy
 - `diversity_artifacts`: nullable paths for request-associated diversity reports
+- `defaults`: canonical downstream-consumption defaults, including the
+  accepted-only curated corpus recommendation
 
 The manifest `throughput` block uses request-run wall-clock stage timing.
 `filter/filter_summary.json` remains the underlying deferred-filter artifact and
 keeps its own timing semantics.
+
+Downstream consumers should treat `artifacts_relative` as the portable contract
+surface and `defaults.recommended_training_corpus=curated` as the canonical
+training target for mainline research runs.
 
 `dagzoo request` does not run `dagzoo diversity-audit` implicitly, so the
 `diversity_artifacts` paths are currently `null` unless a separate workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dagzoo"
-version = "0.9.8"
+version = "0.9.9"
 description = "Synthetic tabular data generator for causal modeling"
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [

--- a/src/dagzoo/core/request_handoff.py
+++ b/src/dagzoo/core/request_handoff.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
 from collections.abc import Mapping
@@ -11,11 +12,16 @@ from typing import Any, cast
 
 from dagzoo.config import RequestFileConfig
 from dagzoo.core.staged_artifacts import cleanup_path, promote_staged_path, staged_output_path
+from dagzoo.io.lineage_artifact import sha256_hex
 from dagzoo.math import sanitize_json
 
 REQUEST_HANDOFF_MANIFEST_FILENAME = "handoff_manifest.json"
 REQUEST_HANDOFF_SCHEMA_NAME = "dagzoo_request_handoff_manifest"
-REQUEST_HANDOFF_SCHEMA_VERSION = 1
+REQUEST_HANDOFF_SCHEMA_VERSION = 2
+REQUEST_HANDOFF_SOURCE_FAMILY = "dagzoo.fixed_layout_scm"
+REQUEST_HANDOFF_RECOMMENDED_TRAINING_CORPUS = "curated"
+_BLAKE2S_HEX_LENGTH = 32
+_SHA256_HEX_LENGTH = 64
 
 
 def _raise(path: str, message: str) -> None:
@@ -38,6 +44,13 @@ def _require_optional_string(value: object, *, path: str) -> str | None:
     if value is None:
         return None
     return _require_non_empty_string(value, path=path)
+
+
+def _require_hex_string(value: object, *, path: str, expected_length: int) -> str:
+    text = _require_non_empty_string(value, path=path)
+    if len(text) != expected_length or any(ch not in "0123456789abcdef" for ch in text):
+        _raise(path, f"must be a {expected_length}-character lowercase hexadecimal string")
+    return text
 
 
 def _require_int(value: object, *, path: str) -> int:
@@ -72,6 +85,24 @@ def _resolve_optional_path_str(path: str | Path | None) -> str | None:
     if path is None:
         return None
     return _resolve_path_str(path)
+
+
+def _read_sha256(path: str | Path) -> str:
+    return sha256_hex(Path(path).read_bytes())
+
+
+def _stable_blake2s_hex(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        sanitize_json(dict(payload)),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.blake2s(encoded, digest_size=16).hexdigest()
+
+
+def _relative_posix_path(path: str | Path, *, start: str | Path) -> str:
+    return Path(path).resolve().relative_to(Path(start).resolve()).as_posix()
 
 
 def _datasets_per_minute(*, datasets: int, elapsed_seconds: float) -> float:
@@ -113,9 +144,41 @@ def build_request_handoff_manifest(
     acceptance_rate = (
         float(filter_accepted_datasets) / float(total_datasets) if total_datasets > 0 else None
     )
+    effective_config_sha256 = _read_sha256(effective_config_path)
+    effective_config_trace_sha256 = _read_sha256(effective_config_trace_path)
+    filter_manifest_sha256 = _read_sha256(filter_manifest_path)
+    filter_summary_sha256 = _read_sha256(filter_summary_path)
+    request_run_id = _stable_blake2s_hex(
+        {
+            "request_payload": request.to_dict(),
+            "effective_config_sha256": effective_config_sha256,
+            "requested_device": str(requested_device),
+            "resolved_device": str(resolved_device),
+            "hardware_policy": str(hardware_policy),
+        }
+    )
+    generated_corpus_id = _stable_blake2s_hex(
+        {
+            "request_run_id": request_run_id,
+            "corpus_kind": "generated",
+        }
+    )
+    curated_corpus_id = _stable_blake2s_hex(
+        {
+            "request_run_id": request_run_id,
+            "corpus_kind": "curated",
+            "filter_summary_sha256": filter_summary_sha256,
+        }
+    )
     payload: dict[str, Any] = {
         "schema_name": REQUEST_HANDOFF_SCHEMA_NAME,
         "schema_version": REQUEST_HANDOFF_SCHEMA_VERSION,
+        "identity": {
+            "source_family": REQUEST_HANDOFF_SOURCE_FAMILY,
+            "request_run_id": request_run_id,
+            "generated_corpus_id": generated_corpus_id,
+            "curated_corpus_id": curated_corpus_id,
+        },
         "request": {
             "path": _resolve_path_str(request_path),
             "payload": request.to_dict(),
@@ -129,6 +192,24 @@ def build_request_handoff_manifest(
             "effective_config_trace_path": _resolve_path_str(effective_config_trace_path),
             "filter_manifest_path": _resolve_path_str(filter_manifest_path),
             "filter_summary_path": _resolve_path_str(filter_summary_path),
+        },
+        "artifacts_relative": {
+            "run_root": ".",
+            "generated_dir": _relative_posix_path(generated_dir, start=run_root),
+            "filter_dir": _relative_posix_path(filter_dir, start=run_root),
+            "filtered_corpus_dir": _relative_posix_path(filtered_corpus_dir, start=run_root),
+            "effective_config_path": _relative_posix_path(effective_config_path, start=run_root),
+            "effective_config_trace_path": _relative_posix_path(
+                effective_config_trace_path, start=run_root
+            ),
+            "filter_manifest_path": _relative_posix_path(filter_manifest_path, start=run_root),
+            "filter_summary_path": _relative_posix_path(filter_summary_path, start=run_root),
+        },
+        "checksums": {
+            "effective_config_sha256": effective_config_sha256,
+            "effective_config_trace_sha256": effective_config_trace_sha256,
+            "filter_manifest_sha256": filter_manifest_sha256,
+            "filter_summary_sha256": filter_summary_sha256,
         },
         "summary": {
             "generated_datasets": int(generated_datasets),
@@ -168,6 +249,11 @@ def build_request_handoff_manifest(
             "summary_json_path": _resolve_optional_path_str(diversity_summary_json_path),
             "summary_md_path": _resolve_optional_path_str(diversity_summary_md_path),
         },
+        "defaults": {
+            "recommended_training_corpus": REQUEST_HANDOFF_RECOMMENDED_TRAINING_CORPUS,
+            "recommended_training_artifact_key": "filtered_corpus_dir",
+            "curation_policy": "accepted_only",
+        },
     }
     validate_request_handoff_manifest(payload)
     return payload
@@ -196,6 +282,32 @@ def validate_request_handoff_manifest(payload: Mapping[str, Any]) -> None:
             f"must equal {REQUEST_HANDOFF_SCHEMA_VERSION}",
         )
 
+    identity = _require_mapping(root.get("identity"), path="handoff_manifest.identity")
+    source_family = _require_non_empty_string(
+        identity.get("source_family"),
+        path="handoff_manifest.identity.source_family",
+    )
+    if source_family != REQUEST_HANDOFF_SOURCE_FAMILY:
+        _raise(
+            "handoff_manifest.identity.source_family",
+            f"must equal {REQUEST_HANDOFF_SOURCE_FAMILY!r}",
+        )
+    _require_hex_string(
+        identity.get("request_run_id"),
+        path="handoff_manifest.identity.request_run_id",
+        expected_length=_BLAKE2S_HEX_LENGTH,
+    )
+    _require_hex_string(
+        identity.get("generated_corpus_id"),
+        path="handoff_manifest.identity.generated_corpus_id",
+        expected_length=_BLAKE2S_HEX_LENGTH,
+    )
+    _require_hex_string(
+        identity.get("curated_corpus_id"),
+        path="handoff_manifest.identity.curated_corpus_id",
+        expected_length=_BLAKE2S_HEX_LENGTH,
+    )
+
     request = _require_mapping(root.get("request"), path="handoff_manifest.request")
     _require_non_empty_string(request.get("path"), path="handoff_manifest.request.path")
     request_payload = _require_mapping(
@@ -221,6 +333,43 @@ def validate_request_handoff_manifest(payload: Mapping[str, Any]) -> None:
         _require_non_empty_string(
             artifacts.get(key),
             path=f"handoff_manifest.artifacts.{key}",
+        )
+
+    artifacts_relative = _require_mapping(
+        root.get("artifacts_relative"),
+        path="handoff_manifest.artifacts_relative",
+    )
+    run_root_relative = _require_non_empty_string(
+        artifacts_relative.get("run_root"),
+        path="handoff_manifest.artifacts_relative.run_root",
+    )
+    if run_root_relative != ".":
+        _raise("handoff_manifest.artifacts_relative.run_root", "must equal '.'")
+    for key in (
+        "generated_dir",
+        "filter_dir",
+        "filtered_corpus_dir",
+        "effective_config_path",
+        "effective_config_trace_path",
+        "filter_manifest_path",
+        "filter_summary_path",
+    ):
+        _require_non_empty_string(
+            artifacts_relative.get(key),
+            path=f"handoff_manifest.artifacts_relative.{key}",
+        )
+
+    checksums = _require_mapping(root.get("checksums"), path="handoff_manifest.checksums")
+    for key in (
+        "effective_config_sha256",
+        "effective_config_trace_sha256",
+        "filter_manifest_sha256",
+        "filter_summary_sha256",
+    ):
+        _require_hex_string(
+            checksums.get(key),
+            path=f"handoff_manifest.checksums.{key}",
+            expected_length=_SHA256_HEX_LENGTH,
         )
 
     summary = _require_mapping(root.get("summary"), path="handoff_manifest.summary")
@@ -307,6 +456,35 @@ def validate_request_handoff_manifest(payload: Mapping[str, Any]) -> None:
         diversity_artifacts.get("summary_md_path"),
         path="handoff_manifest.diversity_artifacts.summary_md_path",
     )
+
+    defaults = _require_mapping(root.get("defaults"), path="handoff_manifest.defaults")
+    recommended_training_corpus = _require_non_empty_string(
+        defaults.get("recommended_training_corpus"),
+        path="handoff_manifest.defaults.recommended_training_corpus",
+    )
+    if recommended_training_corpus != REQUEST_HANDOFF_RECOMMENDED_TRAINING_CORPUS:
+        _raise(
+            "handoff_manifest.defaults.recommended_training_corpus",
+            f"must equal {REQUEST_HANDOFF_RECOMMENDED_TRAINING_CORPUS!r}",
+        )
+    recommended_artifact_key = _require_non_empty_string(
+        defaults.get("recommended_training_artifact_key"),
+        path="handoff_manifest.defaults.recommended_training_artifact_key",
+    )
+    if recommended_artifact_key != "filtered_corpus_dir":
+        _raise(
+            "handoff_manifest.defaults.recommended_training_artifact_key",
+            "must equal 'filtered_corpus_dir'",
+        )
+    curation_policy = _require_non_empty_string(
+        defaults.get("curation_policy"),
+        path="handoff_manifest.defaults.curation_policy",
+    )
+    if curation_policy != "accepted_only":
+        _raise(
+            "handoff_manifest.defaults.curation_policy",
+            "must equal 'accepted_only'",
+        )
 
 
 def write_request_handoff_manifest(

--- a/tests/test_request_execution.py
+++ b/tests/test_request_execution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -22,7 +23,10 @@ from dagzoo.config import (
 )
 from dagzoo.config.io import load_packaged_generator_config
 from dagzoo.core.config_resolution import resolve_request_config, serialize_resolution_events
-from dagzoo.core.request_handoff import REQUEST_HANDOFF_SCHEMA_NAME
+from dagzoo.core.request_handoff import (
+    REQUEST_HANDOFF_SCHEMA_NAME,
+    validate_request_handoff_manifest,
+)
 from dagzoo.filtering import DeferredFilterRunResult
 from dagzoo.hardware import HardwareInfo
 
@@ -317,11 +321,17 @@ def test_request_cli_end_to_end_writes_generated_filter_and_curated_outputs(
     assert summary["rejected_datasets"] == 0
     assert (output_root / "curated" / "shard_00000" / "metadata.ndjson").exists()
     handoff = json.loads((output_root / "handoff_manifest.json").read_text(encoding="utf-8"))
+    validate_request_handoff_manifest(handoff)
     assert handoff["schema_name"] == REQUEST_HANDOFF_SCHEMA_NAME
     assert handoff["artifacts"]["filtered_corpus_dir"] == str((output_root / "curated").resolve())
     assert handoff["artifacts"]["filter_summary_path"] == str(
         (output_root / "filter" / "filter_summary.json").resolve()
     )
+    assert handoff["artifacts_relative"]["filtered_corpus_dir"] == "curated"
+    assert handoff["defaults"]["recommended_training_corpus"] == "curated"
+    assert handoff["defaults"]["curation_policy"] == "accepted_only"
+    assert handoff["identity"]["source_family"] == "dagzoo.fixed_layout_scm"
+    assert len(handoff["checksums"]["filter_summary_sha256"]) == 64
     assert handoff["summary"]["accepted_datasets"] == 1
     assert handoff["diversity_artifacts"]["summary_json_path"] is None
 
@@ -364,6 +374,16 @@ def test_request_execution_manifest_uses_wall_clock_filter_timing(
         assert kwargs["in_dir"] == output_root / "generated"
         assert kwargs["out_dir"] == output_root / "filter"
         assert kwargs["curated_out_dir"] == output_root / "curated"
+        kwargs["out_dir"].mkdir(parents=True, exist_ok=True)
+        kwargs["curated_out_dir"].mkdir(parents=True, exist_ok=True)
+        (kwargs["out_dir"] / "filter_manifest.ndjson").write_text(
+            '{"dataset_index": 0, "accepted": true}\n',
+            encoding="utf-8",
+        )
+        (kwargs["out_dir"] / "filter_summary.json").write_text(
+            '{"accepted_datasets": 1, "rejected_datasets": 1}\n',
+            encoding="utf-8",
+        )
         return DeferredFilterRunResult(
             manifest_path=output_root / "filter" / "filter_manifest.ndjson",
             summary_path=output_root / "filter" / "filter_summary.json",
@@ -398,7 +418,66 @@ def test_request_execution_manifest_uses_wall_clock_filter_timing(
     )
 
     handoff = json.loads((output_root / "handoff_manifest.json").read_text(encoding="utf-8"))
+    validate_request_handoff_manifest(handoff)
     assert handoff["throughput"]["generation_stage"]["elapsed_seconds"] == pytest.approx(6.0)
     assert handoff["throughput"]["generation_stage"]["datasets_per_minute"] == pytest.approx(20.0)
     assert handoff["throughput"]["filter_stage"]["elapsed_seconds"] == pytest.approx(30.0)
     assert handoff["throughput"]["filter_stage"]["datasets_per_minute"] == pytest.approx(4.0)
+
+
+def test_request_handoff_identity_is_stable_after_request_run_directory_move(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output_root = tmp_path / "request_run"
+    request_path = write_yaml(
+        tmp_path,
+        "request.yaml",
+        _request_payload(
+            task=REQUEST_TASK_REGRESSION,
+            dataset_count=1,
+            rows=1024,
+            profile=REQUEST_PROFILE_SMOKE,
+            output_root=str(output_root),
+            seed=7,
+        ),
+    )
+
+    def _stub_filter(*_args, **_kwargs):
+        return True, {"wins_ratio": 1.0, "n_valid_oob": 128}
+
+    monkeypatch.setattr(
+        "dagzoo.filtering.deferred_filter._apply_extra_trees_filter_numpy", _stub_filter
+    )
+
+    code = main(
+        [
+            "request",
+            "--request",
+            str(request_path),
+            "--device",
+            "cpu",
+            "--hardware-policy",
+            "none",
+        ]
+    )
+
+    assert code == 0
+    original_manifest_path = output_root / "handoff_manifest.json"
+    original_manifest = json.loads(original_manifest_path.read_text(encoding="utf-8"))
+    validate_request_handoff_manifest(original_manifest)
+
+    moved_root = tmp_path / "request_run_copy"
+    shutil.copytree(output_root, moved_root)
+    moved_manifest_path = moved_root / "handoff_manifest.json"
+    moved_manifest = json.loads(moved_manifest_path.read_text(encoding="utf-8"))
+    validate_request_handoff_manifest(moved_manifest)
+
+    assert moved_manifest["identity"] == original_manifest["identity"]
+    assert moved_manifest["checksums"] == original_manifest["checksums"]
+    for key, relative_path in moved_manifest["artifacts_relative"].items():
+        resolved = (moved_root / relative_path).resolve()
+        if key == "run_root":
+            assert resolved == moved_root.resolve()
+        else:
+            assert resolved.exists()

--- a/tests/test_request_handoff.py
+++ b/tests/test_request_handoff.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -27,8 +28,26 @@ def _request_config(output_root: str) -> RequestFileConfig:
     )
 
 
+def _write_request_run_artifacts(run_root: Path) -> None:
+    generated_dir = run_root / "generated"
+    filter_dir = run_root / "filter"
+    generated_dir.mkdir(parents=True, exist_ok=True)
+    filter_dir.mkdir(parents=True, exist_ok=True)
+    (generated_dir / "effective_config.yaml").write_text("seed: 7\n", encoding="utf-8")
+    (generated_dir / "effective_config_trace.yaml").write_text("- source: test\n", encoding="utf-8")
+    (filter_dir / "filter_manifest.ndjson").write_text(
+        '{"dataset_index": 0, "accepted": true}\n',
+        encoding="utf-8",
+    )
+    (filter_dir / "filter_summary.json").write_text(
+        '{"accepted_datasets": 1, "rejected_datasets": 1}\n',
+        encoding="utf-8",
+    )
+
+
 def test_build_request_handoff_manifest_is_versioned_and_valid(tmp_path) -> None:
     request = _request_config(output_root="requests/demo")
+    _write_request_run_artifacts(tmp_path / "run")
     payload = build_request_handoff_manifest(
         request_path=tmp_path / "request.yaml",
         request=request,
@@ -58,10 +77,30 @@ def test_build_request_handoff_manifest_is_versioned_and_valid(tmp_path) -> None
 
     assert payload["schema_name"] == REQUEST_HANDOFF_SCHEMA_NAME
     assert payload["schema_version"] == REQUEST_HANDOFF_SCHEMA_VERSION
+    assert payload["identity"]["source_family"] == "dagzoo.fixed_layout_scm"
+    assert len(payload["identity"]["request_run_id"]) == 32
+    assert len(payload["identity"]["generated_corpus_id"]) == 32
+    assert len(payload["identity"]["curated_corpus_id"]) == 32
     assert payload["request"]["payload"] == request.to_dict()
     assert payload["artifacts"]["filtered_corpus_dir"] == str(
         (tmp_path / "run" / "curated").resolve()
     )
+    assert payload["artifacts_relative"] == {
+        "run_root": ".",
+        "generated_dir": "generated",
+        "filter_dir": "filter",
+        "filtered_corpus_dir": "curated",
+        "effective_config_path": "generated/effective_config.yaml",
+        "effective_config_trace_path": "generated/effective_config_trace.yaml",
+        "filter_manifest_path": "filter/filter_manifest.ndjson",
+        "filter_summary_path": "filter/filter_summary.json",
+    }
+    assert len(payload["checksums"]["effective_config_sha256"]) == 64
+    assert payload["defaults"] == {
+        "recommended_training_corpus": "curated",
+        "recommended_training_artifact_key": "filtered_corpus_dir",
+        "curation_policy": "accepted_only",
+    }
     assert payload["summary"]["acceptance_rate"] == pytest.approx(0.5)
     assert payload["throughput"]["generation_stage"]["datasets_per_minute"] == pytest.approx(10.0)
     assert payload["throughput"]["filter_stage"]["datasets_per_minute"] == pytest.approx(20.0)
@@ -73,6 +112,7 @@ def test_build_request_handoff_manifest_is_versioned_and_valid(tmp_path) -> None
 
 def test_write_request_handoff_manifest_writes_json_and_rejects_invalid_payload(tmp_path) -> None:
     request = _request_config(output_root="requests/demo")
+    _write_request_run_artifacts(tmp_path / "run")
     manifest_path = write_request_handoff_manifest(
         request_path=tmp_path / "request.yaml",
         request=request,
@@ -103,6 +143,7 @@ def test_write_request_handoff_manifest_writes_json_and_rejects_invalid_payload(
     validate_request_handoff_manifest(payload)
     assert payload["summary"]["accepted_datasets"] == 2
     assert payload["throughput"]["filter_stage"]["datasets_per_minute"] == pytest.approx(30.0)
+    assert payload["defaults"]["recommended_training_corpus"] == "curated"
     assert list((tmp_path / "run").glob(".handoff_manifest.json.*.tmp")) == []
 
     payload["request"]["payload"]["version"] = "v2"
@@ -117,6 +158,7 @@ def test_write_request_handoff_manifest_does_not_overwrite_existing_file(tmp_pat
     manifest_path = tmp_path / "run" / "handoff_manifest.json"
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
     manifest_path.write_text('{"sentinel": true}\n', encoding="utf-8")
+    _write_request_run_artifacts(tmp_path / "run")
 
     with pytest.raises(RuntimeError, match="promotion target already exists"):
         _ = write_request_handoff_manifest(


### PR DESCRIPTION
## Summary
- capture the Quadrant instructions for creating the Dagzoo Corpus Contract Hardening epic and its tickets
- detail the requested schema and manifest upgrades along with validation steps and dependencies
- record downstream contract changes that will require pyproject and changelog updates before merging

## Testing
- Not run (not requested)