### PR TITLE
ci(benchmark): add PR delta reporting

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,13 +47,25 @@ jobs:
             --no-memory \
             --out-dir benchmarks/results/ci_smoke
 
-      - name: Upload smoke benchmark artifacts
+      - name: Render smoke benchmark PR report
         if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: benchmark-smoke-pr
-          path: benchmarks/results/ci_smoke
-          if-no-files-found: warn
+        run: |
+          uv run python scripts/ci/benchmark_pr_report.py \
+            --summary-json benchmarks/results/ci_smoke/summary.json \
+            --baseline-json benchmarks/baselines/cpu_smoke.json \
+            --title "Benchmark Smoke (CPU)" \
+            --comment-out benchmarks/results/ci_smoke/benchmark_pr_comment.md \
+            --step-summary-out benchmarks/results/ci_smoke/benchmark_pr_step_summary.md \
+            --delta-out benchmarks/results/ci_smoke/benchmark_delta.json
+
+      - name: Publish smoke benchmark step summary
+        if: always()
+        run: |
+          if [ -f benchmarks/results/ci_smoke/benchmark_pr_step_summary.md ]; then
+            cat benchmarks/results/ci_smoke/benchmark_pr_step_summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "benchmark_pr_step_summary.md was not generated." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Comment smoke benchmark summary on PR
         if: always()
@@ -62,14 +74,15 @@ jobs:
           script: |
             const fs = require('fs');
             const marker = '<!-- dagzoo-benchmark-smoke -->';
-            const summaryPath = 'benchmarks/results/ci_smoke/summary.md';
+            const commentPath = 'benchmarks/results/ci_smoke/benchmark_pr_comment.md';
 
-            let summary = 'Benchmark summary file was not generated.';
-            if (fs.existsSync(summaryPath)) {
-              summary = fs.readFileSync(summaryPath, 'utf8');
+            let body = `${marker}\n`;
+            if (fs.existsSync(commentPath)) {
+              body += fs.readFileSync(commentPath, 'utf8');
+            } else {
+              body += '# Benchmark Smoke (CPU)\n\n_Benchmark summary file was not generated._\n';
             }
 
-            const body = `${marker}\n## Benchmark Smoke (CPU)\n\n${summary}`;
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
 
@@ -96,6 +109,14 @@ jobs:
                 body,
               });
             }
+
+      - name: Upload smoke benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-smoke-pr
+          path: benchmarks/results/ci_smoke
+          if-no-files-found: warn
 
   benchmark-standard-scheduled:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'

