### PR TITLE
fix(release): create GitHub releases for published versions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -28,6 +28,7 @@ jobs:
       contents: read
     outputs:
       should_publish: ${{ steps.plan.outputs.should_publish }}
+      tag_name: ${{ steps.plan.outputs.tag_name }}
       version: ${{ steps.plan.outputs.version }}
       source_ref: ${{ steps.target.outputs.source_ref }}
       source_sha: ${{ steps.source.outputs.source_sha }}
@@ -137,9 +138,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
 
   release:
-    if: >-
-      needs.resolve-release.outputs.should_publish == 'true'
-      && startsWith(github.ref, 'refs/tags/v')
+    if: needs.resolve-release.outputs.should_publish == 'true'
     needs:
       - resolve-release
       - build
@@ -160,3 +159,6 @@ jobs:
         with:
           files: dist/*
           generate_release_notes: true
+          name: ${{ needs.resolve-release.outputs.tag_name }}
+          tag_name: ${{ needs.resolve-release.outputs.tag_name }}
+          target_commitish: ${{ needs.resolve-release.outputs.source_sha }}


### PR DESCRIPTION
## Summary
- expose the resolved release tag as a workflow output
- create the GitHub tag/release from the resolved source SHA on every successful publish
- keep manual backfills and main publishes aligned with the repo front page

## Validation
- ./.venv/bin/python -c 'import pathlib, yaml; yaml.safe_load(pathlib.Path(".github/workflows/package.yml").read_text())'
- ./scripts/dev verify quick