### PR TITLE
[codex] Streamline internal generation plumbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ contains imported legacy history, so date order is not strictly monotonic:
 `0.3.0` records the older `cauchy-generator -> dagzoo` rename, while `0.5.0`
 records the later `dagsynth -> dagzoo` rename on the current release line.
 
+## [0.15.1] - 2026-03-27
+
+### Changed
+
+- Streamlined internal generation and benchmark plumbing by removing
+  fixed-layout compatibility shims, consolidating config-resolution and
+  effective-config serialization helpers, routing the PyTorch bridge through
+  the canonical batch iterator, and centralizing shared benchmark/runtime
+  predicate and count helpers without changing the public CLI or artifact
+  contracts.
+
 ## [0.15.0] - 2026-03-27
 
 ### Changed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: Benson
 repository-code: https://github.com/bensonlee5/dagzoo
 url: https://github.com/bensonlee5/dagzoo
-version: 0.15.0
+version: 0.15.1
 date-released: 2026-03-27
 license: Apache-2.0
 abstract: Reproducible synthetic tabular data generation with curated reference packs and stable artifact contracts.
@@ -17,6 +17,6 @@ preferred-citation:
     - family-names: Lee
       given-names: Benson
   title: dagzoo
-  version: 0.14.5
+  version: 0.15.1
   date-released: 2026-03-27
   url: https://github.com/bensonlee5/dagzoo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dagzoo"