--- a/scripts/ci/benchmark_pr_report.py
+++ b/scripts/ci/benchmark_pr_report.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+# ruff: noqa: I001
+"""Render benchmark PR artifacts from a suite summary and checked-in baseline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from dagzoo.bench.baseline import DEFAULT_GATING_METRICS, load_baseline  # noqa: E402
+from dagzoo.bench.metrics import degradation_percent  # noqa: E402
+from dagzoo.math import sanitize_json  # noqa: E402
+
+
+DEFAULT_WARN_THRESHOLD_PCT = 10.0
+DEFAULT_FAIL_THRESHOLD_PCT = 20.0
+
+
+def _load_summary(path: str | Path) -> dict[str, Any]:
+    summary_path = Path(path)
+    if not summary_path.exists():
+        return {"preset_results": []}
+    with summary_path.open("r", encoding="utf-8") as f:
+        payload = json.load(f)
+    if not isinstance(payload, dict):
+        raise ValueError("Benchmark summary payload must be a JSON object.")
+    return payload
+
+
+def _coerce_metric_value(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    as_float = float(value)
+    if not math.isfinite(as_float):
+        return None
+    return as_float
+
+
+def _format_value(value: object, *, digits: int = 3) -> str:
+    coerced = _coerce_metric_value(value)
+    if coerced is None:
+        return "-"
+    return f"{coerced:.{digits}f}"
+
+
+def _format_percent(value: object, *, digits: int = 2) -> str:
+    coerced = _coerce_metric_value(value)
+    if coerced is None:
+        return "-"
+    return f"{coerced:.{digits}f}"
+
+
+def _render_threshold_line(report: dict[str, Any]) -> str:
+    return (
+        f"- Thresholds: warn `{report['warn_threshold_pct']:.1f}%`, "
+        f"fail `{report['fail_threshold_pct']:.1f}%`"
+    )
+
+
+def _severity_from_degradation(
+    degradation_pct: float | None,
+    *,
+    warn_threshold_pct: float,
+    fail_threshold_pct: float,
+) -> str:
+    if degradation_pct is None:
+        return "n/a"
+    if degradation_pct >= fail_threshold_pct:
+        return "fail"
+    if degradation_pct >= warn_threshold_pct:
+        return "warn"
+    return "pass"
+
+
+def build_benchmark_pr_report(
+    summary: dict[str, Any],
+    baseline: dict[str, Any],
+    *,
+    title: str,
+    summary_path: str | Path,
+    baseline_path: str | Path,
+    warn_threshold_pct: float = DEFAULT_WARN_THRESHOLD_PCT,
+    fail_threshold_pct: float = DEFAULT_FAIL_THRESHOLD_PCT,
+    summary_available: bool = True,
+) -> dict[str, Any]:
+    """Build a machine-readable benchmark delta report."""
+
+    metric_names = list(baseline.get("metrics", []))
+    if not metric_names:
+        metric_names = list(DEFAULT_GATING_METRICS)
+
+    baseline_presets = baseline.get("presets", {})
+    preset_reports: list[dict[str, Any]] = []
+    issues: list[dict[str, Any]] = []
+
+    preset_results = summary.get("preset_results", [])
+    if not isinstance(preset_results, list):
+        preset_results = []
+
+    for result in preset_results:
+        if not isinstance(result, dict):
+            continue
+
+        preset_key = str(result.get("preset_key", "-"))
+        preset_baseline = baseline_presets.get(preset_key)
+        preset_rows: list[dict[str, Any]] = []
+
+        for metric in metric_names:
+            current = _coerce_metric_value(result.get(metric))
+            baseline_value = None
+            if isinstance(preset_baseline, dict):
+                baseline_value = _coerce_metric_value(preset_baseline.get(metric))
+
+            degradation_pct = (
+                degradation_percent(metric, float(current), float(baseline_value))
+                if current is not None and baseline_value is not None
+                else None
+            )
+            severity = _severity_from_degradation(
+                degradation_pct,
+                warn_threshold_pct=warn_threshold_pct,
+                fail_threshold_pct=fail_threshold_pct,
+            )
+
+            row = {
+                "metric": metric,
+                "current": current,
+                "baseline": baseline_value,
+                "degradation_pct": degradation_pct,
+                "severity": severity,
+            }
+            preset_rows.append(row)
+            if severity in {"warn", "fail"}:
+                issues.append({"preset": preset_key, **row})
+
+        preset_status = "pass"
+        if any(row["severity"] == "fail" for row in preset_rows):
+            preset_status = "fail"
+        elif any(row["severity"] == "warn" for row in preset_rows):
+            preset_status = "warn"
+        elif any(row["severity"] == "n/a" for row in preset_rows):
+            preset_status = "n/a"
+
+        preset_reports.append(
+            {
+                "preset_key": preset_key,
+                "status": preset_status,
+                "rows": preset_rows,
+            }
+        )
+
+    status = "pass"
+    if not summary_available:
+        status = "missing-summary"
+    elif any(issue["severity"] == "fail" for issue in issues):
+        status = "fail"
+    elif issues:
+        status = "warn"
+
+    return {
+        "title": title,
+        "summary_available": bool(summary_available),
+        "summary_path": str(summary_path),
+        "baseline_path": str(baseline_path),
+        "suite": summary.get("suite"),
+        "baseline_suite": baseline.get("suite"),
+        "warn_threshold_pct": float(warn_threshold_pct),
+        "fail_threshold_pct": float(fail_threshold_pct),
+        "status": status,
+        "metrics": metric_names,
+        "preset_reports": preset_reports,
+        "issues": issues,
+        "issue_count": len(issues),
+    }
+
+
+def render_comment_markdown(report: dict[str, Any]) -> str:
+    """Render the compact PR comment body."""
+
+    lines = [
+        f"# {report['title']}",
+        "",
+        f"- Suite: `{report.get('suite', '-')}`",
+        f"- Status: `{report['status']}`",
+        _render_threshold_line(report),
+    ]
+
+    if not report.get("summary_available", True):
+        lines.extend(
+            [
+                "",
+                "_Benchmark summary file was not generated._",
+            ]
+        )
+        return "\n".join(lines).rstrip() + "\n"
+
+    baseline_suite = report.get("baseline_suite")
+    if baseline_suite is not None and report.get("suite") != baseline_suite:
+        lines.append(f"- Baseline suite: `{baseline_suite}`")
+
+    if report.get("issue_count", 0):
+        lines.append(f"- Regression issues: `{report['issue_count']}`")
+
+    preset_reports = report.get("preset_reports", [])
+    if not isinstance(preset_reports, list) or not preset_reports:
+        lines.extend(["", "_No benchmark preset results were found._"])
+        return "\n".join(lines).rstrip() + "\n"
+
+    for preset in preset_reports:
+        if not isinstance(preset, dict):
+            continue
+        lines.extend(
+            [
+                "",
+                f"## {preset.get('preset_key', '-')}",
+                "",
+                "| Metric | Current | Baseline | Delta % | Severity |",
+                "|---|---:|---:|---:|---|",
+            ]
+        )
+        for row in preset.get("rows", []):
+            if not isinstance(row, dict):
+                continue
+            severity = str(row.get("severity", "n/a"))
+            lines.append(
+                "| "
+                f"{row.get('metric', '-')} | "
+                f"{_format_value(row.get('current'))} | "
+                f"{_format_value(row.get('baseline'))} | "
+                f"{_format_percent(row.get('degradation_pct'))} | "
+                f"{severity} |"
+            )
+
+    if report.get("issues"):
+        lines.extend(["", "## Regression Issues"])
+        for issue in report["issues"]:
+            lines.append(
+                f"- `{issue.get('preset', '-')}` / `{issue.get('metric', '-')}`: "
+                f"{issue.get('severity')} at {_format_percent(issue.get('degradation_pct'))}% "
+                f"({_format_value(issue.get('current'))} vs {_format_value(issue.get('baseline'))})"
+            )
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_step_summary_markdown(report: dict[str, Any]) -> str:
+    """Render the GitHub step-summary body."""
+
+    lines = [
+        f"# {report['title']}",
+        "",
+        f"- Suite: `{report.get('suite', '-')}`",
+        f"- Status: `{report['status']}`",
+        f"- Summary: `{report['summary_path']}`",
+        f"- Baseline: `{report['baseline_path']}`",
+        _render_threshold_line(report),
+    ]
+
+    preset_reports = report.get("preset_reports", [])
+    if not report.get("summary_available", True):
+        lines.extend(
+            [
+                "",
+                "_Benchmark summary file was not generated._",
+            ]
+        )
+    elif not isinstance(preset_reports, list) or not preset_reports:
+        lines.extend(
+            [
+                "",
+                "_No benchmark preset results were found._",
+            ]
+        )
+    else:
+        for preset in preset_reports:
+            if not isinstance(preset, dict):
+                continue
+            lines.extend(
+                [
+                    "",
+                    f"## {preset.get('preset_key', '-')}",
+                    "",
+                    "| Metric | Current | Baseline | Delta % | Severity |",
+                    "|---|---:|---:|---:|---|",
+                ]
+            )
+            for row in preset.get("rows", []):
+                if not isinstance(row, dict):
+                    continue
+                severity = str(row.get("severity", "n/a"))
+                lines.append(
+                    "| "
+                    f"{row.get('metric', '-')} | "
+                    f"{_format_value(row.get('current'))} | "
+                    f"{_format_value(row.get('baseline'))} | "
+                    f"{_format_percent(row.get('degradation_pct'))} | "
+                    f"{severity} |"
+                )
+
+    lines.extend(
+        [
+            "",
+            "## Artifacts",
+            f"- Comment markdown: `{report.get('comment_path', '-')}`",
+            f"- Delta JSON: `{report.get('delta_path', '-')}`",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_report_artifacts(
+    report: dict[str, Any],
+    *,
+    comment_out: str | Path,
+    step_summary_out: str | Path,
+    delta_out: str | Path,
+) -> tuple[Path, Path, Path]:
+    """Write the rendered benchmark artifacts to disk."""
+
+    comment_path = Path(comment_out)
+    step_summary_path = Path(step_summary_out)
+    delta_path = Path(delta_out)
+
+    report = {
+        **report,
+        "comment_path": str(comment_path),
+        "step_summary_path": str(step_summary_path),
+        "delta_path": str(delta_path),
+    }
+
+    comment_path.parent.mkdir(parents=True, exist_ok=True)
+    step_summary_path.parent.mkdir(parents=True, exist_ok=True)
+    delta_path.parent.mkdir(parents=True, exist_ok=True)
+
+    comment_path.write_text(render_comment_markdown(report), encoding="utf-8")
+    step_summary_path.write_text(render_step_summary_markdown(report), encoding="utf-8")
+    with delta_path.open("w", encoding="utf-8") as f:
+        json.dump(sanitize_json(report), f, indent=2, sort_keys=True, allow_nan=False)
+        f.write("\n")
+
+    return comment_path, step_summary_path, delta_path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="benchmark_pr_report")
+    parser.add_argument("--summary-json", required=True)
+    parser.add_argument("--baseline-json", required=True)
+    parser.add_argument("--comment-out", required=True)
+    parser.add_argument("--step-summary-out", required=True)
+    parser.add_argument("--delta-out", required=True)
+    parser.add_argument("--title", required=True)
+    parser.add_argument(
+        "--warn-threshold-pct",
+        type=float,
+        default=DEFAULT_WARN_THRESHOLD_PCT,
+    )
+    parser.add_argument(
+        "--fail-threshold-pct",
+        type=float,
+        default=DEFAULT_FAIL_THRESHOLD_PCT,
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    parser = build_parser()
+    parsed = parser.parse_args(args)
+
+    summary_path = Path(parsed.summary_json)
+    baseline_path = Path(parsed.baseline_json)
+    summary = _load_summary(summary_path)
+    baseline = load_baseline(baseline_path)
+    report = build_benchmark_pr_report(
+        summary,
+        baseline,
+        title=str(parsed.title),
+        summary_path=summary_path,
+        baseline_path=baseline_path,
+        warn_threshold_pct=float(parsed.warn_threshold_pct),
+        fail_threshold_pct=float(parsed.fail_threshold_pct),
+        summary_available=summary_path.exists(),
+    )
+    write_report_artifacts(
+        report,
+        comment_out=parsed.comment_out,
+        step_summary_out=parsed.step_summary_out,
+        delta_out=parsed.delta_out,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_benchmark_pr_report.py
+++ b/tests/test_benchmark_pr_report.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from conftest import load_script_module
+
+
+def _write_json(path: Path, payload: object) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_build_and_render_benchmark_pr_report(tmp_path) -> None:
+    module = load_script_module("benchmark_pr_report", "scripts/ci/benchmark_pr_report.py")
+    summary_path = tmp_path / "summary.json"
+    baseline_path = tmp_path / "baseline.json"
+
+    summary_payload = {
+        "suite": "smoke",
+        "preset_results": [
+            {
+                "preset_key": "cpu",
+                "datasets_per_minute": 85.0,
+                "generation_datasets_per_minute": 100.0,
+                "write_datasets_per_minute": 100.0,
+                "filter_datasets_per_minute": None,
+                "filter_accepted_datasets_per_minute": None,
+            }
+        ],
+    }
+    baseline_payload = {
+        "version": 1,
+        "suite": "smoke",
+        "metrics": [
+            "datasets_per_minute",
+            "generation_datasets_per_minute",
+            "write_datasets_per_minute",
+        ],
+        "presets": {
+            "cpu": {
+                "datasets_per_minute": 100.0,
+                "generation_datasets_per_minute": 100.0,
+                "write_datasets_per_minute": 100.0,
+            }
+        },
+    }
+    _write_json(summary_path, summary_payload)
+    _write_json(baseline_path, baseline_payload)
+
+    report = module.build_benchmark_pr_report(
+        summary_payload,
+        baseline_payload,
+        title="Benchmark Smoke (CPU)",
+        summary_path=summary_path,
+        baseline_path=baseline_path,
+        warn_threshold_pct=10.0,
+        fail_threshold_pct=20.0,
+    )
+    comment = module.render_comment_markdown(report)
+    step_summary = module.render_step_summary_markdown(
+        {
+            **report,
+            "comment_path": "benchmarks/results/ci_smoke/benchmark_pr_comment.md",
+            "delta_path": "benchmarks/results/ci_smoke/benchmark_delta.json",
+        }
+    )
+    comment_path, step_summary_path, delta_path = module.write_report_artifacts(
+        {
+            **report,
+            "comment_path": "benchmarks/results/ci_smoke/benchmark_pr_comment.md",
+            "delta_path": "benchmarks/results/ci_smoke/benchmark_delta.json",
+        },
+        comment_out=tmp_path / "benchmark_pr_comment.md",
+        step_summary_out=tmp_path / "benchmark_pr_step_summary.md",
+        delta_out=tmp_path / "benchmark_delta.json",
+    )
+
+    assert report["status"] == "warn"
+    assert report["issue_count"] == 1
+    assert "| Metric | Current | Baseline | Delta % | Severity |" in comment
+    assert "datasets_per_minute" in comment
+    assert "warn" in comment
+    assert "## Artifacts" in step_summary
+    assert comment_path.exists()
+    assert step_summary_path.exists()
+    assert delta_path.exists()
+    delta_payload = json.loads(delta_path.read_text(encoding="utf-8"))
+    assert delta_payload["status"] == "warn"
+    assert delta_payload["preset_reports"][0]["rows"][0]["severity"] == "warn"
+
+
+def test_main_handles_missing_summary_file(tmp_path) -> None:
+    module = load_script_module("benchmark_pr_report_missing", "scripts/ci/benchmark_pr_report.py")
+    baseline_path = tmp_path / "baseline.json"
+    _write_json(
+        baseline_path,
+        {
+            "version": 1,
+            "suite": "smoke",
+            "metrics": ["datasets_per_minute"],
+            "presets": {"cpu": {"datasets_per_minute": 100.0}},
+        },
+    )
+
+    exit_code = module.main(
+        [
+            "--summary-json",
+            str(tmp_path / "missing_summary.json"),
+            "--baseline-json",
+            str(baseline_path),
+            "--title",
+            "Benchmark Smoke (CPU)",
+            "--comment-out",
+            str(tmp_path / "comment.md"),
+            "--step-summary-out",
+            str(tmp_path / "step_summary.md"),
+            "--delta-out",
+            str(tmp_path / "delta.json"),
+        ]
+    )
+
+    assert exit_code == 0
+    assert "Benchmark summary file was not generated." in (tmp_path / "comment.md").read_text(
+        encoding="utf-8"
+    )
+    assert '"missing-summary"' in (tmp_path / "delta.json").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- move benchmark PR comment rendering into a repo script
- emit PR comment markdown, step-summary markdown, and `benchmark_delta.json` from benchmark summary + baseline inputs
- update the benchmark workflow to publish the generated report artifacts and post the PR comment from the rendered file

## Validation
- `./scripts/dev verify quick`
- `./.venv/bin/pytest tests/test_benchmark_pr_report.py -q`
- `./.venv/bin/python scripts/ci/benchmark_pr_report.py --help`
- `./.venv/bin/pytest -q`