-version = "0.15.0"
+version = "0.15.1"
 description = "Synthetic tabular data generator for causal modeling"
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [

--- a/src/dagzoo/bench/corpus_probe.py
+++ b/src/dagzoo/bench/corpus_probe.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from dagzoo.bench.constants import SMOKE_NUM_DATASETS_CAP, SMOKE_WARMUP_DATASETS_CAP
+from dagzoo.bench.runtime_support import _resolve_benchmark_run_counts
 from dagzoo.bench.stage_metrics import FilterStageMeasurement, replay_filter_stage_metrics
 from dagzoo.bench.throughput import iter_throughput_measure_bundles, run_throughput_benchmark
 from dagzoo.config import GeneratorConfig, clone_generator_config
@@ -57,10 +57,11 @@ def resolve_corpus_probe_counts(
         num_datasets = int(num_datasets_override)
     if warmup_override is not None:
         warmup = int(warmup_override)
-    if suite == "smoke":
-        num_datasets = min(num_datasets, SMOKE_NUM_DATASETS_CAP)
-        warmup = min(warmup, SMOKE_WARMUP_DATASETS_CAP)
-    return max(1, num_datasets), max(0, warmup)
+    return _resolve_benchmark_run_counts(
+        num_datasets=num_datasets,
+        warmup_datasets=warmup,
+        suite=suite,
+    )
 
 
 def build_corpus_probe_coverage_config(config: GeneratorConfig) -> CoverageAggregationConfig:

--- a/src/dagzoo/bench/runtime_support.py
+++ b/src/dagzoo/bench/runtime_support.py
@@ -13,11 +13,7 @@ from typing import Any
 
 import torch
 
-from dagzoo.config import (
-    MISSINGNESS_MECHANISM_NONE,
-    NOISE_FAMILY_GAUSSIAN,
-    GeneratorConfig,
-)
+from dagzoo.config import GeneratorConfig
 from dagzoo.core.dataset import generate_batch_iter, generate_one
 from dagzoo.diagnostics import CoverageAggregator
 from dagzoo.diagnostics_targets import build_diagnostics_aggregation_config
@@ -98,10 +94,26 @@ def _preset_counts(
     if warmup_override is not None:
         warmup = int(warmup_override)
 
+    return _resolve_benchmark_run_counts(
+        num_datasets=num,
+        warmup_datasets=warmup,
+        suite=suite,
+    )
+
+
+def _resolve_benchmark_run_counts(
+    *,
+    num_datasets: int,
+    warmup_datasets: int,
+    suite: str,
+) -> tuple[int, int]:
+    """Apply shared benchmark-style suite caps to dataset and warmup counts."""
+
+    num = int(num_datasets)
+    warmup = int(warmup_datasets)
     if suite == "smoke":
         num = min(num, SMOKE_NUM_DATASETS_CAP)
         warmup = min(warmup, SMOKE_WARMUP_DATASETS_CAP)
-
     return max(1, num), max(0, warmup)
 
 
@@ -180,27 +192,6 @@ def _build_diagnostics_aggregator(config: GeneratorConfig) -> CoverageAggregator
     """Create a diagnostics coverage aggregator from config."""
 
     return CoverageAggregator(build_diagnostics_aggregation_config(config))
-
-
-def _is_missingness_enabled(config: GeneratorConfig) -> bool:
-    """Return whether missingness is enabled in config."""
-
-    return bool(
-        float(config.dataset.missing_rate) > 0.0
-        and str(config.dataset.missing_mechanism).strip().lower() != MISSINGNESS_MECHANISM_NONE
-    )
-
-
-def _is_shift_enabled(config: GeneratorConfig) -> bool:
-    """Return whether shift controls are enabled in config."""
-
-    return bool(config.shift.enabled)
-
-
-def _is_noise_enabled(config: GeneratorConfig) -> bool:
-    """Return whether non-gaussian noise controls are enabled in config."""
-
-    return str(config.noise.family).strip().lower() != NOISE_FAMILY_GAUSSIAN
 
 
 def _build_shift_directional_check(

--- a/src/dagzoo/bench/suite.py
+++ b/src/dagzoo/bench/suite.py
@@ -54,9 +54,6 @@ from dagzoo.bench.runtime_support import (
     _build_diagnostics_aggregator,
     _build_shift_directional_check,
     _collect_latency,
-    _is_missingness_enabled,
-    _is_noise_enabled,
-    _is_shift_enabled,
     _latency_sample_count,
     _peak_rss_mb,
     _preset_counts,
@@ -76,6 +73,15 @@ from dagzoo.config import (
     SHIFT_MODE_OFF,
     GeneratorConfig,
     effective_config_payload,
+)
+from dagzoo.core.config_predicates import (
+    missingness_enabled as _is_missingness_enabled,
+)
+from dagzoo.core.config_predicates import (
+    non_gaussian_noise_enabled as _is_noise_enabled,
+)
+from dagzoo.core.config_predicates import (
+    shift_enabled as _is_shift_enabled,
 )
 from dagzoo.core.config_resolution import (
     append_config_diff_events,

--- a/src/dagzoo/cli/commands/benchmark.py
+++ b/src/dagzoo/cli/commands/benchmark.py
@@ -8,8 +8,6 @@ import re
 from pathlib import Path
 from typing import Any
 
-import yaml
-
 from dagzoo.bench.baseline import (
     build_baseline_payload,
     load_baseline,
@@ -20,7 +18,12 @@ from dagzoo.bench.suite import resolve_preset_run_specs, run_benchmark_suite
 from dagzoo.config import GeneratorConfig
 
 from ..common import load_config_or_usage_error, raise_usage_error
-from ..effective_config import print_resolution_trace
+from ..effective_config import (
+    print_effective_config_payload,
+    print_resolution_trace,
+    write_effective_config_payload,
+    write_effective_config_trace,
+)
 
 
 def _default_benchmark_config(args: argparse.Namespace) -> GeneratorConfig:
@@ -97,19 +100,13 @@ def _write_benchmark_effective_configs(
         count = key_counts[key]
         suffix = f"_run{count}" if count > 1 else ""
         path = out_root / f"{key}{suffix}.yaml"
-        path.write_text(
-            yaml.safe_dump(payload, sort_keys=False, default_flow_style=False),
-            encoding="utf-8",
-        )
+        write_effective_config_payload(payload, path)
         config_paths.append(path)
 
         trace_payload = result.get("effective_config_trace")
         if isinstance(trace_payload, list):
             trace_path = out_root / f"{key}{suffix}_trace.yaml"
-            trace_path.write_text(
-                yaml.safe_dump(trace_payload, sort_keys=False, default_flow_style=False),
-                encoding="utf-8",
-            )
+            write_effective_config_trace(trace_payload, trace_path)
             trace_paths.append(trace_path)
     return config_paths, trace_paths
 
@@ -268,8 +265,7 @@ def run_benchmark_command(args: argparse.Namespace) -> int:
             if not isinstance(payload, dict):
                 continue
             preset_key = str(result.get("preset_key", "unknown"))
-            print(f"Effective config [{preset_key}]:")
-            print(yaml.safe_dump(payload, sort_keys=False, default_flow_style=False).rstrip())
+            print_effective_config_payload(payload, header=f"Effective config [{preset_key}]:")
     if args.print_resolution_trace:
         for result in summary.get("preset_results", []):
             if not isinstance(result, dict):

--- a/src/dagzoo/cli/effective_config.py
+++ b/src/dagzoo/cli/effective_config.py
@@ -10,22 +10,34 @@ import yaml
 from dagzoo.config import GeneratorConfig, effective_config_payload
 
 
-def effective_config_yaml(config: GeneratorConfig) -> str:
-    """Render an effective config payload as YAML text."""
+def effective_config_payload_yaml(payload: dict[str, Any]) -> str:
+    """Render an already-materialized effective config payload as YAML text."""
 
     return yaml.safe_dump(
-        effective_config_payload(config),
+        payload,
         sort_keys=False,
         default_flow_style=False,
     )
 
 
+def effective_config_yaml(config: GeneratorConfig) -> str:
+    """Render an effective config payload as YAML text."""
+
+    return effective_config_payload_yaml(effective_config_payload(config))
+
+
+def write_effective_config_payload(payload: dict[str, Any], path: Path) -> Path:
+    """Persist one already-materialized effective config payload as YAML."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(effective_config_payload_yaml(payload), encoding="utf-8")
+    return path
+
+
 def write_effective_config(config: GeneratorConfig, path: Path) -> Path:
     """Persist effective config YAML to disk."""
 
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(effective_config_yaml(config), encoding="utf-8")
-    return path
+    return write_effective_config_payload(effective_config_payload(config), path)
 
 
 def effective_resolution_trace_yaml(trace_payload: list[dict[str, Any]]) -> str:
@@ -49,8 +61,14 @@ def write_effective_config_trace(trace_payload: list[dict[str, Any]], path: Path
 def print_effective_config(config: GeneratorConfig, *, header: str) -> None:
     """Print effective config YAML to stdout with a short header."""
 
+    print_effective_config_payload(effective_config_payload(config), header=header)
+
+
+def print_effective_config_payload(payload: dict[str, Any], *, header: str) -> None:
+    """Print one already-materialized effective config payload as YAML."""
+
     print(header)
-    print(effective_config_yaml(config).rstrip())
+    print(effective_config_payload_yaml(payload).rstrip())
 
 
 def print_resolution_trace(trace_payload: list[dict[str, Any]], *, header: str) -> None:

--- a/src/dagzoo/core/config_predicates.py
+++ b/src/dagzoo/core/config_predicates.py
@@ -1,0 +1,30 @@
+"""Shared config state predicates used across runtime and benchmark code."""
+
+from __future__ import annotations
+
+from dagzoo.config import (
+    MISSINGNESS_MECHANISM_NONE,
+    NOISE_FAMILY_GAUSSIAN,
+    GeneratorConfig,
+)
+
+
+def missingness_enabled(config: GeneratorConfig) -> bool:
+    """Return whether missingness injection can mutate emitted tensors."""
+
+    return bool(
+        float(config.dataset.missing_rate) > 0.0
+        and str(config.dataset.missing_mechanism).strip().lower() != MISSINGNESS_MECHANISM_NONE
+    )
+
+
+def shift_enabled(config: GeneratorConfig) -> bool:
+    """Return whether shift controls are enabled in config."""
+
+    return bool(config.shift.enabled)
+
+
+def non_gaussian_noise_enabled(config: GeneratorConfig) -> bool:
+    """Return whether non-Gaussian noise controls are enabled in config."""
+
+    return str(config.noise.family).strip().lower() != NOISE_FAMILY_GAUSSIAN

--- a/src/dagzoo/core/config_resolution.py
+++ b/src/dagzoo/core/config_resolution.py
@@ -255,6 +255,72 @@ def cap_rows_spec_to_total(config: GeneratorConfig, *, total_rows_cap: int) -> N
     config.dataset.rows = DatasetRowsSpec(mode="range", start=capped_start, stop=capped_stop)
 
 
+def _resolve_config_with_policy(
+    config: GeneratorConfig,
+    *,
+    device_override: str | None,
+    device_source: str,
+    hardware_policy: str,
+    before_materialization_hook: Callable[[GeneratorConfig, list[ResolutionEvent]], None] | None,
+    after_policy_hook: Callable[[GeneratorConfig, list[ResolutionEvent]], None] | None,
+) -> ResolvedConfigBundle:
+    """Resolve shared device/materialization/policy flow for command paths."""
+
+    resolved = _clone_config(config)
+    trace_events: list[ResolutionEvent] = []
+
+    requested_device = _normalize_requested_device(device_override, resolved.runtime.device)
+    _set_config_path(
+        resolved,
+        path="runtime.device",
+        value=requested_device,
+        source=device_source,
+        events=trace_events,
+    )
+    if before_materialization_hook is not None:
+        before_materialization_hook(resolved, trace_events)
+
+    resolved.validate_generation_constraints()
+    materialized = materialize_stress_profile(
+        resolved,
+        revalidate=False,
+        clear_selector=True,
+    )
+    append_config_diff_events(
+        resolved,
+        materialized,
+        source="stress.profile_materialization",
+        events=trace_events,
+    )
+    resolved = materialized
+
+    hw = detect_hardware(requested_device)
+    before_policy = resolved.to_dict()
+    resolved = apply_hardware_policy(
+        resolved,
+        hw,
+        policy_name=hardware_policy,
+        validate=False,
+    )
+    after_policy = resolved.to_dict()
+    _append_diff_events(
+        before_policy,
+        after_policy,
+        source=f"hardware_policy.{str(hardware_policy).strip().lower()}",
+        events=trace_events,
+    )
+    _apply_default_cuda_fixed_layout_target_floor(resolved, hw=hw, events=trace_events)
+    if after_policy_hook is not None:
+        after_policy_hook(resolved, trace_events)
+    resolved.validate_generation_constraints()
+    return {
+        "config": resolved,
+        "hardware": hw,
+        "requested_device": requested_device,
+        "trace_events": trace_events,
+    }
+
+
 def resolve_generate_config(
     config: GeneratorConfig,
     *,
@@ -268,73 +334,35 @@ def resolve_generate_config(
 ) -> ResolvedConfigBundle:
     """Resolve effective config for one generate command invocation."""
 
-    resolved = _clone_config(config)
-    trace_events: list[ResolutionEvent] = []
+    def _before_materialization(
+        resolved: GeneratorConfig,
+        trace_events: list[ResolutionEvent],
+    ) -> None:
+        _apply_rows_override(resolved, rows=rows, source=rows_source, events=trace_events)
+        if path_overrides:
+            _apply_path_overrides(
+                resolved,
+                overrides=path_overrides,
+                source="cli.set",
+                events=trace_events,
+            )
+        if diagnostics_enabled:
+            _set_config_path(
+                resolved,
+                path="diagnostics.enabled",
+                value=True,
+                source="cli.diagnostics",
+                events=trace_events,
+            )
 
-    requested_device = _normalize_requested_device(device_override, resolved.runtime.device)
-    _set_config_path(
-        resolved,
-        path="runtime.device",
-        value=requested_device,
-        source="cli.device",
-        events=trace_events,
+    return _resolve_config_with_policy(
+        config,
+        device_override=device_override,
+        device_source="cli.device",
+        hardware_policy=hardware_policy,
+        before_materialization_hook=_before_materialization,
+        after_policy_hook=post_policy_hook,
     )
-    _apply_rows_override(resolved, rows=rows, source=rows_source, events=trace_events)
-    if path_overrides:
-        _apply_path_overrides(
-            resolved,
-            overrides=path_overrides,
-            source="cli.set",
-            events=trace_events,
-        )
-    if diagnostics_enabled:
-        _set_config_path(
-            resolved,
-            path="diagnostics.enabled",
-            value=True,
-            source="cli.diagnostics",
-            events=trace_events,
-        )
-
-    resolved.validate_generation_constraints()
-    materialized = materialize_stress_profile(
-        resolved,
-        revalidate=False,
-        clear_selector=True,
-    )
-    append_config_diff_events(
-        resolved,
-        materialized,
-        source="stress.profile_materialization",
-        events=trace_events,
-    )
-    resolved = materialized
-
-    hw = detect_hardware(requested_device)
-    before_policy = resolved.to_dict()
-    resolved = apply_hardware_policy(
-        resolved,
-        hw,
-        policy_name=hardware_policy,
-        validate=False,
-    )
-    after_policy = resolved.to_dict()
-    _append_diff_events(
-        before_policy,
-        after_policy,
-        source=f"hardware_policy.{str(hardware_policy).strip().lower()}",
-        events=trace_events,
-    )
-    _apply_default_cuda_fixed_layout_target_floor(resolved, hw=hw, events=trace_events)
-    if post_policy_hook is not None:
-        post_policy_hook(resolved, trace_events)
-    resolved.validate_generation_constraints()
-    return {
-        "config": resolved,
-        "hardware": hw,
-        "requested_device": requested_device,
-        "trace_events": trace_events,
-    }
 
 
 def resolve_benchmark_preset_config(
@@ -348,61 +376,24 @@ def resolve_benchmark_preset_config(
 ) -> ResolvedConfigBundle:
     """Resolve effective config for one benchmark preset run."""
 
-    resolved = _clone_config(config)
-    trace_events: list[ResolutionEvent] = []
-
-    requested_device = _normalize_requested_device(preset_device, resolved.runtime.device)
-    _set_config_path(
-        resolved,
-        path="runtime.device",
-        value=requested_device,
-        source="benchmark.preset_device",
-        events=trace_events,
-    )
-
-    resolved.validate_generation_constraints()
-    materialized = materialize_stress_profile(
-        resolved,
-        revalidate=False,
-        clear_selector=True,
-    )
-    append_config_diff_events(
-        resolved,
-        materialized,
-        source="stress.profile_materialization",
-        events=trace_events,
-    )
-    resolved = materialized
-
-    hw = detect_hardware(requested_device)
-    before_policy = resolved.to_dict()
-    resolved = apply_hardware_policy(
-        resolved,
-        hw,
-        policy_name=hardware_policy,
-        validate=False,
-    )
-    after_policy = resolved.to_dict()
-    _append_diff_events(
-        before_policy,
-        after_policy,
-        source=f"hardware_policy.{str(hardware_policy).strip().lower()}",
-        events=trace_events,
-    )
-    _apply_default_cuda_fixed_layout_target_floor(resolved, hw=hw, events=trace_events)
-
-    if str(suite).strip().lower() == "smoke":
+    def _after_policy(resolved: GeneratorConfig, trace_events: list[ResolutionEvent]) -> None:
+        if str(suite).strip().lower() != "smoke":
+            return
         if smoke_caps is None:
             raise ValueError("Benchmark smoke suite config resolution requires smoke cap values.")
         _apply_smoke_caps(resolved, smoke_caps=smoke_caps, events=trace_events)
 
-    resolved.validate_generation_constraints()
+    resolved = _resolve_config_with_policy(
+        config,
+        device_override=preset_device,
+        device_source="benchmark.preset_device",
+        hardware_policy=hardware_policy,
+        before_materialization_hook=None,
+        after_policy_hook=_after_policy,
+    )
     return {
         "preset_key": preset_key,
-        "config": resolved,
-        "hardware": hw,
-        "requested_device": requested_device,
-        "trace_events": trace_events,
+        **resolved,
     }
 
 

--- a/src/dagzoo/core/fixed_layout/grouped.py
+++ b/src/dagzoo/core/fixed_layout/grouped.py
@@ -112,29 +112,16 @@ def generate_grouped_raw_batches(
     for group in grouped_noise_runtime:
         noise_spec = noise_sampling_spec(group.selection)
         runtime_metrics: dict[str, float] = {}
-        try:
-            x_batch, y_batch, aux_meta_batch = generate_graph_batch(
-                config,
-                layout,
-                execution_plan=execution_plan,
-                dataset_seeds=group.generation_seeds,
-                device=resolved_device,
-                noise_sigma_multiplier=noise_sigma_multiplier,
-                noise_spec=noise_spec,
-                runtime_metrics_out=runtime_metrics,
-            )
-        except TypeError as exc:
-            if "runtime_metrics_out" not in str(exc):
-                raise
-            x_batch, y_batch, aux_meta_batch = generate_graph_batch(
-                config,
-                layout,
-                execution_plan=execution_plan,
-                dataset_seeds=group.generation_seeds,
-                device=resolved_device,
-                noise_sigma_multiplier=noise_sigma_multiplier,
-                noise_spec=noise_spec,
-            )
+        x_batch, y_batch, aux_meta_batch = generate_graph_batch(
+            config,
+            layout,
+            execution_plan=execution_plan,
+            dataset_seeds=group.generation_seeds,
+            device=resolved_device,
+            noise_sigma_multiplier=noise_sigma_multiplier,
+            noise_spec=noise_spec,
+            runtime_metrics_out=runtime_metrics,
+        )
         grouped_batches.append(
             _GroupedRawBatch(
                 chunk_offsets=list(group.chunk_offsets),

--- a/src/dagzoo/core/fixed_layout/runtime.py
+++ b/src/dagzoo/core/fixed_layout/runtime.py
@@ -675,7 +675,7 @@ def _generate_batch_with_dynamic_steering_iter(
 
         for offset, descriptor in enumerate(descriptors):
             if offset in retry_offset_set:
-                bundle = _generate_bundle_with_retries_compat(
+                bundle = _generate_fixed_layout_bundle_with_retries(
                     descriptor.effective_config,
                     plan=descriptor.effective_plan,
                     dataset_root=descriptor.dataset_root,
@@ -693,7 +693,7 @@ def _generate_batch_with_dynamic_steering_iter(
                     )
                 candidate_bundle = raw_batch_by_offset[offset]
                 if candidate_bundle is None:
-                    bundle = _generate_bundle_with_retries_compat(
+                    bundle = _generate_fixed_layout_bundle_with_retries(
                         descriptor.effective_config,
                         plan=descriptor.effective_plan,
                         dataset_root=descriptor.dataset_root,
@@ -954,68 +954,16 @@ def _generate_fixed_layout_graph_batch_with_runtime_metrics(
     noise_spec,
     runtime_metrics_out: dict[str, float],
 ) -> tuple[torch.Tensor, torch.Tensor, list[dict[str, object]]]:
-    try:
-        return generate_fixed_layout_graph_batch(
-            config,
-            plan.layout,
-            execution_plan=plan.execution_plan,
-            dataset_seeds=dataset_seeds,
-            device=resolved_device,
-            noise_sigma_multiplier=noise_sigma_multiplier,
-            noise_spec=noise_spec,
-            runtime_metrics_out=runtime_metrics_out,
-        )
-    except TypeError as exc:
-        if "runtime_metrics_out" not in str(exc):
-            raise
-        return generate_fixed_layout_graph_batch(
-            config,
-            plan.layout,
-            execution_plan=plan.execution_plan,
-            dataset_seeds=dataset_seeds,
-            device=resolved_device,
-            noise_sigma_multiplier=noise_sigma_multiplier,
-            noise_spec=noise_spec,
-        )
-
-
-def _generate_bundle_with_retries_compat(
-    config: GeneratorConfig,
-    *,
-    plan: _FixedLayoutPlan,
-    dataset_root: KeyedRng,
-    requested_device: str,
-    resolved_device: str,
-    preserve_feature_schema: bool,
-    start_attempt: int,
-    finalization_context: _FixedSchemaFinalizationContext,
-    on_raw_batch_metrics: Callable[[dict[str, float]], None] | None,
-) -> DatasetBundle:
-    try:
-        return _generate_fixed_layout_bundle_with_retries(
-            config,
-            plan=plan,
-            dataset_root=dataset_root,
-            requested_device=requested_device,
-            resolved_device=resolved_device,
-            preserve_feature_schema=preserve_feature_schema,
-            start_attempt=start_attempt,
-            finalization_context=finalization_context,
-            on_raw_batch_metrics=on_raw_batch_metrics,
-        )
-    except TypeError as exc:
-        if "on_raw_batch_metrics" not in str(exc):
-            raise
-        return _generate_fixed_layout_bundle_with_retries(
-            config,
-            plan=plan,
-            dataset_root=dataset_root,
-            requested_device=requested_device,
-            resolved_device=resolved_device,
-            preserve_feature_schema=preserve_feature_schema,
-            start_attempt=start_attempt,
-            finalization_context=finalization_context,
-        )
+    return generate_fixed_layout_graph_batch(
+        config,
+        plan.layout,
+        execution_plan=plan.execution_plan,
+        dataset_seeds=dataset_seeds,
+        device=resolved_device,
+        noise_sigma_multiplier=noise_sigma_multiplier,
+        noise_spec=noise_spec,
+        runtime_metrics_out=runtime_metrics_out,
+    )
 
 
 def _generate_fixed_layout_bundle_with_retries(
@@ -1241,7 +1189,7 @@ def _generate_batch_with_plan_iter(
                 finalized_offsets.add(offset)
         for offset, dataset_root in enumerate(dataset_roots):
             if offset in retry_offset_set:
-                bundle = _generate_bundle_with_retries_compat(
+                bundle = _generate_fixed_layout_bundle_with_retries(
                     config,
                     plan=plan,
                     dataset_root=dataset_root,
@@ -1268,7 +1216,7 @@ def _generate_batch_with_plan_iter(
                 raise RuntimeError("Missing grouped raw batch entry for fixed-layout chunk offset.")
             grouped_bundle = raw_batch_by_offset[offset]
             if grouped_bundle is None:
-                grouped_bundle = _generate_bundle_with_retries_compat(
+                grouped_bundle = _generate_fixed_layout_bundle_with_retries(
                     config,
                     plan=plan,
                     dataset_root=dataset_root,

--- a/src/dagzoo/core/generation_runtime.py
+++ b/src/dagzoo/core/generation_runtime.py
@@ -9,7 +9,8 @@ from typing import Any
 
 import torch
 
-from dagzoo.config import MISSINGNESS_MECHANISM_NONE, GeneratorConfig
+from dagzoo.config import GeneratorConfig
+from dagzoo.core.config_predicates import missingness_enabled as _is_missingness_enabled
 from dagzoo.core.layout_types import LayoutPlan
 from dagzoo.core.metadata import _build_lineage_metadata, _build_shift_metadata
 from dagzoo.core.noise_runtime import (
@@ -181,15 +182,6 @@ def _normalized_filter_metadata(aux_meta: dict[str, Any]) -> dict[str, Any]:
     if isinstance(filter_metadata, dict):
         return dict(filter_metadata)
     return {"mode": "deferred", "status": "not_run"}
-
-
-def _is_missingness_enabled(config: GeneratorConfig) -> bool:
-    """Return whether missingness injection can mutate emitted feature tensors."""
-
-    return (
-        float(config.dataset.missing_rate) > 0.0
-        and str(config.dataset.missing_mechanism).strip().lower() != MISSINGNESS_MECHANISM_NONE
-    )
 
 
 def _base_bundle_metadata_for_layout(

--- a/src/dagzoo/pytorch.py
+++ b/src/dagzoo/pytorch.py
@@ -10,11 +10,7 @@ import torch
 from torch.utils.data import DataLoader, IterableDataset, get_worker_info
 
 from dagzoo.config import GeneratorConfig, clone_generator_config
-from dagzoo.core.dataset import (
-    _iter_prepared_canonical_batch_iter,
-    _validate_public_generation_config,
-)
-from dagzoo.core.fixed_layout.runtime import prepare_canonical_fixed_layout_run
+from dagzoo.core.dataset import _validate_public_generation_config, generate_batch_iter
 from dagzoo.recipes import load_config_reference
 from dagzoo.types import DatasetBundle
 
@@ -112,15 +108,11 @@ class DagzooDataset(IterableDataset[DagzooSample]):
             )
         if self._num_datasets == 0:
             return
-        prepared = prepare_canonical_fixed_layout_run(
+        for bundle in generate_batch_iter(
             self._config,
             num_datasets=self._num_datasets,
             seed=self._seed,
             device=self._device,
-        )
-        for bundle in _iter_prepared_canonical_batch_iter(
-            prepared,
-            num_datasets=self._num_datasets,
         ):
             yield _bundle_to_sample(bundle)
 

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -8,8 +8,10 @@ from conftest import load_repo_config, write_config
 
 from dagzoo.bench.constants import SMOKE_N_TEST_CAP, SMOKE_N_TRAIN_CAP
 from dagzoo.cli.commands.benchmark import _print_preset_result_line
+from dagzoo.cli.effective_config import effective_config_payload_yaml, effective_config_yaml
 from dagzoo.cli.entrypoint import main
 from dagzoo.cli.parsing import DEVICE_CHOICES, HARDWARE_POLICY_CHOICES
+from dagzoo.config import effective_config_payload
 
 
 def test_cli_parser_choice_constants_are_stable() -> None:
@@ -88,6 +90,12 @@ def test_benchmark_cli_realizes_dataset_rows_once_per_preset(tmp_path) -> None:
     effective_config = result["effective_config"]
     assert int(result["dataset_rows_total"]) <= int(SMOKE_N_TRAIN_CAP + SMOKE_N_TEST_CAP)
     assert effective_config["dataset"]["rows"] is None
+    config_files = sorted(
+        path
+        for path in (out_dir / "effective_configs").glob("*.yaml")
+        if not path.name.endswith("_trace.yaml")
+    )
+    assert config_files
     trace_files = sorted((out_dir / "effective_configs").glob("*_trace.yaml"))
     assert trace_files
     trace_payload = yaml.safe_load(trace_files[0].read_text(encoding="utf-8"))
@@ -95,6 +103,49 @@ def test_benchmark_cli_realizes_dataset_rows_once_per_preset(tmp_path) -> None:
         isinstance(item, dict) and item.get("source") == "benchmark.smoke_rows_cap"
         for item in trace_payload
     )
+
+
+def test_effective_config_payload_yaml_matches_config_yaml() -> None:
+    cfg = load_repo_config()
+
+    assert effective_config_payload_yaml(effective_config_payload(cfg)) == effective_config_yaml(
+        cfg
+    )
+
+
+def test_benchmark_cli_prints_effective_config_with_shared_yaml_shape(
+    tmp_path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    out_dir = tmp_path / "printed_effective_config"
+
+    code = main(
+        [
+            "benchmark",
+            "--config",
+            "configs/default.yaml",
+            "--preset",
+            "custom",
+            "--suite",
+            "smoke",
+            "--num-datasets",
+            "1",
+            "--warmup",
+            "0",
+            "--hardware-policy",
+            "none",
+            "--no-memory",
+            "--out-dir",
+            str(out_dir),
+            "--print-effective-config",
+        ]
+    )
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "Effective config [" in output
+    assert "dataset:" in output
+    assert "benchmark:" in output
 
 
 @pytest.mark.parametrize(

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -443,7 +443,7 @@ def test_generate_batch_with_plan_iter_batches_steering_missingness_changes(
         _stub_finalize_generated_chunk_preserve_schema,
     )
     monkeypatch.setattr(
-        "dagzoo.core.fixed_layout.runtime._generate_bundle_with_retries_compat",
+        "dagzoo.core.fixed_layout.runtime._generate_fixed_layout_bundle_with_retries",
         lambda *_args, **_kwargs: pytest.fail(
             "steering missingness-only batching should not fall back to scalar retries"
         ),
@@ -682,7 +682,7 @@ def test_generate_batch_with_plan_iter_batches_noise_only_steering_by_cohort(
         _stub_finalize_generated_chunk_preserve_schema,
     )
     monkeypatch.setattr(
-        "dagzoo.core.fixed_layout.runtime._generate_bundle_with_retries_compat",
+        "dagzoo.core.fixed_layout.runtime._generate_fixed_layout_bundle_with_retries",
         lambda *_args, **_kwargs: pytest.fail(
             "noise-only steering cohorts should stay on the grouped batch path"
         ),
@@ -925,7 +925,7 @@ def test_generate_batch_with_plan_iter_batches_graph_steering_by_effective_plan(
         _stub_finalize_generated_chunk_preserve_schema,
     )
     monkeypatch.setattr(
-        "dagzoo.core.fixed_layout.runtime._generate_bundle_with_retries_compat",
+        "dagzoo.core.fixed_layout.runtime._generate_fixed_layout_bundle_with_retries",
         lambda *_args, **_kwargs: pytest.fail(
             "graph-steered cohorts should stay on the grouped batch path"
         ),
@@ -1163,7 +1163,7 @@ def test_generate_batch_with_plan_iter_classification_steering_captures_split_fa
         assert resolved_split_indices[1] is None
         return [_make_bundle(dataset_roots[0].child_seed()), None]
 
-    def _stub_generate_bundle_with_retries_compat(
+    def _stub_generate_fixed_layout_bundle_with_retries(
         _config: GeneratorConfig,
         *,
         plan: _FixedLayoutPlan,
@@ -1207,8 +1207,8 @@ def test_generate_batch_with_plan_iter_classification_steering_captures_split_fa
         _stub_finalize_generated_chunk_preserve_schema,
     )
     monkeypatch.setattr(
-        "dagzoo.core.fixed_layout.runtime._generate_bundle_with_retries_compat",
-        _stub_generate_bundle_with_retries_compat,
+        "dagzoo.core.fixed_layout.runtime._generate_fixed_layout_bundle_with_retries",
+        _stub_generate_fixed_layout_bundle_with_retries,
     )
 
     bundles = list(
@@ -1408,7 +1408,7 @@ def test_generate_batch_with_plan_iter_dynamic_steering_uses_retry_attempt_plan_
         )
         return [_make_bundle(dataset_roots[0].child_seed())]
 
-    def _stub_generate_bundle_with_retries_compat(
+    def _stub_generate_fixed_layout_bundle_with_retries(
         _config: GeneratorConfig,
         *,
         plan: _FixedLayoutPlan,
@@ -1448,8 +1448,8 @@ def test_generate_batch_with_plan_iter_dynamic_steering_uses_retry_attempt_plan_
         _stub_finalize_generated_chunk_preserve_schema,
     )
     monkeypatch.setattr(
-        "dagzoo.core.fixed_layout.runtime._generate_bundle_with_retries_compat",
-        _stub_generate_bundle_with_retries_compat,
+        "dagzoo.core.fixed_layout.runtime._generate_fixed_layout_bundle_with_retries",
+        _stub_generate_fixed_layout_bundle_with_retries,
     )
 
     bundles = list(
@@ -1670,7 +1670,7 @@ def test_generate_batch_with_plan_iter_dynamic_steering_rejects_schema_mismatch(
         _stub_finalize_generated_chunk_preserve_schema,
     )
     monkeypatch.setattr(
-        "dagzoo.core.fixed_layout.runtime._generate_bundle_with_retries_compat",
+        "dagzoo.core.fixed_layout.runtime._generate_fixed_layout_bundle_with_retries",
         lambda *_args, **_kwargs: pytest.fail("schema mismatch should fail before retry fallback"),
     )
 
@@ -1882,7 +1882,7 @@ def test_generate_batch_with_plan_iter_dynamic_steering_requires_all_grouped_off
         _stub_finalize_generated_chunk_preserve_schema,
     )
     monkeypatch.setattr(
-        "dagzoo.core.fixed_layout.runtime._generate_bundle_with_retries_compat",
+        "dagzoo.core.fixed_layout.runtime._generate_fixed_layout_bundle_with_retries",
         lambda *_args, **_kwargs: pytest.fail(
             "missing grouped offsets should fail before retry fallback"
         ),
@@ -3532,11 +3532,13 @@ def test_generate_batch_with_plan_iter_groups_mixed_noise_runtime_subbatches(
         device,
         noise_sigma_multiplier,
         noise_spec,
+        runtime_metrics_out=None,
     ):
         _ = execution_plan
         _ = device
         _ = noise_sigma_multiplier
         _ = noise_spec
+        _ = runtime_metrics_out
         grouped_call_sizes.append(len(dataset_seeds))
         batch_size = len(dataset_seeds)
         n_rows = cfg.dataset.n_train + cfg.dataset.n_test
@@ -3920,11 +3922,13 @@ def test_auto_surfaces_mps_runtime_failure_in_generate_one(
         device,
         noise_sigma_multiplier,
         noise_spec,
+        runtime_metrics_out=None,
     ):
         _ = execution_plan
         _ = dataset_seeds
         _ = noise_sigma_multiplier
         _ = noise_spec
+        _ = runtime_metrics_out
         calls.append(str(device))
         if device == "mps":
             raise RuntimeError("simulated mps failure")
@@ -3966,11 +3970,13 @@ def test_generate_batch_iter_auto_surfaces_mps_batch_generation_failure(
         device,
         noise_sigma_multiplier,
         noise_spec,
+        runtime_metrics_out=None,
     ):
         _ = execution_plan
         _ = dataset_seeds
         _ = noise_sigma_multiplier
         _ = noise_spec
+        _ = runtime_metrics_out
         calls.append(str(device))
         if device == "mps":
             raise RuntimeError("simulated mps failure")
@@ -4578,11 +4584,13 @@ def test_generate_batch_with_plan_iter_allows_late_classification_failure_after_
         preserve_feature_schema: bool,
         start_attempt: int = 0,
         finalization_context=None,
+        on_raw_batch_metrics=None,
     ) -> DatasetBundle:
         _ = plan
         _ = requested_device
         _ = resolved_device
         _ = preserve_feature_schema
+        _ = on_raw_batch_metrics
         assert finalization_context is not None
         assert int(start_attempt) == 1
         raise ValueError("Failed to generate a valid fixed-layout dataset after 2 attempts.")
@@ -4782,11 +4790,13 @@ def test_generate_batch_with_plan_iter_uses_cached_classification_attempt_plan_f
         preserve_feature_schema: bool,
         start_attempt: int = 0,
         finalization_context=None,
+        on_raw_batch_metrics=None,
     ) -> DatasetBundle:
         _ = plan
         _ = requested_device
         _ = resolved_device
         _ = preserve_feature_schema
+        _ = on_raw_batch_metrics
         assert finalization_context is not None
         retry_starts.append(int(start_attempt))
         return _make_bundle(dataset_root.child_seed())
@@ -4870,12 +4880,14 @@ def test_generate_fixed_layout_bundle_with_retries_reuses_cached_finalization_co
         device: str,
         noise_sigma_multiplier: float,
         noise_spec,
+        runtime_metrics_out=None,
     ) -> tuple[torch.Tensor, torch.Tensor, list[dict[str, object]]]:
         _ = execution_plan
         _ = dataset_seeds
         _ = device
         _ = noise_sigma_multiplier
         _ = noise_spec
+        _ = runtime_metrics_out
         return (
             torch.zeros((1, 6, 2), dtype=torch.float32),
             torch.zeros((1, 6), dtype=torch.float32),

--- a/tests/test_pytorch_bridge.py
+++ b/tests/test_pytorch_bridge.py
@@ -6,6 +6,7 @@ from conftest import load_repo_config, write_config
 
 from dagzoo.core.dataset import generate_batch_iter
 from dagzoo.pytorch import DagzooDataset, build_dataloader
+from dagzoo.types import DatasetBundle
 
 
 def _tiny_bridge_config():
@@ -110,3 +111,36 @@ def test_dagzoo_dataset_rejects_multi_worker_loading(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr("dagzoo.pytorch.get_worker_info", lambda: object())
     with pytest.raises(RuntimeError, match="num_workers=0"):
         _ = list(DagzooDataset(cfg, num_datasets=1, seed=7, device="cpu"))
+
+
+def test_dagzoo_dataset_delegates_to_generate_batch_iter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = _tiny_bridge_config()
+    seen: dict[str, object] = {}
+
+    def _stub_generate_batch_iter(config, *, num_datasets, seed=None, device=None):
+        seen["config"] = config
+        seen["num_datasets"] = num_datasets
+        seen["seed"] = seed
+        seen["device"] = device
+        yield DatasetBundle(
+            X_train=torch.zeros((2, 2), dtype=torch.float32),
+            y_train=torch.zeros(2, dtype=torch.float32),
+            X_test=torch.zeros((1, 2), dtype=torch.float32),
+            y_test=torch.zeros(1, dtype=torch.float32),
+            feature_types=["num", "num"],
+            metadata={"dataset_id": "delegated"},
+        )
+
+    monkeypatch.setattr("dagzoo.pytorch.generate_batch_iter", _stub_generate_batch_iter)
+
+    sample = next(iter(DagzooDataset(cfg, num_datasets=1, seed=13, device="cpu")))
+
+    assert seen == {
+        "config": cfg,
+        "num_datasets": 1,
+        "seed": 13,
+        "device": "cpu",
+    }
+    assert sample["metadata"]["dataset_id"] == "delegated"


### PR DESCRIPTION
## Summary
- remove fixed-layout compat shims and TypeError fallback paths in the internal generation runtime
- collapse duplicated generate and benchmark config-resolution flows onto one shared resolver and centralize shared benchmark/runtime predicates and count helpers
- route the PyTorch bridge through the canonical batch iterator and reuse shared effective-config serialization in benchmark CLI output
- include the required patch-level release metadata updates for this release-risk refactor (`pyproject.toml`, `CHANGELOG.md`, `CITATION.cff`)

## Why
This change resolves the four review findings and the adjacent cleanup sweep by deleting internal duplication and migration baggage without changing CLI flags, artifact layout, or result shapes.

## Validation
- `./.venv/bin/python -m pytest tests/test_benchmark_cli.py tests/test_pytorch_bridge.py tests/test_corpus_probe.py tests/test_config_resolution.py -q`
- `./.venv/bin/python -m pytest tests/test_generate.py -q`
- `./.venv/bin/python -m ruff check src tests scripts`
- `./.venv/bin/python -m ruff format --check src tests scripts`
- `./.venv/bin/python -m mypy src`
- `./.venv/bin/deptry .`
- `./.venv/bin/lint-imports`
- `./.venv/bin/python scripts/dev.py contract --source staged`
- `./.venv/bin/python scripts/ci/check_adoption_surface.py`