### PR TITLE
Add RD-005 promotion evaluation suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ contains imported legacy history, so date order is not strictly monotonic:
 `0.3.0` records the older `cauchy-generator -> dagzoo` rename, while `0.5.0`
 records the later `dagsynth -> dagzoo` rename on the current release line.
 
+## [0.19.11] - 2026-04-09
+
+### Added
+
+- Added first-class parity-surface diagnostics coverage for converter methods
+  and variants, GP variants, kernel `gamma` and `signed`, matrix kinds,
+  root-base kinds, parent arity, source-shape policy, and categorical
+  cardinality across fixed-layout bundle metadata and `dagzoo diversity-audit`
+  summaries.
+- Added internal RD-005 follow-on evaluation lanes for
+  categorical/cardinality, hybrid, and robustness-composition comparisons,
+  plus one suite runner that joins diversity-audit, parity, and handoff/Pareto
+  evidence into a single promotion decision artifact.
+
+### Changed
+
+- Updated the RD-005 maintainer workflow so internal slice promotion is decided
+  from explicit `promote`, `hold_internal`, and `structural_control_only`
+  statuses rather than a prose-only checklist, while keeping the public recipe
+  surface unchanged until a lane clears the gate.
+- Updated the roadmap, parity audit note, stress-profile guide, and scripts
+  reference so the repo documents the new internal evaluation workflow without
+  overclaiming public promotion.
+
 ## [0.19.10] - 2026-04-07
 
 ### Added

--- a/configs/preset_stress_categorical_cardinality_benchmark_smoke.yaml
+++ b/configs/preset_stress_categorical_cardinality_benchmark_smoke.yaml
@@ -1,0 +1,32 @@
+seed: 88
+
+stress:
+  profile: anti_memorization_piecewise_classification_categorical_cardinality_slice_v1
+
+runtime:
+  device: cpu
+
+output:
+  out_dir: benchmarks/results/smoke_stress_categorical_cardinality
+  shard_size: 16
+  compression: zstd
+
+diagnostics:
+  enabled: false
+
+benchmark:
+  preset_name: stress_categorical_cardinality_smoke
+  suite: smoke
+  num_datasets: 20
+  warmup_datasets: 0
+  warn_threshold_pct: 10.0
+  fail_threshold_pct: 20.0
+  collect_memory: false
+  collect_reproducibility: false
+  reproducibility_num_datasets: 1
+  latency_num_samples: 5
+  presets:
+    stress_categorical_cardinality_smoke:
+      device: cpu
+      num_datasets: 20
+      warmup_datasets: 0

--- a/configs/preset_stress_categorical_cardinality_generate_smoke.yaml
+++ b/configs/preset_stress_categorical_cardinality_generate_smoke.yaml
@@ -1,0 +1,32 @@
+seed: 88
+
+stress:
+  profile: anti_memorization_piecewise_classification_categorical_cardinality_slice_v1
+
+runtime:
+  device: cpu
+
+output:
+  out_dir: data/run_stress_categorical_cardinality_smoke
+  shard_size: 16
+  compression: zstd
+
+diagnostics:
+  enabled: true
+
+benchmark:
+  preset_name: stress_categorical_cardinality_smoke
+  suite: smoke
+  num_datasets: 20
+  warmup_datasets: 0
+  warn_threshold_pct: 10.0
+  fail_threshold_pct: 20.0
+  collect_memory: false
+  collect_reproducibility: false
+  reproducibility_num_datasets: 1
+  latency_num_samples: 5
+  presets:
+    stress_categorical_cardinality_smoke:
+      device: cpu
+      num_datasets: 20
+      warmup_datasets: 0

--- a/configs/preset_stress_hybrid_benchmark_smoke.yaml
+++ b/configs/preset_stress_hybrid_benchmark_smoke.yaml
@@ -1,0 +1,32 @@
+seed: 89
+
+stress:
+  profile: anti_memorization_piecewise_classification_hybrid_slice_v1
+
+runtime:
+  device: cpu
+
+output:
+  out_dir: benchmarks/results/smoke_stress_hybrid
+  shard_size: 16
+  compression: zstd
+
+diagnostics:
+  enabled: false
+
+benchmark:
+  preset_name: stress_hybrid_smoke
+  suite: smoke
+  num_datasets: 20
+  warmup_datasets: 0
+  warn_threshold_pct: 10.0
+  fail_threshold_pct: 20.0
+  collect_memory: false
+  collect_reproducibility: false
+  reproducibility_num_datasets: 1
+  latency_num_samples: 5
+  presets:
+    stress_hybrid_smoke:
+      device: cpu
+      num_datasets: 20
+      warmup_datasets: 0

--- a/configs/preset_stress_hybrid_generate_smoke.yaml
+++ b/configs/preset_stress_hybrid_generate_smoke.yaml
@@ -1,0 +1,32 @@
+seed: 89
+
+stress:
+  profile: anti_memorization_piecewise_classification_hybrid_slice_v1
+
+runtime:
+  device: cpu
+
+output:
+  out_dir: data/run_stress_hybrid_smoke
+  shard_size: 16
+  compression: zstd
+
+diagnostics:
+  enabled: true
+
+benchmark:
+  preset_name: stress_hybrid_smoke
+  suite: smoke
+  num_datasets: 20
+  warmup_datasets: 0
+  warn_threshold_pct: 10.0
+  fail_threshold_pct: 20.0
+  collect_memory: false
+  collect_reproducibility: false
+  reproducibility_num_datasets: 1
+  latency_num_samples: 5
+  presets:
+    stress_hybrid_smoke:
+      device: cpu
+      num_datasets: 20
+      warmup_datasets: 0

--- a/configs/preset_stress_robustness_composition_benchmark_smoke.yaml
+++ b/configs/preset_stress_robustness_composition_benchmark_smoke.yaml
@@ -1,0 +1,32 @@
+seed: 90
+
+stress:
+  profile: anti_memorization_piecewise_classification_robustness_composition_slice_v1
+
+runtime:
+  device: cpu
+
+output:
+  out_dir: benchmarks/results/smoke_stress_robustness_composition
+  shard_size: 16
+  compression: zstd
+
+diagnostics:
+  enabled: false
+
+benchmark:
+  preset_name: stress_robustness_composition_smoke
+  suite: smoke
+  num_datasets: 20
+  warmup_datasets: 0
+  warn_threshold_pct: 10.0
+  fail_threshold_pct: 20.0
+  collect_memory: false
+  collect_reproducibility: false
+  reproducibility_num_datasets: 1
+  latency_num_samples: 5
+  presets:
+    stress_robustness_composition_smoke:
+      device: cpu
+      num_datasets: 20
+      warmup_datasets: 0

--- a/configs/preset_stress_robustness_composition_generate_smoke.yaml
+++ b/configs/preset_stress_robustness_composition_generate_smoke.yaml
@@ -1,0 +1,32 @@
+seed: 90
+
+stress:
+  profile: anti_memorization_piecewise_classification_robustness_composition_slice_v1
+
+runtime:
+  device: cpu
+
+output:
+  out_dir: data/run_stress_robustness_composition_smoke
+  shard_size: 16
+  compression: zstd
+
+diagnostics:
+  enabled: true
+
+benchmark:
+  preset_name: stress_robustness_composition_smoke
+  suite: smoke
+  num_datasets: 20
+  warmup_datasets: 0
+  warn_threshold_pct: 10.0
+  fail_threshold_pct: 20.0
+  collect_memory: false
+  collect_reproducibility: false
+  reproducibility_num_datasets: 1
+  latency_num_samples: 5
+  presets:
+    stress_robustness_composition_smoke:
+      device: cpu
+      num_datasets: 20
+      warmup_datasets: 0

--- a/docs/development/rd005_handoff_evaluation.md
+++ b/docs/development/rd005_handoff_evaluation.md
@@ -2,7 +2,34 @@
 
 `RD-005` should be promoted by structural diversity first, then throughput
 stability, with the lightweight downstream probe used only as an anti-triviality
-ceiling. The supported maintainer loop for that comparison is:
+ceiling. The supported maintainer loop for the full follow-on suite is:
+
+```bash
+./.venv/bin/python scripts/evaluate_rd005_follow_on_suite.py \
+  --baseline-config configs/default.yaml \
+  --out-root benchmarks/results/rd005_follow_on \
+  --suite smoke \
+  --num-datasets 8 \
+  --seed 123 \
+  --device cpu
+```
+
+This writes one promotion decision bundle at the suite root:
+
+- `follow_on_promotion_summary.json`
+- `follow_on_promotion_summary.md`
+
+alongside the supporting artifacts under:
+
+- `diversity_audit/summary.json`
+- `diversity_audit/summary.md`
+- `diversity_audit/parity_report/parity_report.json`
+- `diversity_audit/parity_report/parity_report.md`
+- `handoff_pareto/pareto_summary.json`
+- `handoff_pareto/pareto_summary.md`
+
+When you want to run just the handoff comparison loop without the suite
+orchestration, the lower-level Pareto helper remains:
 
 ```bash
 ./.venv/bin/python scripts/evaluate_handoff_pareto.py \
@@ -16,6 +43,16 @@ ceiling. The supported maintainer loop for that comparison is:
 
 ## What It Does
 
+- Materializes the carried internal RD-005 candidate set:
+  - `compositional` as the incumbent
+  - `graph-breadth` as the structural control
+  - `categorical-cardinality`, `hybrid`, and `robustness-composition` as
+    challengers
+- Runs matched-budget `dagzoo diversity-audit` across that full lane set.
+- Renders one parity report from the diversity-audit summary.
+- Runs matched-budget handoff/Pareto evaluation against the same candidate set.
+- Joins structural diversity, throughput, downstream ceiling, and parity-surface
+  snapshots into one machine-readable promotion decision summary.
 - Runs `dagzoo generate --handoff-root` for one baseline plus one variant at a
   time under the same seed, dataset budget, device, and hardware policy.
 - Scores each generated corpus with a lightweight downstream linear probe:
@@ -28,25 +65,40 @@ ceiling. The supported maintainer loop for that comparison is:
   - `pareto_summary.json`
   - `pareto_summary.md`
 
+When you already have one matched-budget `dagzoo diversity-audit` run and want a
+maintainer parity snapshot rather than a new handoff evaluation, render:
+
+```bash
+./.venv/bin/python scripts/render_tabiclv2_parity_report.py \
+  --summary-json benchmarks/results/diversity_audit_stress_graph_breadth/summary.json \
+  --out-dir benchmarks/results/diversity_audit_stress_graph_breadth/parity_report
+```
+
 ## Decision Rule
 
-- Rank variants by higher `structural_diversity_composite_shift_pct` first, then
+- Rank lanes by higher `structural_diversity_composite_shift_pct` first, then
   higher `datasets_per_minute`, then lower downstream mean.
 - Treat `diversity_status` and the full `diversity_composite_shift_pct` as
   compatibility/reporting fields only; they still mean “distance from baseline,”
   not “better” or “worse.”
 - Reject variants that exceed the easy-task ceiling
   `baseline_downstream_mean + 0.10`.
-- For confirmation runs, require:
+- For promotion runs, require:
   - positive structural diversity shift
-  - structural diversity exceeding the current promoted slice on the same protocol
+  - challengers to beat the compositional incumbent on the same protocol
   - throughput at least 85% of baseline
   - downstream mean at or below the easy-task ceiling
-- Look at the reported RD-005 priority order and the structural frontier before
-  promoting any slice into a benchmark/default workflow.
+- Persist one machine-readable status per lane:
+  - `promote`
+  - `hold_internal`
+  - `structural_control_only`
+- If no lane clears the gate, the correct output is `no_promotion`.
 
 ## Notes
 
+- `scripts/evaluate_rd005_follow_on_suite.py` is the canonical maintainer entry
+  point for this decision. It should be the artifact root linked from tracker
+  updates when someone argues for public promotion.
 - The script is repo workflow tooling, not a packaged `dagzoo` CLI command.
 - `--stress-profile` variants are synthesized by applying the profile to the
   baseline config and writing a temporary config file under the evaluation root.
@@ -55,6 +107,8 @@ ceiling. The supported maintainer loop for that comparison is:
   - `structural_diversity_composite_shift_pct`
   - `easy_task_ceiling_pass`
   - `priority_variant_labels`
+  - `promotion_status`
+  - `promotion_failure_reasons`
 - For the graph/source-shape lane (`#293`), compare baseline against
   `anti_memorization_piecewise_classification_graph_breadth_slice_v1` and read
   `graph_target_ancestor_fraction`, `graph_ancestor_overlap_mean`,

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -79,15 +79,15 @@ Lower rank means higher priority. Rank `0` is reserved for completed items retai
 | 0    | RD-016     | Generate-handoff manifest and one-way downstream handoff               | implemented | Now       | `BL-143 -> BL-144 -> BL-145 -> BL-146 -> BL-147` (completed)                                                     |
 | 0    | RD-011     | Mechanism diversity expansion with measurable effective-diversity gain | implemented | Now       | `#28 -> #240` (completed), `#220` (later analytical follow-on), `BL-26 -> BL-151 -> BL-29 -> BL-30` (historical) |
 | 0    | RD-008     | Meta-feature coverage steering                                         | implemented | Now       | `#246 -> #251 -> #256 -> #261 -> #266` (completed)                                                               |
-| 1    | RD-005     | Robustness stress profiles (hard-task/adversarial regimes)             | research    | Now       | `#247 -> #252 -> #257 -> #262 -> #267`                                                                           |
+| 1    | RD-005     | Robustness stress profiles (hard-task/adversarial regimes)             | implemented | Now       | `#247 -> #252 -> #257 -> #262 -> #267` (completed), follow-ons `#293 + #294`                                    |
 | 2    | RD-013     | Time-series generation tracks for PFN pretraining                      | research    | Later     | `#248 -> #253 -> (#258 + #263) -> #268`                                                                          |
 | 0    | RD-002     | Observational and hard-interventional generation modes                 | implemented | Now       | `#249 -> #255 -> (#259 + #265) -> #269` (completed)                                                             |
 | 4    | RD-010     | Hardware-adaptive autotuning beyond coarse FLOPs tiers                 | planned     | Later     | `#250 -> #254 -> #260 -> #264 -> (#270 + #271) -> #272`                                                          |
 
 ## Dependency Graph
 
-With RD-008 and RD-002 implemented, the active execution order is `RD-005`,
-then the later lanes. Within `RD-013` and `RD-010`, the graph fans out where
+With RD-008, RD-002, and RD-005 implemented, the remaining execution order is
+`RD-013`, then `RD-010`. Within `RD-013` and `RD-010`, the graph fans out where
 the work can proceed in parallel after the schema/spec step.
 
 ```mermaid
@@ -167,11 +167,11 @@ graph TD
 
 | README Mission/Pillar Claim                                         | Current State | Evidence in Repo                                                                                                                                                                                                                                                                                              | Gap                                                                                                                                              | Roadmap IDs    |
 | ------------------------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
-| Foundation model pretraining with diverse structural priors         | `partial`     | Heterogeneous-by-default public generation, shared grouped-runtime execution helpers, `dataset.rows`, deferred filtering, effective-diversity audits, diagnostics coverage aggregation, explicit noise/shift controls, stage-level throughput metrics, generate-handoff manifests, steering, and the shipped `piecewise` plus widened `gp` paths are implemented | Time-series generation tracks and broader named reference/stress packs remain active follow-on work                                              | RD-013, RD-005 |
+| Foundation model pretraining with diverse structural priors         | `partial`     | Heterogeneous-by-default public generation, shared grouped-runtime execution helpers, `dataset.rows`, deferred filtering, effective-diversity audits, diagnostics coverage aggregation, explicit noise/shift controls, stage-level throughput metrics, generate-handoff manifests, steering, shipped mechanism diversity, named RD-005 slices, and parity/Pareto maintainer workflows are implemented | Time-series generation tracks and public promotion of the current internal RD-005 evaluation lanes remain active follow-on work                  | RD-013, RD-005 |
 | Causal discovery with ground-truth DAGs and interventional datasets | `implemented` | DAG lineage metadata, hard-interventional sampling semantics, summary-only intervention contracts, and handoff provenance are emitted with schema validation, discoverable presets, and user-facing workflow guardrails                                                                                      | Counterfactual paired-output generation remains deferred rather than part of the current public contract                                          | RD-002         |
-| Robustness testing with hard tasks, shifts, adversarial regimes     | `partial`     | Deferred filtering, diagnostics proxies, missingness mechanisms, explicit noise-family controls, shift/drift controls, and steering are implemented with deterministic controls and benchmark guardrails                                                                                                      | Named hard-task and adversarial profile suites are not implemented yet                                                                           | RD-005         |
+| Robustness testing with hard tasks, shifts, adversarial regimes     | `implemented` | Deferred filtering, diagnostics proxies, missingness mechanisms, explicit noise-family controls, shift/drift controls, steering, named carried stress slices, parity-surface diagnostics, matched-budget diversity audits, and the RD-005 Pareto workflow are implemented with deterministic controls and benchmark guardrails | Further slice promotion should remain audit-gated; the default baseline is intentionally unchanged until a wider corpus pack clears the guardrails | RD-005         |
 | Causal structural integrity (hierarchical dependencies)             | `implemented` | Graph-driven node pipeline, shared runtime execution, DAG lineage artifacts, hard-interventional generation, shipped mechanism-family diversity controls, and keyed RNG semantic reproducibility are implemented                                                                                             | Counterfactual paired-output generation remains deferred, but the current structural-generation contract is implemented                           | RD-002         |
-| Tabular realism (mixed type + postprocess hooks)                    | `partial`     | Numeric/categorical converters, postprocess hooks, many-class rollout within the current `<=32` class envelope, configurable missingness, explicit noise families, shipped mechanism diversity controls, steering, and the current public generation runtime are implemented                                | Named robustness compositions over the shipped levers remain active work                                                                         | RD-005         |
+| Tabular realism (mixed type + postprocess hooks)                    | `partial`     | Numeric/categorical converters, postprocess hooks, many-class rollout within the current `<=32` class envelope, configurable missingness, explicit noise families, shipped mechanism diversity controls, steering, parity-surface diagnostics, and the current public generation runtime are implemented    | Promotion of the current internal categorical/cardinality and hybrid evaluation lanes remains active follow-on work                               | RD-005         |
 | PFN task coverage (classification, regression, time-series)         | `partial`     | Classification and regression generation pipelines are fully supported with deterministic seeds, keyed replay metadata, and benchmark workflows                                                                                                                                                               | No time-series generation mode, temporal metadata contract, or temporal diagnostics/guardrails                                                   | RD-013         |
 | Staged complexity scaling (features/nodes/samples)                  | `retired`     | Historical staged-complexity implementation (RD-006) has been retired in favor of explicit split sizing and the current heterogeneous/stratified generation model                                                                                                                                             | Not active                                                                                                                                       | RD-006         |
 | Hardware-native performance (Torch + hardware-aware tuning)         | `partial`     | Torch CPU/CUDA/MPS path, hardware detection, coarse profile-based tuning, benchmark suite, and stage-level generation/write/filter metrics are implemented                                                                                                                                                    | Hardware-adaptive autotuning is not implemented; any further throughput work is deferred to later follow-ons after the completed RD-009 baseline | RD-010, RD-014 |
@@ -303,38 +303,32 @@ Use the canonical docs instead:
 
 ### RD-005: Robustness Stress Profiles (Hard-Task/Adversarial Regimes)
 
-- Status: `research`
-- Milestone: `Now`
+- Status: `implemented`
+- Milestone: `Now` (completed via `#247`, `#252`, `#257`, `#262`, `#267`; closed follow-ons `#293`, `#294`)
 - Mission alignment: robustness testing
 - Pillar alignment: tabular realism
-- Goal: define reproducible named stress profiles and carried regime slices
-  built from the current harder-data levers so contributors can run
-  benchmark-guarded hard-task and adversarial-style regimes without inventing
-  one-off configs, and downstream repos can hold the data regime fixed while
-  comparing model scales.
-- GitHub tracking: `#247 -> #252 -> #257 -> #262 -> #267`
-- Repo touchpoints: `src/dagzoo/config/`, `src/dagzoo/core/config_resolution.py`, `src/dagzoo/functions/random_functions.py`, `src/dagzoo/postprocess/postprocess.py`, `src/dagzoo/bench/`, `src/dagzoo/sampling/missingness.py`, `src/dagzoo/core/shift.py`, `src/dagzoo/core/noise_runtime.py`
-- Exit criteria:
-  - Reproducible named stress presets are selectable via config/CLI and remain opt-in.
+- Goal: ship reproducible named stress profiles and carried regime slices built
+  from the current harder-data levers so contributors can run benchmark-guarded
+  hard-task and adversarial-style regimes without inventing one-off configs,
+  and downstream repos can hold the data regime fixed while comparing model
+  scales.
+- GitHub tracking: completed epic `#247`; shipped chain `#252 -> #257 -> #262 -> #267`; closed follow-ons `#293`, `#294`
+- Repo touchpoints: `src/dagzoo/config/`, `src/dagzoo/core/config_resolution.py`, `src/dagzoo/core/execution_semantics.py`, `src/dagzoo/core/layout.py`, `src/dagzoo/core/fixed_layout/metadata.py`, `src/dagzoo/diagnostics/`, `src/dagzoo/recipes/`, `scripts/evaluate_handoff_pareto.py`, `scripts/evaluate_rd005_follow_on_suite.py`, `scripts/render_tabiclv2_parity_report.py`, `docs/features/stress-profiles.md`
+- Delivered scope:
+  - Named carried slices are implemented for the baseline anti-memorization classification lane plus the graph-breadth and compositional comparison lanes used by the closed RD-005 chain.
   - Stress profiles are composed from the lever families surfaced by RD-008, RD-003, RD-004, and RD-012 rather than bespoke parallel plumbing.
-  - Benchmarks and diagnostics confirm regimes differ from baseline in intended directions.
-  - Profiles expose stable regime identifiers and enough metadata for
-    downstream matched-regime-budget comparisons, including comparable
-    dataset-size/task-complexity envelopes when they are used as scaling
-    slices.
-  - Reproducibility tests pass for fixed seed runs.
-- Delivery issues:
-  - `#252` `spec(stress): define named robustness stress profiles and validation`
-  - `#257` `feat(stress): integrate named stress profiles into generate and filter workflows`
-  - `#262` `analysis(stress): add regime characterization and baseline-comparison diagnostics`
-  - `#267` `docs(stress): add presets, tests, and benchmark guardrails for robustness profiles`
+  - Bundle metadata, diagnostics coverage artifacts, and `dagzoo diversity-audit` now expose first-class parity-surface summaries for converter, GP, kernel, matrix, root-base-kind, parent-arity, source-shape-policy, and categorical-cardinality coverage.
+  - The maintainer decision loop is implemented: `dagzoo diversity-audit` measures matched-budget diversity movement, `scripts/evaluate_handoff_pareto.py` ranks variants by structural diversity then throughput, `scripts/render_tabiclv2_parity_report.py` renders one audit into a parity report, and `scripts/evaluate_rd005_follow_on_suite.py` joins those artifacts into one explicit promotion decision with per-lane status fields.
+- Completion evidence:
+  - Reproducible named stress presets are selectable via config/CLI and remain opt-in.
+  - Fixed-seed materialization tests cover the current carried profiles and smoke presets.
+  - The parity note, stress-profile docs, and audit artifacts all frame the target as realized diversity under current contracts rather than exact TabICLv2 reproduction.
 - Current repo baseline:
-  - Curated recipe entries labeled `stress profile` remain adoption-layer
-    examples rather than the carried-slice contract for downstream scaling.
-  - `#252` introduces the first carried classification slice as
-    `stress.profile=anti_memorization_piecewise_classification_slice_v1`,
-    resolving onto the default classification envelope plus
-    `steering.preset=anti_memorization_piecewise_v1`.
+  - `configs/default.yaml` remains the stable default baseline and is not widened implicitly by RD-005.
+  - `anti_memorization_piecewise_classification_compositional_slice_v1` is the current promotion candidate for broader use.
+  - `anti_memorization_piecewise_classification_graph_breadth_slice_v1` remains the structural extreme rather than the default promotion target.
+  - `anti_memorization_piecewise_classification_categorical_cardinality_slice_v1`, `anti_memorization_piecewise_classification_hybrid_slice_v1`, and `anti_memorization_piecewise_classification_robustness_composition_slice_v1` are repo-local evaluation lanes pending matched-budget confirmation rather than closed roadmap delivery.
+  - Further public promotions should stay audit-gated and remain deferred until the follow-on suite produces a winner with tracked confirmation artifacts.
 
 ### RD-006: Staged Complexity Scaling (Features + Graph)
 

--- a/docs/development/tabiclv2_parity_audit.md
+++ b/docs/development/tabiclv2_parity_audit.md
@@ -23,6 +23,29 @@ changes are justified.
 | Kernel-family hyperparameters | `partial` | Fixed-layout kernel plans now carry plan-time `gamma`/`signed`, and the compositional stress slice correlates them, but the broader matrix surface still differs from TabICLv2. |
 | Global relationship-policy reuse across all plan families | `partial` | Matrix-family, activation-base-kind, and root-base-kind reuse exist in the compositional slice, and parent-arity/source-shape policy now exists in the graph-breadth slice; the remaining gap is that the full reuse surface is intentionally split across opt-in RD-005 lanes rather than applied globally. |
 
+## Evidence Snapshot
+
+- Treat realized artifacts, not this static table, as the current source of
+  truth. Start with `dagzoo diversity-audit` `summary.json` / `summary.md`.
+- Read `parity_surface_summary` first when you want the remaining parity gaps
+  directly: converter methods/variants, GP variants, kernel `gamma` / `signed`,
+  matrix kinds, root base kinds, parent arity, source-shape policy, and
+  categorical cardinality now surface as first-class summary fields.
+- Use [rd005_handoff_evaluation.md](rd005_handoff_evaluation.md) plus
+  [`scripts/evaluate_rd005_follow_on_suite.py`](../../scripts/evaluate_rd005_follow_on_suite.py)
+  when you want the canonical promotion decision across all current internal
+  RD-005 lanes.
+- Use [`scripts/evaluate_handoff_pareto.py`](../../scripts/evaluate_handoff_pareto.py)
+  when you want only the lower-level structural-diversity/throughput/downstream
+  ranking loop without the full suite orchestration.
+- Use [`scripts/render_tabiclv2_parity_report.py`](../../scripts/render_tabiclv2_parity_report.py)
+  when you want one maintainer-facing markdown/json snapshot from a single
+  diversity-audit run.
+- Current maintained read: the compositional slice is the promotion candidate,
+  graph breadth is the structural extreme, and parity means same-or-better
+  realized diversity under the shipped contracts rather than exact Appendix E
+  reproduction.
+
 ## RD-005 Read
 
 - The main gap was narrower correlation reuse, not absence of graph correlation.

--- a/docs/features/diagnostics.md
+++ b/docs/features/diagnostics.md
@@ -4,7 +4,7 @@ Diagnostics adds run-level coverage summaries to a generated corpus so you can
 see what the run actually produced. When enabled, `dagzoo` writes
 `coverage_summary.json` and `coverage_summary.md` alongside the generated data,
 making it easier to inspect feature counts, class counts, mechanism mix, noise,
-missingness, and other realized properties.
+missingness, parity-surface relationship reuse, and other realized properties.
 
 Use diagnostics when you want to compare recipes, confirm that a preset landed
 in the range you expected, or explain why one run behaves differently from
@@ -29,6 +29,12 @@ missingness rate) across the corpus and reporting coverage statistics. Optional
 target bands let you define expected ranges for specific meta-features and track
 what fraction of your corpus falls within those bands, turning effective
 diversity from a vague goal into a quantitative metric.
+
+Coverage summaries also persist a `parity_surface_summary` block for the
+realized relationship-reuse surface. That additive section reports converter
+method/variant frequency, GP variant frequency, kernel `gamma` / `signed`
+coverage, matrix-family coverage, root-base-kind coverage, parent-arity counts,
+source-shape policy counts, and categorical-cardinality ranges.
 
 ______________________________________________________________________
 
@@ -100,7 +106,7 @@ ______________________________________________________________________
 
 - Public `dataset_catalog.ndjson` for stable per-dataset identity and emitted schema.
 - In-process `DatasetBundle.metadata` when you need rich realized generation parameters.
-- Coverage summaries for meta-features, enabled observability metrics, and steering movement when curriculum steering is enabled.
+- Coverage summaries for meta-features, enabled observability metrics, parity-surface summaries, and steering movement when curriculum steering is enabled.
 - Benchmark summary guardrail sections that include diagnostics context.
 
 Exact output contracts are documented in

--- a/docs/features/stress-profiles.md
+++ b/docs/features/stress-profiles.md
@@ -36,10 +36,16 @@ ______________________________________________________________________
 - You need one graph-breadth-heavy slice for relationship-structure audits.
 - You want a compositional mechanism slice that pushes family mixing harder
   than the default baseline.
+- You want a categorical/cardinality-heavy lane without hand-authoring the
+  converter and cardinality envelope.
+- You want one hybrid slice that combines graph/source-shape reuse with
+  compositional matrix/kernel reuse.
+- You want one robustness-composition slice that explicitly couples missingness,
+  shift, and noise with the harder mechanism mix.
 
 ______________________________________________________________________
 
-## Shipped profiles
+## Shipped core profiles
 
 ### `anti_memorization_piecewise_classification_slice_v1`
 
@@ -159,6 +165,128 @@ Inspect first:
 - `metrics.mechanism_family_cooccurrence_ratio`
 - `metrics.graph_ancestor_overlap_mean`
 
+## Current internal evaluation profiles
+
+These profiles are available through repo-local configs and `stress.profile`,
+but they are still evaluation lanes rather than promoted public recipes. Keep
+them audit-gated and compare them against baseline and the current
+compositional slice before treating them as a broader adoption candidate.
+
+### `anti_memorization_piecewise_classification_categorical_cardinality_slice_v1`
+
+- Intended regime: categorical-heavy harder slice with broader correlated
+  categorical-cardinality regimes than the default baseline.
+- Main lever composition:
+  - raised categorical ratio floor and wider class envelope
+  - larger categorical cardinality ceiling tied to the existing
+    high-cardinality workflow
+  - anti-memorization steering retained as the base harder slice control
+
+Generate smoke run:
+
+```bash
+dagzoo generate \
+  --config configs/preset_stress_categorical_cardinality_generate_smoke.yaml \
+  --num-datasets 25 \
+  --out data/run_stress_categorical_cardinality_smoke
+```
+
+Benchmark smoke run:
+
+```bash
+dagzoo benchmark \
+  --config configs/preset_stress_categorical_cardinality_benchmark_smoke.yaml \
+  --preset custom \
+  --suite smoke \
+  --diagnostics \
+  --no-memory \
+  --out-dir benchmarks/results/smoke_stress_categorical_cardinality
+```
+
+Inspect first:
+
+- `coverage_summary.json`
+- `parity_surface_summary.categorical_cardinality`
+- `parity_surface_summary.converter_method_counts`
+- `metrics.cat_cardinality_mean`
+
+### `anti_memorization_piecewise_classification_hybrid_slice_v1`
+
+- Intended regime: hybrid structural+compositional slice that combines the
+  graph/source-shape reuse pressure from the graph-breadth lane with the
+  matrix/kernel/root reuse from the compositional lane.
+- Main lever composition:
+  - broader node and feature envelope with graph gating enabled
+  - parent-arity/source-shape policy reuse
+  - correlated matrix/kernel/root-base-kind reuse
+
+Generate smoke run:
+
+```bash
+dagzoo generate \
+  --config configs/preset_stress_hybrid_generate_smoke.yaml \
+  --num-datasets 25 \
+  --out data/run_stress_hybrid_smoke
+```
+
+Benchmark smoke run:
+
+```bash
+dagzoo benchmark \
+  --config configs/preset_stress_hybrid_benchmark_smoke.yaml \
+  --preset custom \
+  --suite smoke \
+  --diagnostics \
+  --no-memory \
+  --out-dir benchmarks/results/smoke_stress_hybrid
+```
+
+Inspect first:
+
+- `coverage_summary.json`
+- `parity_surface_summary.matrix_kind_counts`
+- `parity_surface_summary.root_base_kind_counts`
+- `parity_surface_summary.source_shape_policy_counts`
+
+### `anti_memorization_piecewise_classification_robustness_composition_slice_v1`
+
+- Intended regime: explicit robustness composition that couples missingness,
+  shift, and mixed noise with the anti-memorization harder slice instead of
+  leaving those levers as separate recipes.
+- Main lever composition:
+  - structured MNAR missingness
+  - mixed graph/variance drift
+  - explicit Gaussian/Laplace/Student-t residual mixture
+
+Generate smoke run:
+
+```bash
+dagzoo generate \
+  --config configs/preset_stress_robustness_composition_generate_smoke.yaml \
+  --num-datasets 25 \
+  --out data/run_stress_robustness_composition_smoke
+```
+
+Benchmark smoke run:
+
+```bash
+dagzoo benchmark \
+  --config configs/preset_stress_robustness_composition_benchmark_smoke.yaml \
+  --preset custom \
+  --suite smoke \
+  --diagnostics \
+  --no-memory \
+  --out-dir benchmarks/results/smoke_stress_robustness_composition
+```
+
+Inspect first:
+
+- `coverage_summary.json`
+- `missingness`
+- `shift`
+- `noise_distribution`
+- `parity_surface_summary.gp_variant_counts`
+
 ______________________________________________________________________
 
 ## Baseline comparison workflow
@@ -178,12 +306,34 @@ dagzoo diversity-audit \
   --out-dir benchmarks/results/diversity_audit_stress_graph_breadth
 ```
 
-Swap `--variant-config` to
-`configs/preset_stress_classification_slice_benchmark_smoke.yaml` or
-`configs/preset_stress_compositional_benchmark_smoke.yaml` for the other
-profiles. Inspect `summary.json` and `summary.md` first, then inspect
+Swap `--variant-config` to any of the other stress benchmark presets for the
+other profiles. Inspect `summary.json` and `summary.md` first, then inspect
 coverage artifacts from a diagnostics-enabled benchmark run when you need the
 relationship-structure or mechanism-family metrics behind the shift.
+
+To turn one diversity-audit run into a parity-focused maintainer report:
+
+```bash
+./.venv/bin/python scripts/render_tabiclv2_parity_report.py \
+  --summary-json benchmarks/results/diversity_audit_stress_graph_breadth/summary.json \
+  --out-dir benchmarks/results/diversity_audit_stress_graph_breadth/parity_report
+```
+
+To run the full internal RD-005 promotion suite across the incumbent,
+structural control, and current challenger lanes:
+
+```bash
+./.venv/bin/python scripts/evaluate_rd005_follow_on_suite.py \
+  --baseline-config configs/default.yaml \
+  --out-root benchmarks/results/rd005_follow_on \
+  --suite smoke \
+  --num-datasets 8 \
+  --seed 123 \
+  --device cpu
+```
+
+Read `follow_on_promotion_summary.json` / `follow_on_promotion_summary.md`
+first when you want the explicit promotion status for each internal lane.
 
 ______________________________________________________________________
 
@@ -194,6 +344,13 @@ ______________________________________________________________________
 - Benchmark smoke presets keep diagnostics off by default. Pass
   `--diagnostics` when you want coverage artifacts in addition to the benchmark
   summary.
+- `dagzoo diversity-audit` `summary.json` now carries `parity_surface_summary`
+  alongside the mechanism-family summary so the remaining TabICLv2 parity gaps
+  can be measured directly instead of inferred indirectly.
+- The full RD-005 suite runner keeps the public/internal boundary explicit:
+  internal lanes can receive `promote`, `hold_internal`, or
+  `structural_control_only`, but public recipe promotion remains a separate
+  follow-up step after a winner clears the gate.
 - Benchmark summaries stay on the current contract. Steering and
   stress-profile evidence lives in diagnostics artifacts and in
   `dagzoo diversity-audit`, not in a new benchmark-only field family.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dagzoo"
-version = "0.19.10"
+version = "0.19.11"
 description = "Synthetic tabular data generator for causal modeling"
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -33,6 +33,10 @@ docs helpers, and maintenance utilities rather than convenience wrappers.
   - Dry-run or remove ignored local runtime/docs outputs (`data/`, `benchmarks/results/`, and the built docs output under `site/`) without touching tracked files.
 - `scripts/evaluate_handoff_pareto.py --baseline-config <path> --out-root <dir> [--stress-profile <name> ...] [--variant-config <path> ...]`
   - Runs matched `dagzoo generate --handoff-root` baseline/variant comparisons and writes RD-005 maintainer summaries for structural diversity, throughput, and the anti-triviality downstream ceiling.
+- `scripts/evaluate_rd005_follow_on_suite.py --baseline-config <path> --out-root <dir>`
+  - Runs the full internal RD-005 lane set through diversity-audit, parity rendering, and handoff Pareto evaluation, then writes one combined promotion decision summary with `promote` / `hold_internal` / `structural_control_only` statuses.
+- `scripts/render_tabiclv2_parity_report.py --summary-json <path> --out-dir <dir>`
+  - Renders one `dagzoo diversity-audit` summary into a maintainer-facing parity report with first-class converter/GP/kernel/matrix/root/source-shape snapshots.
 - `scripts/docs/sync_hugo_content.py [--check]`
   - Sync canonical docs from `docs/` into the generated Hugo input area described in `site/README.md` (single-source docs model).
 - `scripts/docs/check_links.py [roots...]`
@@ -61,6 +65,8 @@ docs helpers, and maintenance utilities rather than convenience wrappers.
 ./.venv/bin/python scripts/cleanup_local_artifacts.py --group all
 ./.venv/bin/python scripts/cleanup_local_artifacts.py --group runtime --apply
 ./.venv/bin/python scripts/evaluate_handoff_pareto.py --baseline-config configs/default.yaml --stress-profile anti_memorization_piecewise_classification_graph_breadth_slice_v1 --stress-profile anti_memorization_piecewise_classification_compositional_slice_v1 --out-root benchmarks/results/rd005_pareto --num-datasets 8 --seed 123 --device cpu
+./.venv/bin/python scripts/evaluate_rd005_follow_on_suite.py --baseline-config configs/default.yaml --out-root benchmarks/results/rd005_follow_on --suite smoke --num-datasets 8 --seed 123 --device cpu
+./.venv/bin/python scripts/render_tabiclv2_parity_report.py --summary-json benchmarks/results/diversity_audit_stress_graph_breadth/summary.json --out-dir benchmarks/results/diversity_audit_stress_graph_breadth/parity_report
 uv run dagzoo generate --config configs/default.yaml --num-datasets 50 --device cpu --out data/run_cpu_50
 uv run dagzoo generate --config configs/preset_cuda_h100.yaml --num-datasets 500 --device cuda --out data/run_h100_500 --seed 123
 uv run dagzoo generate --config configs/preset_many_class_generate_smoke.yaml --num-datasets 25 --device cpu --out data/run_many_class --seed 123

--- a/scripts/evaluate_handoff_pareto.py
+++ b/scripts/evaluate_handoff_pareto.py
@@ -52,6 +52,7 @@ class _CliArgs:
     baseline_config: str
     out_root: str
     variant_config: tuple[str, ...]
+    variant_label: tuple[str, ...]
     stress_profile: tuple[str, ...]
     num_datasets: int
     seed: int
@@ -71,6 +72,8 @@ def _sanitize_label(label: str) -> str:
 
 def _build_variant_specs(args: _CliArgs, *, temp_dir: Path) -> list[_VariantSpec]:
     baseline_config_path = Path(args.baseline_config).resolve()
+    if args.variant_label and len(args.variant_label) != len(args.variant_config):
+        raise ValueError("--variant-label count must match --variant-config count.")
     specs: list[_VariantSpec] = [
         _VariantSpec(
             label="baseline",
@@ -78,11 +81,16 @@ def _build_variant_specs(args: _CliArgs, *, temp_dir: Path) -> list[_VariantSpec
             regime_id="baseline",
         )
     ]
-    for config_path_text in args.variant_config:
+    for index, config_path_text in enumerate(args.variant_config):
         config_path = Path(config_path_text).resolve()
+        label = (
+            str(args.variant_label[index])
+            if index < len(args.variant_label) and str(args.variant_label[index]).strip()
+            else f"config:{config_path.stem}"
+        )
         specs.append(
             _VariantSpec(
-                label=f"config:{config_path.stem}",
+                label=label,
                 config_path=config_path,
                 regime_id=f"config:{config_path.stem}",
             )
@@ -348,6 +356,11 @@ def _entry_payload(
         "datasets_per_minute": _datasets_per_minute(num_datasets, elapsed_seconds),
         "downstream": downstream,
         "supporting_metrics": _supporting_metric_snapshot(coverage_summary),
+        "parity_surface_summary": (
+            coverage_summary.get("parity_surface_summary")
+            if isinstance(coverage_summary, dict)
+            else None
+        ),
         "coverage_summary": coverage_summary,
     }
 
@@ -485,8 +498,38 @@ def _write_markdown_report(report: dict[str, Any], *, out_path: Path) -> None:
         for metric, value in entry["supporting_metrics"].items():
             rendered = "-" if value is None else f"{float(value):.4f}"
             lines.append(f"  - `{metric}`: {rendered}")
+        parity_surface_summary = entry.get("parity_surface_summary")
+        if isinstance(parity_surface_summary, dict):
+            lines.append("- Parity surface snapshot:")
+            lines.append(
+                "  - Converter methods: "
+                f"`{_render_count_snapshot(parity_surface_summary.get('converter_method_counts'))}`"
+            )
+            lines.append(
+                "  - GP variants: "
+                f"`{_render_count_snapshot(parity_surface_summary.get('gp_variant_counts'))}`"
+            )
+            lines.append(
+                "  - Matrix kinds: "
+                f"`{_render_count_snapshot(parity_surface_summary.get('matrix_kind_counts'))}`"
+            )
+            lines.append(
+                "  - Source-shape policy: "
+                f"`{_render_count_snapshot(parity_surface_summary.get('source_shape_policy_counts'))}`"
+            )
         lines.append("")
     out_path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def _render_count_snapshot(payload: object) -> str:
+    if not isinstance(payload, dict) or not payload:
+        return "-"
+    parts: list[str] = []
+    for label in sorted(payload):
+        value = payload.get(label)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            parts.append(f"{label}={int(value)}")
+    return ", ".join(parts) if parts else "-"
 
 
 @click.command(
@@ -503,6 +546,12 @@ def _write_markdown_report(report: dict[str, Any], *, out_path: Path) -> None:
     multiple=True,
     default=(),
     help="Additional full config YAML path to evaluate as one variant. Repeatable.",
+)
+@click.option(
+    "--variant-label",
+    multiple=True,
+    default=(),
+    help="Optional label for each --variant-config entry. Repeatable and positional.",
 )
 @click.option(
     "--stress-profile",
@@ -544,6 +593,7 @@ def cli(
     baseline_config: str,
     out_root: str,
     variant_config: tuple[str, ...],
+    variant_label: tuple[str, ...],
     stress_profile: tuple[str, ...],
     num_datasets: int,
     seed: int,
@@ -558,6 +608,7 @@ def cli(
         baseline_config=baseline_config,
         out_root=out_root,
         variant_config=variant_config,
+        variant_label=variant_label,
         stress_profile=stress_profile,
         num_datasets=num_datasets,
         seed=seed,

--- a/scripts/evaluate_rd005_follow_on_suite.py
+++ b/scripts/evaluate_rd005_follow_on_suite.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python
+"""Run the full RD-005 follow-on promotion suite."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import click
+import yaml
+
+from dagzoo.config import GeneratorConfig, clone_generator_config
+from dagzoo.diagnostics.effective_diversity import (
+    run_effective_diversity_audit,
+    write_effective_diversity_artifacts,
+)
+from dagzoo.diagnostics.rd005_follow_on import (
+    DEFAULT_THROUGHPUT_FLOOR_RATIO,
+    RD005_FOLLOW_ON_LANES,
+    build_rd005_follow_on_report,
+    write_rd005_follow_on_artifacts,
+)
+
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True, slots=True)
+class _VariantInput:
+    label: str
+    stress_profile: str
+    config_path: Path
+    config: GeneratorConfig
+
+
+def _load_repo_script_module(module_name: str, rel_path: str):
+    """Load one repo script module from a repo-relative path."""
+
+    script_path = _REPO_ROOT / rel_path
+    spec = importlib.util.spec_from_file_location(module_name, script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load script module from {script_path}.")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_variant_inputs(
+    *,
+    baseline_config: GeneratorConfig,
+    out_dir: Path,
+) -> list[_VariantInput]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    variants: list[_VariantInput] = []
+    for lane in RD005_FOLLOW_ON_LANES:
+        config = clone_generator_config(baseline_config, revalidate=False)
+        config.stress.profile = lane.stress_profile
+        config_path = out_dir / f"{lane.label}.yaml"
+        config_path.write_text(yaml.safe_dump(config.to_dict(), sort_keys=False), encoding="utf-8")
+        variants.append(
+            _VariantInput(
+                label=lane.label,
+                stress_profile=lane.stress_profile,
+                config_path=config_path,
+                config=config,
+            )
+        )
+    return variants
+
+
+def _run_diversity_audit_suite(
+    *,
+    baseline_config: GeneratorConfig,
+    baseline_config_path: Path,
+    variants: list[_VariantInput],
+    suite: str,
+    num_datasets: int,
+    warmup: int | None,
+    device: str,
+    warn_threshold_pct: float,
+    fail_threshold_pct: float,
+    out_dir: Path,
+    reuse_existing: bool,
+) -> tuple[dict[str, Path], dict[str, Any]]:
+    summary_json = out_dir / "summary.json"
+    summary_md = out_dir / "summary.md"
+    if reuse_existing and summary_json.exists() and summary_md.exists():
+        return {"summary_json": summary_json, "summary_md": summary_md}, _load_json(summary_json)
+
+    report = run_effective_diversity_audit(
+        baseline_config=baseline_config,
+        baseline_config_path=str(baseline_config_path),
+        variant_configs=[variant.config for variant in variants],
+        variant_config_paths=[str(variant.config_path) for variant in variants],
+        variant_labels=[variant.label for variant in variants],
+        suite=suite,
+        num_datasets=num_datasets,
+        warmup=warmup,
+        device=device,
+        warn_threshold_pct=warn_threshold_pct,
+        fail_threshold_pct=fail_threshold_pct,
+    )
+    artifact_paths = write_effective_diversity_artifacts(report, out_dir=out_dir)
+    return artifact_paths, _load_json(artifact_paths["summary_json"])
+
+
+def _run_parity_report(
+    *,
+    summary_json: Path,
+    out_dir: Path,
+) -> tuple[dict[str, Path], dict[str, Any]]:
+    module = _load_repo_script_module(
+        "evaluate_rd005_follow_on_parity_report",
+        "scripts/render_tabiclv2_parity_report.py",
+    )
+    exit_code = module.main(["--summary-json", str(summary_json), "--out-dir", str(out_dir)])
+    if exit_code != 0:
+        raise RuntimeError(f"render_tabiclv2_parity_report.py failed with exit code {exit_code}.")
+    json_path = out_dir / "parity_report.json"
+    md_path = out_dir / "parity_report.md"
+    return {"summary_json": json_path, "summary_md": md_path}, _load_json(json_path)
+
+
+def _run_pareto_suite(
+    *,
+    baseline_config_path: Path,
+    variants: list[_VariantInput],
+    out_dir: Path,
+    num_datasets: int,
+    seed: int,
+    device: str,
+    hardware_policy: str,
+    rows: str | None,
+    warn_threshold_pct: float,
+    fail_threshold_pct: float,
+    reuse_existing: bool,
+) -> tuple[dict[str, Path], dict[str, Any]]:
+    module = _load_repo_script_module(
+        "evaluate_rd005_follow_on_pareto",
+        "scripts/evaluate_handoff_pareto.py",
+    )
+    argv = [
+        "--baseline-config",
+        str(baseline_config_path),
+        "--out-root",
+        str(out_dir),
+        "--num-datasets",
+        str(int(num_datasets)),
+        "--seed",
+        str(int(seed)),
+        "--device",
+        str(device),
+        "--hardware-policy",
+        str(hardware_policy),
+        "--warn-threshold-pct",
+        str(float(warn_threshold_pct)),
+        "--fail-threshold-pct",
+        str(float(fail_threshold_pct)),
+    ]
+    if rows is not None:
+        argv.extend(["--rows", str(rows)])
+    if reuse_existing:
+        argv.append("--reuse-existing")
+    for variant in variants:
+        argv.extend(["--variant-config", str(variant.config_path)])
+        argv.extend(["--variant-label", variant.label])
+    exit_code = module.main(argv)
+    if exit_code != 0:
+        raise RuntimeError(f"evaluate_handoff_pareto.py failed with exit code {exit_code}.")
+    json_path = out_dir / "pareto_summary.json"
+    md_path = out_dir / "pareto_summary.md"
+    return {"summary_json": json_path, "summary_md": md_path}, _load_json(json_path)
+
+
+@click.command(
+    context_settings=CONTEXT_SETTINGS,
+    help="Run the full RD-005 follow-on suite and write a promotion decision summary.",
+)
+@click.option(
+    "--baseline-config",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Baseline config YAML path.",
+)
+@click.option(
+    "--out-root",
+    required=True,
+    type=click.Path(file_okay=False, path_type=Path),
+    help="Output root for the full follow-on suite.",
+)
+@click.option(
+    "--suite",
+    type=click.Choice(["smoke", "standard"]),
+    default="smoke",
+    show_default=True,
+    help="Diversity-audit probe suite.",
+)
+@click.option(
+    "--num-datasets",
+    type=int,
+    default=8,
+    show_default=True,
+    help="Datasets per run for diversity and handoff evaluation.",
+)
+@click.option(
+    "--warmup",
+    type=int,
+    default=None,
+    help="Optional diversity-audit warmup override.",
+)
+@click.option("--seed", type=int, default=0, show_default=True, help="Shared generation seed.")
+@click.option("--device", default="cpu", show_default=True, help="Generation device.")
+@click.option(
+    "--hardware-policy",
+    default="none",
+    show_default=True,
+    help="Hardware policy passed through to `dagzoo generate`.",
+)
+@click.option("--rows", default=None, help="Optional rows override for handoff generation.")
+@click.option(
+    "--warn-threshold-pct",
+    type=float,
+    default=2.5,
+    show_default=True,
+    help="Warn threshold passed to diversity-summary comparison.",
+)
+@click.option(
+    "--fail-threshold-pct",
+    type=float,
+    default=5.0,
+    show_default=True,
+    help="Fail threshold passed to diversity-summary comparison.",
+)
+@click.option(
+    "--throughput-floor-ratio",
+    type=float,
+    default=DEFAULT_THROUGHPUT_FLOOR_RATIO,
+    show_default=True,
+    help="Minimum datasets/minute ratio vs baseline required for promotion.",
+)
+@click.option(
+    "--reuse-existing",
+    is_flag=True,
+    help="Reuse existing diversity-audit and handoff artifacts when present.",
+)
+def cli(
+    *,
+    baseline_config: Path,
+    out_root: Path,
+    suite: str,
+    num_datasets: int,
+    warmup: int | None,
+    seed: int,
+    device: str,
+    hardware_policy: str,
+    rows: str | None,
+    warn_threshold_pct: float,
+    fail_threshold_pct: float,
+    throughput_floor_ratio: float,
+    reuse_existing: bool,
+) -> int:
+    if throughput_floor_ratio <= 0.0:
+        raise click.ClickException("--throughput-floor-ratio must be > 0.")
+
+    baseline_config_path = baseline_config.resolve()
+    out_root = out_root.resolve()
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    baseline_cfg = GeneratorConfig.from_yaml(str(baseline_config_path))
+    variant_inputs = _write_variant_inputs(
+        baseline_config=baseline_cfg,
+        out_dir=out_root / "variant_inputs",
+    )
+
+    diversity_paths, diversity_report = _run_diversity_audit_suite(
+        baseline_config=baseline_cfg,
+        baseline_config_path=baseline_config_path,
+        variants=variant_inputs,
+        suite=suite,
+        num_datasets=int(num_datasets),
+        warmup=warmup,
+        device=str(device),
+        warn_threshold_pct=float(warn_threshold_pct),
+        fail_threshold_pct=float(fail_threshold_pct),
+        out_dir=out_root / "diversity_audit",
+        reuse_existing=bool(reuse_existing),
+    )
+    diversity_report.setdefault("summary", {})
+    diversity_report["summary"]["source_summary_json"] = str(diversity_paths["summary_json"])
+
+    parity_paths, parity_report = _run_parity_report(
+        summary_json=diversity_paths["summary_json"],
+        out_dir=out_root / "diversity_audit" / "parity_report",
+    )
+    parity_report.setdefault("summary", {})
+    parity_report["summary"]["source_parity_report_json"] = str(parity_paths["summary_json"])
+
+    pareto_paths, pareto_report = _run_pareto_suite(
+        baseline_config_path=baseline_config_path,
+        variants=variant_inputs,
+        out_dir=out_root / "handoff_pareto",
+        num_datasets=int(num_datasets),
+        seed=int(seed),
+        device=str(device),
+        hardware_policy=str(hardware_policy),
+        rows=rows,
+        warn_threshold_pct=float(warn_threshold_pct),
+        fail_threshold_pct=float(fail_threshold_pct),
+        reuse_existing=bool(reuse_existing),
+    )
+    pareto_report.setdefault("summary", {})
+    pareto_report["summary"]["source_pareto_summary_json"] = str(pareto_paths["summary_json"])
+
+    report = build_rd005_follow_on_report(
+        baseline_config_path=str(baseline_config_path),
+        diversity_report=diversity_report,
+        parity_report=parity_report,
+        pareto_report=pareto_report,
+        throughput_floor_ratio=float(throughput_floor_ratio),
+    )
+    report.setdefault("artifacts", {})
+    report["artifacts"].update(
+        {
+            "diversity_summary_json": str(diversity_paths["summary_json"]),
+            "diversity_summary_md": str(diversity_paths["summary_md"]),
+            "parity_report_json": str(parity_paths["summary_json"]),
+            "parity_report_md": str(parity_paths["summary_md"]),
+            "pareto_summary_json": str(pareto_paths["summary_json"]),
+            "pareto_summary_md": str(pareto_paths["summary_md"]),
+        }
+    )
+    artifact_paths = write_rd005_follow_on_artifacts(report, out_dir=out_root)
+    print(f"Wrote follow-on promotion summary: {artifact_paths['summary_json']}")
+    print(f"Wrote follow-on promotion markdown: {artifact_paths['summary_md']}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        result = cli.main(
+            args=argv,
+            prog_name="evaluate_rd005_follow_on_suite.py",
+            standalone_mode=False,
+        )
+    except click.ClickException as exc:
+        exc.show(file=sys.stderr)
+        return int(exc.exit_code)
+    except click.exceptions.Exit as exc:
+        return int(exc.exit_code)
+    except click.Abort:
+        return 1
+    return 0 if result is None else int(result)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_tabiclv2_parity_report.py
+++ b/scripts/render_tabiclv2_parity_report.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python
+"""Render a maintainer-facing TabICLv2 parity report from a diversity audit."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import click
+
+from dagzoo.diagnostics.effective_diversity.compare import compare_coverage_summaries
+
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+
+def _datasets_per_minute_value(entry: dict[str, Any]) -> float:
+    value = entry.get("datasets_per_minute")
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return 0.0
+
+
+def _structural_diversity_value(entry: dict[str, Any]) -> float:
+    value = entry.get("structural_diversity_composite_shift_pct")
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return 0.0
+
+
+def _diversity_value(entry: dict[str, Any]) -> float:
+    value = entry.get("diversity_composite_shift_pct")
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return 0.0
+
+
+def _priority_sort_key(entry: dict[str, Any]) -> tuple[float, float, float]:
+    return (
+        -_structural_diversity_value(entry),
+        -_datasets_per_minute_value(entry),
+        -_diversity_value(entry),
+    )
+
+
+def _render_count_snapshot(payload: object) -> str:
+    if not isinstance(payload, dict) or not payload:
+        return "-"
+    parts: list[str] = []
+    for label in sorted(payload):
+        value = payload.get(label)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            parts.append(f"{label}={int(value)}")
+    return ", ".join(parts) if parts else "-"
+
+
+def _render_scalar_snapshot(payload: object) -> str:
+    if not isinstance(payload, dict) or int(payload.get("count") or 0) <= 0:
+        return "-"
+    return (
+        f"count={int(payload['count'])}, "
+        f"mean={float(payload.get('mean') or 0.0):.3f}, "
+        f"range={float(payload.get('min') or 0.0):.3f}-{float(payload.get('max') or 0.0):.3f}"
+    )
+
+
+def _comparison_with_structural(
+    *,
+    baseline: dict[str, Any],
+    variant: dict[str, Any],
+    comparison: dict[str, Any] | None,
+    summary: dict[str, Any],
+) -> dict[str, Any]:
+    if comparison is None:
+        comparison = {}
+    baseline_summary = baseline.get("coverage_summary")
+    variant_summary = variant.get("coverage_summary")
+    if not isinstance(baseline_summary, dict) or not isinstance(variant_summary, dict):
+        return dict(comparison)
+    structural = compare_coverage_summaries(
+        baseline_summary=baseline_summary,
+        variant_summary=variant_summary,
+        warn_threshold_pct=float(summary.get("warn_threshold_pct", 2.5)),
+        fail_threshold_pct=float(summary.get("fail_threshold_pct", 5.0)),
+        include_structural_summary=True,
+    )
+    return {
+        **comparison,
+        "diversity_status": structural.get(
+            "diversity_status",
+            comparison.get("diversity_status", "insufficient_metrics"),
+        ),
+        "diversity_composite_shift_pct": structural.get(
+            "diversity_composite_shift_pct",
+            comparison.get("diversity_composite_shift_pct"),
+        ),
+        "structural_diversity_composite_shift_pct": structural.get(
+            "structural_diversity_composite_shift_pct"
+        ),
+        "structural_diversity_metric_shift_pct": structural.get(
+            "structural_diversity_metric_shift_pct"
+        ),
+    }
+
+
+def _write_markdown_report(report: dict[str, Any], *, out_path: Path) -> None:
+    baseline = report["baseline"]
+    lines = [
+        "# TabICLv2 Parity Report",
+        "",
+        f"- Source diversity summary: `{report['summary']['source_summary_json']}`",
+        f"- Variants: `{report['summary']['num_variants']}`",
+        "- Priority order: structural diversity, throughput, then broader diversity shift",
+        "",
+        "## Priority Order",
+        "",
+    ]
+    for label in report["summary"]["priority_variant_labels"]:
+        lines.append(f"- `{label}`")
+
+    lines.extend(
+        [
+            "",
+            "## Baseline",
+            "",
+            f"- Label: `{baseline['label']}`",
+            f"- Config path: `{baseline['config_path']}`",
+            f"- Datasets/minute: `{baseline.get('datasets_per_minute', '-')}`",
+            "- Parity surface:",
+            f"  - Converter methods: `{_render_count_snapshot(baseline['parity_surface_summary'].get('converter_method_counts'))}`",
+            f"  - GP variants: `{_render_count_snapshot(baseline['parity_surface_summary'].get('gp_variant_counts'))}`",
+            f"  - Matrix kinds: `{_render_count_snapshot(baseline['parity_surface_summary'].get('matrix_kind_counts'))}`",
+            f"  - Root base kinds: `{_render_count_snapshot(baseline['parity_surface_summary'].get('root_base_kind_counts'))}`",
+            f"  - Source-shape policy: `{_render_count_snapshot(baseline['parity_surface_summary'].get('source_shape_policy_counts'))}`",
+            f"  - Kernel gamma: `{_render_scalar_snapshot(baseline['parity_surface_summary'].get('kernel_gamma'))}`",
+            f"  - Categorical cardinality: `{_render_scalar_snapshot(baseline['parity_surface_summary'].get('categorical_cardinality'))}`",
+            "",
+            "## Variants",
+            "",
+        ]
+    )
+    for entry in report["variants"]:
+        lines.extend(
+            [
+                f"### {entry['label']}",
+                "",
+                f"- Config path: `{entry['config_path']}`",
+                f"- Diversity status: `{entry['diversity_status']}`",
+                f"- Diversity composite shift pct: `{float(entry.get('diversity_composite_shift_pct') or 0.0):.2f}`",
+                "- Structural diversity composite shift pct: "
+                f"`{float(entry.get('structural_diversity_composite_shift_pct') or 0.0):.2f}`",
+                f"- Datasets/minute: `{float(entry.get('datasets_per_minute') or 0.0):.2f}`",
+                f"- Datasets/minute delta pct: `{float(entry.get('datasets_per_minute_delta_pct') or 0.0):.2f}`",
+                "- Parity surface:",
+                f"  - Converter methods: `{_render_count_snapshot(entry['parity_surface_summary'].get('converter_method_counts'))}`",
+                f"  - Converter method+variant: `{_render_count_snapshot(entry['parity_surface_summary'].get('converter_method_variant_counts'))}`",
+                f"  - GP variants: `{_render_count_snapshot(entry['parity_surface_summary'].get('gp_variant_counts'))}`",
+                f"  - Matrix kinds: `{_render_count_snapshot(entry['parity_surface_summary'].get('matrix_kind_counts'))}`",
+                f"  - Root base kinds: `{_render_count_snapshot(entry['parity_surface_summary'].get('root_base_kind_counts'))}`",
+                f"  - Source-shape policy: `{_render_count_snapshot(entry['parity_surface_summary'].get('source_shape_policy_counts'))}`",
+                f"  - Kernel gamma: `{_render_scalar_snapshot(entry['parity_surface_summary'].get('kernel_gamma'))}`",
+                f"  - Categorical cardinality: `{_render_scalar_snapshot(entry['parity_surface_summary'].get('categorical_cardinality'))}`",
+                "",
+            ]
+        )
+    out_path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+@click.command(
+    context_settings=CONTEXT_SETTINGS,
+    help="Render a maintainer parity report from one diversity-audit summary.json artifact.",
+)
+@click.option(
+    "--summary-json",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Path to dagzoo diversity-audit summary.json.",
+)
+@click.option(
+    "--out-dir",
+    required=True,
+    type=click.Path(file_okay=False, path_type=Path),
+    help="Directory to write parity_report.json and parity_report.md.",
+)
+def cli(*, summary_json: Path, out_dir: Path) -> int:
+    payload = json.loads(summary_json.read_text(encoding="utf-8"))
+    baseline = payload.get("baseline")
+    variants = payload.get("variants")
+    comparisons = payload.get("comparisons")
+    summary = payload.get("summary")
+    if (
+        not isinstance(baseline, dict)
+        or not isinstance(variants, list)
+        or not isinstance(summary, dict)
+    ):
+        raise click.ClickException(
+            "summary.json does not look like a dagzoo diversity-audit report."
+        )
+
+    comparison_map = {
+        str(item.get("variant_label")): item
+        for item in comparisons
+        if isinstance(comparisons, list) and isinstance(item, dict) and item.get("variant_label")
+    }
+    rendered_variants: list[dict[str, Any]] = []
+    for variant in variants:
+        if not isinstance(variant, dict):
+            continue
+        label = str(variant.get("label", "-"))
+        rendered_variants.append(
+            {
+                "label": label,
+                "config_path": variant.get("config_path"),
+                "datasets_per_minute": variant.get("datasets_per_minute"),
+                "datasets_per_minute_delta_pct": (
+                    comparison_map.get(label, {}).get("datasets_per_minute_delta_pct")
+                ),
+                "parity_surface_summary": (
+                    variant.get("parity_surface_summary")
+                    if isinstance(variant.get("parity_surface_summary"), dict)
+                    else {}
+                ),
+                **_comparison_with_structural(
+                    baseline=baseline,
+                    variant=variant,
+                    comparison=comparison_map.get(label),
+                    summary=summary,
+                ),
+            }
+        )
+    rendered_variants.sort(key=_priority_sort_key)
+
+    report = {
+        "schema_name": "dagzoo_tabiclv2_parity_report",
+        "schema_version": 1,
+        "baseline": {
+            "label": baseline.get("label"),
+            "config_path": baseline.get("config_path"),
+            "datasets_per_minute": baseline.get("datasets_per_minute"),
+            "parity_surface_summary": (
+                baseline.get("parity_surface_summary")
+                if isinstance(baseline.get("parity_surface_summary"), dict)
+                else {}
+            ),
+        },
+        "variants": rendered_variants,
+        "summary": {
+            "source_summary_json": str(summary_json.resolve()),
+            "num_variants": len(rendered_variants),
+            "priority_variant_labels": [entry["label"] for entry in rendered_variants],
+        },
+    }
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / "parity_report.json"
+    md_path = out_dir / "parity_report.md"
+    json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_markdown_report(report, out_path=md_path)
+    print(f"Wrote parity report: {json_path}")
+    print(f"Wrote parity markdown: {md_path}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        result = cli.main(
+            args=argv,
+            prog_name="render_tabiclv2_parity_report.py",
+            standalone_mode=False,
+        )
+    except click.ClickException as exc:
+        exc.show(file=sys.stderr)
+        return int(exc.exit_code)
+    except click.exceptions.Exit as exc:
+        return int(exc.exit_code)
+    except click.Abort:
+        return 1
+    return 0 if result is None else int(result)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/dagzoo/config/models.py
+++ b/src/dagzoo/config/models.py
@@ -73,6 +73,15 @@ _STRESS_PROFILE_ANTI_MEMORIZATION_PIECEWISE_CLASSIFICATION_GRAPH_BREADTH_SLICE_V
 _STRESS_PROFILE_ANTI_MEMORIZATION_PIECEWISE_CLASSIFICATION_COMPOSITIONAL_SLICE_V1 = (
     "anti_memorization_piecewise_classification_compositional_slice_v1"
 )
+_STRESS_PROFILE_ANTI_MEMORIZATION_PIECEWISE_CLASSIFICATION_CATEGORICAL_CARDINALITY_SLICE_V1 = (
+    "anti_memorization_piecewise_classification_categorical_cardinality_slice_v1"
+)
+_STRESS_PROFILE_ANTI_MEMORIZATION_PIECEWISE_CLASSIFICATION_HYBRID_SLICE_V1 = (
+    "anti_memorization_piecewise_classification_hybrid_slice_v1"
+)
+_STRESS_PROFILE_ANTI_MEMORIZATION_PIECEWISE_CLASSIFICATION_ROBUSTNESS_COMPOSITION_SLICE_V1 = (
+    "anti_memorization_piecewise_classification_robustness_composition_slice_v1"
+)
 _REMOVED_FILTER_FIELDS = frozenset(
     {
         "threshold",
@@ -247,6 +256,156 @@ _STRESS_PROFILE_DEFINITIONS: dict[str, dict[str, Any]] = {
         },
         "runtime": {
             "fixed_layout_target_cells": 8_000_000,
+        },
+        "steering": {
+            "enabled": True,
+            "preset": _STEERING_PRESET_ANTI_MEMORIZATION_PIECEWISE_V1,
+            "stages": [],
+        },
+    },
+    _STRESS_PROFILE_ANTI_MEMORIZATION_PIECEWISE_CLASSIFICATION_CATEGORICAL_CARDINALITY_SLICE_V1: {
+        "dataset": {
+            "task": "classification",
+            "n_train": 768,
+            "n_test": 256,
+            "rows": None,
+            "n_features_min": 20,
+            "n_features_max": 72,
+            "n_classes_min": 2,
+            "n_classes_max": 12,
+            "categorical_ratio_min": 0.45,
+            "categorical_ratio_max": 1.0,
+            "max_categorical_cardinality": 64,
+        },
+        "graph": {
+            "n_nodes_min": 4,
+            "n_nodes_max": 28,
+        },
+        "filter": {
+            "enabled": False,
+            "min_target_indegree": 1,
+            "min_target_relevant_feature_count": 2,
+            "min_target_relevant_feature_fraction": 0.05,
+        },
+        "mechanism": {
+            "function_family_mix": {
+                "piecewise": 1.50,
+                "gp": 1.25,
+                "discretization": 1.25,
+                "linear": 1.0,
+                "quadratic": 1.0,
+                "tree": 1.0,
+                "nn": 0.8,
+                "em": 0.8,
+                "product": 0.8,
+            },
+        },
+        "runtime": {
+            "fixed_layout_target_cells": 6_000_000,
+        },
+        "steering": {
+            "enabled": True,
+            "preset": _STEERING_PRESET_ANTI_MEMORIZATION_PIECEWISE_V1,
+            "stages": [],
+        },
+    },
+    _STRESS_PROFILE_ANTI_MEMORIZATION_PIECEWISE_CLASSIFICATION_HYBRID_SLICE_V1: {
+        "dataset": {
+            "task": "classification",
+            "n_train": 768,
+            "n_test": 256,
+            "rows": None,
+            "n_features_min": 24,
+            "n_features_max": 72,
+            "n_classes_min": 2,
+            "n_classes_max": 12,
+            "categorical_ratio_min": 0.15,
+            "categorical_ratio_max": 0.90,
+            "max_categorical_cardinality": 16,
+        },
+        "graph": {
+            "n_nodes_min": 12,
+            "n_nodes_max": 40,
+        },
+        "filter": {
+            "enabled": False,
+            "min_target_indegree": 2,
+            "min_target_relevant_feature_count": 4,
+            "min_target_relevant_feature_fraction": 0.15,
+        },
+        "mechanism": {
+            "function_family_mix": {
+                "piecewise": 2.25,
+                "product": 2.0,
+                "gp": 1.5,
+                "tree": 1.5,
+                "nn": 1.0,
+                "discretization": 1.0,
+                "em": 0.9,
+                "quadratic": 0.9,
+                "linear": 0.7,
+            },
+        },
+        "runtime": {
+            "fixed_layout_target_cells": 6_000_000,
+        },
+        "steering": {
+            "enabled": True,
+            "preset": _STEERING_PRESET_ANTI_MEMORIZATION_PIECEWISE_V1,
+            "stages": [],
+        },
+    },
+    _STRESS_PROFILE_ANTI_MEMORIZATION_PIECEWISE_CLASSIFICATION_ROBUSTNESS_COMPOSITION_SLICE_V1: {
+        "dataset": {
+            "task": "classification",
+            "n_train": 768,
+            "n_test": 256,
+            "rows": None,
+            "n_features_min": 16,
+            "n_features_max": 64,
+            "n_classes_min": 2,
+            "n_classes_max": 10,
+            "categorical_ratio_min": 0.20,
+            "categorical_ratio_max": 0.90,
+            "max_categorical_cardinality": 24,
+            "missing_rate": 0.15,
+            "missing_mechanism": "mnar",
+            "missing_mnar_logit_scale": 2.0,
+        },
+        "graph": {
+            "n_nodes_min": 6,
+            "n_nodes_max": 32,
+        },
+        "mechanism": {
+            "function_family_mix": {
+                "piecewise": 1.75,
+                "gp": 1.5,
+                "product": 1.25,
+                "tree": 1.25,
+                "nn": 1.0,
+                "discretization": 1.0,
+                "em": 1.0,
+                "quadratic": 0.9,
+                "linear": 0.75,
+            },
+        },
+        "shift": {
+            "enabled": True,
+            "mode": "mixed",
+            "graph_scale": 0.35,
+            "variance_scale": 0.35,
+        },
+        "noise": {
+            "family": "mixture",
+            "student_t_df": 6.0,
+            "mixture_weights": {
+                "gaussian": 0.50,
+                "laplace": 0.30,
+                "student_t": 0.20,
+            },
+        },
+        "runtime": {
+            "fixed_layout_target_cells": 6_000_000,
         },
         "steering": {
             "enabled": True,

--- a/src/dagzoo/core/execution_semantics.py
+++ b/src/dagzoo/core/execution_semantics.py
@@ -123,14 +123,31 @@ _JOINT_VARIANTS: tuple[tuple[FixedLayoutConverterMethod, FixedLayoutConverterVar
 )
 _COMPOSITIONAL_STRESS_PROFILE = "anti_memorization_piecewise_classification_compositional_slice_v1"
 _GRAPH_BREADTH_STRESS_PROFILE = "anti_memorization_piecewise_classification_graph_breadth_slice_v1"
+_HYBRID_STRESS_PROFILE = "anti_memorization_piecewise_classification_hybrid_slice_v1"
+_ROBUSTNESS_COMPOSITION_STRESS_PROFILE = (
+    "anti_memorization_piecewise_classification_robustness_composition_slice_v1"
+)
+_MATRIX_KERNEL_CORRELATION_PROFILES = frozenset(
+    {
+        _COMPOSITIONAL_STRESS_PROFILE,
+        _HYBRID_STRESS_PROFILE,
+        _ROBUSTNESS_COMPOSITION_STRESS_PROFILE,
+    }
+)
+_PARENT_ARITY_SOURCE_SHAPE_CORRELATION_PROFILES = frozenset(
+    {
+        _GRAPH_BREADTH_STRESS_PROFILE,
+        _HYBRID_STRESS_PROFILE,
+    }
+)
 
 
 def _matrix_kernel_correlation_enabled(stress_profile_name: str | None) -> bool:
-    return str(stress_profile_name) == _COMPOSITIONAL_STRESS_PROFILE
+    return str(stress_profile_name) in _MATRIX_KERNEL_CORRELATION_PROFILES
 
 
 def _parent_arity_source_shape_correlation_enabled(stress_profile_name: str | None) -> bool:
-    return str(stress_profile_name) == _GRAPH_BREADTH_STRESS_PROFILE
+    return str(stress_profile_name) in _PARENT_ARITY_SOURCE_SHAPE_CORRELATION_PROFILES
 
 
 class ConverterSpecLike(Protocol):

--- a/src/dagzoo/core/fixed_layout/metadata.py
+++ b/src/dagzoo/core/fixed_layout/metadata.py
@@ -17,9 +17,12 @@ from .plan_types import (
     FixedLayoutExecutionPlan,
     execution_plan_family_counts,
     execution_plan_variant_counts,
+    fixed_layout_signature_payloads,
 )
 
 _FIXED_LAYOUT_METADATA_SCHEMA_VERSION = 11
+_PARITY_SURFACE_SCHEMA_NAME = "dagzoo_fixed_layout_parity_surface"
+_PARITY_SURFACE_SCHEMA_VERSION = 1
 
 
 @dataclass(slots=True)
@@ -130,6 +133,285 @@ def _annotate_fixed_layout_metadata(
         "sampled_variant_counts": dict(variant_counts),
         "variants_present": [label for label in sorted(variant_counts)],
         "total_function_plans": int(total_function_plans),
+    }
+    bundle.metadata["parity_surface"] = _build_parity_surface_metadata(plan)
+
+
+def _increment_count(counter: dict[str, int], label: object, count: int = 1) -> None:
+    if isinstance(label, str) and label:
+        counter[str(label)] = int(counter.get(str(label), 0)) + int(count)
+
+
+def _summarize_values(values: list[float]) -> dict[str, Any]:
+    if not values:
+        return {"count": 0, "min": None, "max": None, "mean": None, "total": 0.0}
+    total = float(sum(float(value) for value in values))
+    return {
+        "count": int(len(values)),
+        "min": float(min(values)),
+        "max": float(max(values)),
+        "mean": float(total / len(values)),
+        "total": float(total),
+    }
+
+
+def _parent_arity_label(parent_count: int) -> str:
+    if int(parent_count) >= 3:
+        return "3plus"
+    return str(int(parent_count))
+
+
+def _source_shape_policy_label(
+    *, source_kind: str, combine_kind: str | None, parent_count: int
+) -> str:
+    if source_kind == "random_points":
+        return "random_points"
+    assert combine_kind is not None
+    return f"{combine_kind}_parent{_parent_arity_label(parent_count)}"
+
+
+def _walk_matrix_payload(
+    payload: object,
+    *,
+    matrix_kind_counts: dict[str, int],
+    activation_base_kind_counts: dict[str, int],
+    kernel_gamma_values: list[float],
+    kernel_signed_counts: dict[str, int],
+) -> None:
+    if not isinstance(payload, dict):
+        return
+    kind = payload.get("kind")
+    if not isinstance(kind, str):
+        return
+    _increment_count(matrix_kind_counts, kind)
+    if kind == "activation":
+        _increment_count(activation_base_kind_counts, payload.get("base_kind"))
+        return
+    if kind == "kernel":
+        gamma = payload.get("gamma")
+        if isinstance(gamma, (int, float)) and not isinstance(gamma, bool):
+            kernel_gamma_values.append(float(gamma))
+        signed = payload.get("signed")
+        if isinstance(signed, bool):
+            _increment_count(kernel_signed_counts, "signed" if signed else "unsigned")
+
+
+def _walk_function_payload(
+    payload: object,
+    *,
+    matrix_kind_counts: dict[str, int],
+    activation_base_kind_counts: dict[str, int],
+    gp_variant_counts: dict[str, int],
+    kernel_gamma_values: list[float],
+    kernel_signed_counts: dict[str, int],
+) -> None:
+    if not isinstance(payload, dict):
+        return
+    family = payload.get("family")
+    if not isinstance(family, str):
+        return
+    if family in {"linear", "quadratic"}:
+        _walk_matrix_payload(
+            payload.get("matrix"),
+            matrix_kind_counts=matrix_kind_counts,
+            activation_base_kind_counts=activation_base_kind_counts,
+            kernel_gamma_values=kernel_gamma_values,
+            kernel_signed_counts=kernel_signed_counts,
+        )
+        return
+    if family == "nn":
+        layer_matrices = payload.get("layer_matrices")
+        if isinstance(layer_matrices, list):
+            for matrix_payload in layer_matrices:
+                _walk_matrix_payload(
+                    matrix_payload,
+                    matrix_kind_counts=matrix_kind_counts,
+                    activation_base_kind_counts=activation_base_kind_counts,
+                    kernel_gamma_values=kernel_gamma_values,
+                    kernel_signed_counts=kernel_signed_counts,
+                )
+        return
+    if family in {"discretization", "em"}:
+        _walk_matrix_payload(
+            payload.get("linear_matrix"),
+            matrix_kind_counts=matrix_kind_counts,
+            activation_base_kind_counts=activation_base_kind_counts,
+            kernel_gamma_values=kernel_gamma_values,
+            kernel_signed_counts=kernel_signed_counts,
+        )
+        return
+    if family == "gp":
+        variant = payload.get("variant")
+        if isinstance(variant, str):
+            _increment_count(gp_variant_counts, f"gp.{variant}")
+        return
+    if family == "piecewise":
+        _walk_matrix_payload(
+            payload.get("gate_matrix"),
+            matrix_kind_counts=matrix_kind_counts,
+            activation_base_kind_counts=activation_base_kind_counts,
+            kernel_gamma_values=kernel_gamma_values,
+            kernel_signed_counts=kernel_signed_counts,
+        )
+        _walk_function_payload(
+            payload.get("lhs"),
+            matrix_kind_counts=matrix_kind_counts,
+            activation_base_kind_counts=activation_base_kind_counts,
+            gp_variant_counts=gp_variant_counts,
+            kernel_gamma_values=kernel_gamma_values,
+            kernel_signed_counts=kernel_signed_counts,
+        )
+        _walk_function_payload(
+            payload.get("rhs"),
+            matrix_kind_counts=matrix_kind_counts,
+            activation_base_kind_counts=activation_base_kind_counts,
+            gp_variant_counts=gp_variant_counts,
+            kernel_gamma_values=kernel_gamma_values,
+            kernel_signed_counts=kernel_signed_counts,
+        )
+        return
+    if family == "product":
+        _walk_function_payload(
+            payload.get("lhs"),
+            matrix_kind_counts=matrix_kind_counts,
+            activation_base_kind_counts=activation_base_kind_counts,
+            gp_variant_counts=gp_variant_counts,
+            kernel_gamma_values=kernel_gamma_values,
+            kernel_signed_counts=kernel_signed_counts,
+        )
+        _walk_function_payload(
+            payload.get("rhs"),
+            matrix_kind_counts=matrix_kind_counts,
+            activation_base_kind_counts=activation_base_kind_counts,
+            gp_variant_counts=gp_variant_counts,
+            kernel_gamma_values=kernel_gamma_values,
+            kernel_signed_counts=kernel_signed_counts,
+        )
+
+
+def _build_parity_surface_metadata(plan: _FixedLayoutPlan) -> dict[str, Any]:
+    payloads = fixed_layout_signature_payloads(plan.execution_plan)
+    converter_method_counts: dict[str, int] = {}
+    converter_variant_counts: dict[str, int] = {}
+    converter_method_variant_counts: dict[str, int] = {}
+    gp_variant_counts: dict[str, int] = {}
+    kernel_signed_counts: dict[str, int] = {}
+    matrix_kind_counts: dict[str, int] = {}
+    activation_base_kind_counts: dict[str, int] = {}
+    root_base_kind_counts: dict[str, int] = {}
+    source_kind_counts: dict[str, int] = {}
+    combine_kind_counts: dict[str, int] = {}
+    aggregation_kind_counts: dict[str, int] = {}
+    parent_arity_counts: dict[str, int] = {}
+    source_shape_policy_counts: dict[str, int] = {}
+    kernel_gamma_values: list[float] = []
+    categorical_cardinality_values = [
+        float(value) for value in plan.layout.cardinalities if int(value) > 0
+    ]
+
+    for node_payload in payloads:
+        if not isinstance(node_payload, dict):
+            continue
+        source_kind = node_payload.get("source_kind")
+        if source_kind == "random_points":
+            _increment_count(source_kind_counts, "random_points")
+            _increment_count(root_base_kind_counts, node_payload.get("base_kind"))
+            _increment_count(
+                source_shape_policy_counts,
+                _source_shape_policy_label(
+                    source_kind="random_points",
+                    combine_kind=None,
+                    parent_count=0,
+                ),
+            )
+            _walk_function_payload(
+                node_payload.get("function"),
+                matrix_kind_counts=matrix_kind_counts,
+                activation_base_kind_counts=activation_base_kind_counts,
+                gp_variant_counts=gp_variant_counts,
+                kernel_gamma_values=kernel_gamma_values,
+                kernel_signed_counts=kernel_signed_counts,
+            )
+        elif source_kind == "multi":
+            parent_indices = node_payload.get("parent_indices")
+            parent_count = len(parent_indices) if isinstance(parent_indices, list) else 0
+            combine_kind = node_payload.get("combine_kind")
+            if isinstance(combine_kind, str):
+                _increment_count(source_kind_counts, combine_kind)
+                _increment_count(combine_kind_counts, combine_kind)
+                _increment_count(
+                    source_shape_policy_counts,
+                    _source_shape_policy_label(
+                        source_kind="multi",
+                        combine_kind=combine_kind,
+                        parent_count=parent_count,
+                    ),
+                )
+            _increment_count(parent_arity_counts, _parent_arity_label(parent_count))
+            if node_payload.get("combine_kind") == "stack":
+                _increment_count(aggregation_kind_counts, node_payload.get("aggregation_kind"))
+                parent_functions = node_payload.get("parent_functions")
+                if isinstance(parent_functions, list):
+                    for function_payload in parent_functions:
+                        _walk_function_payload(
+                            function_payload,
+                            matrix_kind_counts=matrix_kind_counts,
+                            activation_base_kind_counts=activation_base_kind_counts,
+                            gp_variant_counts=gp_variant_counts,
+                            kernel_gamma_values=kernel_gamma_values,
+                            kernel_signed_counts=kernel_signed_counts,
+                        )
+            else:
+                _walk_function_payload(
+                    node_payload.get("function"),
+                    matrix_kind_counts=matrix_kind_counts,
+                    activation_base_kind_counts=activation_base_kind_counts,
+                    gp_variant_counts=gp_variant_counts,
+                    kernel_gamma_values=kernel_gamma_values,
+                    kernel_signed_counts=kernel_signed_counts,
+                )
+
+        converter_plans = node_payload.get("converter_plans")
+        if not isinstance(converter_plans, list):
+            continue
+        for converter_payload in converter_plans:
+            if not isinstance(converter_payload, dict):
+                continue
+            method = converter_payload.get("method")
+            variant = converter_payload.get("variant")
+            if isinstance(method, str):
+                _increment_count(converter_method_counts, method)
+            if isinstance(variant, str):
+                _increment_count(converter_variant_counts, variant)
+            if isinstance(method, str) and isinstance(variant, str):
+                _increment_count(converter_method_variant_counts, f"{method}.{variant}")
+            _walk_function_payload(
+                converter_payload.get("function"),
+                matrix_kind_counts=matrix_kind_counts,
+                activation_base_kind_counts=activation_base_kind_counts,
+                gp_variant_counts=gp_variant_counts,
+                kernel_gamma_values=kernel_gamma_values,
+                kernel_signed_counts=kernel_signed_counts,
+            )
+
+    return {
+        "schema_name": _PARITY_SURFACE_SCHEMA_NAME,
+        "schema_version": int(_PARITY_SURFACE_SCHEMA_VERSION),
+        "converter_method_counts": dict(sorted(converter_method_counts.items())),
+        "converter_variant_counts": dict(sorted(converter_variant_counts.items())),
+        "converter_method_variant_counts": dict(sorted(converter_method_variant_counts.items())),
+        "gp_variant_counts": dict(sorted(gp_variant_counts.items())),
+        "kernel_gamma": _summarize_values(kernel_gamma_values),
+        "kernel_signed_counts": dict(sorted(kernel_signed_counts.items())),
+        "matrix_kind_counts": dict(sorted(matrix_kind_counts.items())),
+        "activation_base_kind_counts": dict(sorted(activation_base_kind_counts.items())),
+        "root_base_kind_counts": dict(sorted(root_base_kind_counts.items())),
+        "source_kind_counts": dict(sorted(source_kind_counts.items())),
+        "combine_kind_counts": dict(sorted(combine_kind_counts.items())),
+        "aggregation_kind_counts": dict(sorted(aggregation_kind_counts.items())),
+        "parent_arity_counts": dict(sorted(parent_arity_counts.items())),
+        "source_shape_policy_counts": dict(sorted(source_shape_policy_counts.items())),
+        "categorical_cardinality": _summarize_values(categorical_cardinality_values),
     }
 
 

--- a/src/dagzoo/core/layout.py
+++ b/src/dagzoo/core/layout.py
@@ -16,6 +16,7 @@ from dagzoo.rng import KeyedRng
 from dagzoo.sampling.correlated import sample_correlated_choice, sample_correlated_num
 
 _GRAPH_BREADTH_STRESS_PROFILE = "anti_memorization_piecewise_classification_graph_breadth_slice_v1"
+_HYBRID_STRESS_PROFILE = "anti_memorization_piecewise_classification_hybrid_slice_v1"
 _GRAPH_RELATIONSHIP_PROFILES: tuple[str, ...] = (
     "fanin_heavy",
     "ancestor_breadth",
@@ -88,7 +89,10 @@ def _ancestor_nodes_for_target(adjacency: torch.Tensor, *, target_to_node: int) 
 
 
 def _graph_relationship_policy_enabled(stress_profile_name: str | None) -> bool:
-    return str(stress_profile_name) == _GRAPH_BREADTH_STRESS_PROFILE
+    return str(stress_profile_name) in {
+        _GRAPH_BREADTH_STRESS_PROFILE,
+        _HYBRID_STRESS_PROFILE,
+    }
 
 
 def _sample_graph_relationship_profile(

--- a/src/dagzoo/diagnostics/coverage.py
+++ b/src/dagzoo/diagnostics/coverage.py
@@ -75,6 +75,31 @@ class _ValueAccumulator:
         self.min_value = min(self.min_value, as_float)
         self.max_value = max(self.max_value, as_float)
 
+    def merge_stats(
+        self,
+        *,
+        count: object,
+        total: object,
+        min_value: object,
+        max_value: object,
+    ) -> None:
+        count_value = _coerce_optional_int(count)
+        total_value = _coerce_optional_float(total)
+        min_stat = _coerce_optional_float(min_value)
+        max_stat = _coerce_optional_float(max_value)
+        if (
+            count_value is None
+            or count_value <= 0
+            or total_value is None
+            or min_stat is None
+            or max_stat is None
+        ):
+            return
+        self.count += int(count_value)
+        self.total += float(total_value)
+        self.min_value = min(self.min_value, float(min_stat))
+        self.max_value = max(self.max_value, float(max_stat))
+
     def finalize(self) -> dict[str, Any]:
         if self.count <= 0:
             return {"count": 0, "min": None, "max": None, "mean": None}
@@ -222,6 +247,22 @@ class CoverageAggregator:
         self._mechanism_family_dataset_presence: dict[str, int] = {}
         self._mechanism_variant_sampled_counts: dict[str, int] = {}
         self._mechanism_variant_dataset_presence: dict[str, int] = {}
+        self._parity_surface_bundles_with_metadata = 0
+        self._parity_converter_method_counts: dict[str, int] = {}
+        self._parity_converter_variant_counts: dict[str, int] = {}
+        self._parity_converter_method_variant_counts: dict[str, int] = {}
+        self._parity_gp_variant_counts: dict[str, int] = {}
+        self._parity_kernel_signed_counts: dict[str, int] = {}
+        self._parity_matrix_kind_counts: dict[str, int] = {}
+        self._parity_activation_base_kind_counts: dict[str, int] = {}
+        self._parity_root_base_kind_counts: dict[str, int] = {}
+        self._parity_source_kind_counts: dict[str, int] = {}
+        self._parity_combine_kind_counts: dict[str, int] = {}
+        self._parity_aggregation_kind_counts: dict[str, int] = {}
+        self._parity_parent_arity_counts: dict[str, int] = {}
+        self._parity_source_shape_policy_counts: dict[str, int] = {}
+        self._parity_kernel_gamma = _ValueAccumulator()
+        self._parity_categorical_cardinality = _ValueAccumulator()
         self._metrics = {
             name: _MetricAccumulator(
                 sample_limit=self._config.max_values_per_metric,
@@ -242,6 +283,7 @@ class CoverageAggregator:
         metrics = extract_dataset_metrics(bundle, include_spearman=self._config.include_spearman)
         self.update_metrics(metrics)
         self._update_mechanism_families(bundle)
+        self._update_parity_surface(bundle)
         return metrics
 
     def update_metrics(self, metrics: DatasetMetrics) -> None:
@@ -273,6 +315,7 @@ class CoverageAggregator:
             "quantiles": list(self._config.quantiles),
             "max_values_per_metric": self._config.max_values_per_metric,
             "mechanism_family_summary": self._build_mechanism_family_summary(),
+            "parity_surface_summary": self._build_parity_surface_summary(),
             "metrics": summary_metrics,
         }
 
@@ -353,6 +396,133 @@ class CoverageAggregator:
             "mean_total_function_plans": float(mean_total_function_plans),
         }
 
+    def _update_count_summary(
+        self,
+        payload: object,
+        *,
+        destination: dict[str, int],
+    ) -> None:
+        if not isinstance(payload, dict):
+            return
+        for raw_label, raw_count in payload.items():
+            if not isinstance(raw_label, str) or isinstance(raw_count, bool):
+                continue
+            if not isinstance(raw_count, (int, float)) or not math.isfinite(float(raw_count)):
+                continue
+            count = max(0, int(raw_count))
+            if count > 0:
+                destination[str(raw_label)] = int(destination.get(str(raw_label), 0)) + int(count)
+
+    def _update_parity_surface(self, bundle: DatasetBundle) -> None:
+        metadata = bundle.metadata.get("parity_surface")
+        if not isinstance(metadata, dict):
+            return
+        self._parity_surface_bundles_with_metadata += 1
+        self._update_count_summary(
+            metadata.get("converter_method_counts"),
+            destination=self._parity_converter_method_counts,
+        )
+        self._update_count_summary(
+            metadata.get("converter_variant_counts"),
+            destination=self._parity_converter_variant_counts,
+        )
+        self._update_count_summary(
+            metadata.get("converter_method_variant_counts"),
+            destination=self._parity_converter_method_variant_counts,
+        )
+        self._update_count_summary(
+            metadata.get("gp_variant_counts"),
+            destination=self._parity_gp_variant_counts,
+        )
+        self._update_count_summary(
+            metadata.get("kernel_signed_counts"),
+            destination=self._parity_kernel_signed_counts,
+        )
+        self._update_count_summary(
+            metadata.get("matrix_kind_counts"),
+            destination=self._parity_matrix_kind_counts,
+        )
+        self._update_count_summary(
+            metadata.get("activation_base_kind_counts"),
+            destination=self._parity_activation_base_kind_counts,
+        )
+        self._update_count_summary(
+            metadata.get("root_base_kind_counts"),
+            destination=self._parity_root_base_kind_counts,
+        )
+        self._update_count_summary(
+            metadata.get("source_kind_counts"),
+            destination=self._parity_source_kind_counts,
+        )
+        self._update_count_summary(
+            metadata.get("combine_kind_counts"),
+            destination=self._parity_combine_kind_counts,
+        )
+        self._update_count_summary(
+            metadata.get("aggregation_kind_counts"),
+            destination=self._parity_aggregation_kind_counts,
+        )
+        self._update_count_summary(
+            metadata.get("parent_arity_counts"),
+            destination=self._parity_parent_arity_counts,
+        )
+        self._update_count_summary(
+            metadata.get("source_shape_policy_counts"),
+            destination=self._parity_source_shape_policy_counts,
+        )
+        kernel_gamma = metadata.get("kernel_gamma")
+        if isinstance(kernel_gamma, dict):
+            self._parity_kernel_gamma.merge_stats(
+                count=kernel_gamma.get("count"),
+                total=kernel_gamma.get("total"),
+                min_value=kernel_gamma.get("min"),
+                max_value=kernel_gamma.get("max"),
+            )
+        categorical_cardinality = metadata.get("categorical_cardinality")
+        if isinstance(categorical_cardinality, dict):
+            self._parity_categorical_cardinality.merge_stats(
+                count=categorical_cardinality.get("count"),
+                total=categorical_cardinality.get("total"),
+                min_value=categorical_cardinality.get("min"),
+                max_value=categorical_cardinality.get("max"),
+            )
+
+    def _build_parity_surface_summary(self) -> dict[str, Any]:
+        bundles_with_metadata = int(self._parity_surface_bundles_with_metadata)
+        num_datasets = int(self._num_datasets)
+        metadata_denominator = num_datasets if num_datasets > 0 else 0
+        return {
+            "schema_name": "dagzoo_parity_surface_summary",
+            "schema_version": 1,
+            "metadata_coverage_rate": (
+                float(bundles_with_metadata / metadata_denominator)
+                if metadata_denominator > 0
+                else 0.0
+            ),
+            "bundles_with_metadata": bundles_with_metadata,
+            "converter_method_counts": dict(sorted(self._parity_converter_method_counts.items())),
+            "converter_variant_counts": dict(sorted(self._parity_converter_variant_counts.items())),
+            "converter_method_variant_counts": dict(
+                sorted(self._parity_converter_method_variant_counts.items())
+            ),
+            "gp_variant_counts": dict(sorted(self._parity_gp_variant_counts.items())),
+            "kernel_gamma": self._parity_kernel_gamma.finalize(),
+            "kernel_signed_counts": dict(sorted(self._parity_kernel_signed_counts.items())),
+            "matrix_kind_counts": dict(sorted(self._parity_matrix_kind_counts.items())),
+            "activation_base_kind_counts": dict(
+                sorted(self._parity_activation_base_kind_counts.items())
+            ),
+            "root_base_kind_counts": dict(sorted(self._parity_root_base_kind_counts.items())),
+            "source_kind_counts": dict(sorted(self._parity_source_kind_counts.items())),
+            "combine_kind_counts": dict(sorted(self._parity_combine_kind_counts.items())),
+            "aggregation_kind_counts": dict(sorted(self._parity_aggregation_kind_counts.items())),
+            "parent_arity_counts": dict(sorted(self._parity_parent_arity_counts.items())),
+            "source_shape_policy_counts": dict(
+                sorted(self._parity_source_shape_policy_counts.items())
+            ),
+            "categorical_cardinality": self._parity_categorical_cardinality.finalize(),
+        }
+
 
 def write_coverage_summary_json(summary: dict[str, Any], out_path: str | Path) -> Path:
     """Write run-level coverage summary JSON artifact."""
@@ -384,12 +554,20 @@ def write_coverage_summary_markdown(summary: dict[str, Any], out_path: str | Pat
         task_parts = [f"{name}={count}" for name, count in sorted(task_counts.items())]
         lines.append(f"- Task counts: `{', '.join(task_parts)}`")
     mechanism_family_summary = summary.get("mechanism_family_summary", {})
+    parity_surface_summary = summary.get("parity_surface_summary", {})
     if isinstance(mechanism_family_summary, dict):
         lines.extend(
             [
                 f"- Mechanism metadata coverage: `{_fmt(mechanism_family_summary.get('metadata_coverage_rate'))}`",
                 f"- Bundles with mechanism metadata: `{_fmt(mechanism_family_summary.get('bundles_with_metadata'), digits=0)}`",
                 f"- Mean total function plans: `{_fmt(mechanism_family_summary.get('mean_total_function_plans'))}`",
+            ]
+        )
+    if isinstance(parity_surface_summary, dict):
+        lines.extend(
+            [
+                f"- Parity-surface metadata coverage: `{_fmt(parity_surface_summary.get('metadata_coverage_rate'))}`",
+                f"- Bundles with parity-surface metadata: `{_fmt(parity_surface_summary.get('bundles_with_metadata'), digits=0)}`",
             ]
         )
     lines.extend(["", "## Metrics", ""])
@@ -444,9 +622,132 @@ def write_coverage_summary_markdown(summary: dict[str, Any], out_path: str | Pat
                     f"{_fmt((variant_presence or {}).get(label))} |"
                 )
 
+    if isinstance(parity_surface_summary, dict):
+        lines.extend(["", "## Parity Surface", ""])
+        lines.extend(
+            _parity_surface_markdown_lines(
+                "Converter methods",
+                parity_surface_summary.get("converter_method_counts"),
+            )
+        )
+        lines.extend(
+            _parity_surface_markdown_lines(
+                "Converter variants",
+                parity_surface_summary.get("converter_variant_counts"),
+            )
+        )
+        lines.extend(
+            _parity_surface_markdown_lines(
+                "Converter method+variant",
+                parity_surface_summary.get("converter_method_variant_counts"),
+            )
+        )
+        lines.extend(
+            _parity_surface_markdown_lines(
+                "GP variants",
+                parity_surface_summary.get("gp_variant_counts"),
+            )
+        )
+        lines.extend(
+            _parity_surface_markdown_lines(
+                "Kernel signed counts",
+                parity_surface_summary.get("kernel_signed_counts"),
+            )
+        )
+        lines.extend(
+            _parity_surface_markdown_lines(
+                "Matrix kinds",
+                parity_surface_summary.get("matrix_kind_counts"),
+            )
+        )
+        lines.extend(
+            _parity_surface_markdown_lines(
+                "Activation-matrix base kinds",
+                parity_surface_summary.get("activation_base_kind_counts"),
+            )
+        )
+        lines.extend(
+            _parity_surface_markdown_lines(
+                "Root base kinds",
+                parity_surface_summary.get("root_base_kind_counts"),
+            )
+        )
+        lines.extend(
+            _parity_surface_markdown_lines(
+                "Source kinds",
+                parity_surface_summary.get("source_kind_counts"),
+            )
+        )
+        lines.extend(
+            _parity_surface_markdown_lines(
+                "Combine kinds",
+                parity_surface_summary.get("combine_kind_counts"),
+            )
+        )
+        lines.extend(
+            _parity_surface_markdown_lines(
+                "Aggregation kinds",
+                parity_surface_summary.get("aggregation_kind_counts"),
+            )
+        )
+        lines.extend(
+            _parity_surface_markdown_lines(
+                "Parent arities",
+                parity_surface_summary.get("parent_arity_counts"),
+            )
+        )
+        lines.extend(
+            _parity_surface_markdown_lines(
+                "Source-shape policy",
+                parity_surface_summary.get("source_shape_policy_counts"),
+            )
+        )
+        lines.extend(
+            _parity_surface_scalar_markdown_lines(
+                "Kernel gamma",
+                parity_surface_summary.get("kernel_gamma"),
+            )
+        )
+        lines.extend(
+            _parity_surface_scalar_markdown_lines(
+                "Categorical cardinality",
+                parity_surface_summary.get("categorical_cardinality"),
+            )
+        )
+
     with path.open("w", encoding="utf-8") as f:
         f.write("\n".join(lines).rstrip() + "\n")
     return path
+
+
+def _parity_surface_markdown_lines(title: str, payload: object) -> list[str]:
+    lines = [f"### {title}", ""]
+    if not isinstance(payload, dict) or not payload:
+        lines.append("- No observed counts.")
+        lines.append("")
+        return lines
+    lines.append("| Label | Sampled Count |")
+    lines.append("|---|---:|")
+    for label in sorted(payload):
+        lines.append(f"| {label} | {_fmt(payload.get(label), digits=0)} |")
+    lines.append("")
+    return lines
+
+
+def _parity_surface_scalar_markdown_lines(title: str, payload: object) -> list[str]:
+    lines = [f"### {title}", ""]
+    if not isinstance(payload, dict) or int(_coerce_optional_int(payload.get("count")) or 0) <= 0:
+        lines.append("- No observed values.")
+        lines.append("")
+        return lines
+    lines.append(
+        "- Count / mean / range: "
+        f"`{_fmt(payload.get('count'), digits=0)}` / "
+        f"`{_fmt(payload.get('mean'))}` / "
+        f"`{_fmt(payload.get('min'))}-{_fmt(payload.get('max'))}`"
+    )
+    lines.append("")
+    return lines
 
 
 def _normalize_quantiles(quantiles: tuple[float, ...] | list[float]) -> tuple[float, ...]:

--- a/src/dagzoo/diagnostics/effective_diversity/artifacts.py
+++ b/src/dagzoo/diagnostics/effective_diversity/artifacts.py
@@ -75,6 +75,68 @@ def _mechanism_family_markdown_lines(
     return lines
 
 
+def _parity_surface_markdown_lines(
+    title: str,
+    summary: object,
+) -> list[str]:
+    if not isinstance(summary, dict):
+        return [f"### {title}", "", "- No parity-surface metadata was recorded.", ""]
+
+    lines = [
+        f"### {title}",
+        "",
+        f"- Metadata coverage: `{_fmt(summary.get('metadata_coverage_rate'))}`",
+        f"- Bundles with metadata: `{_fmt(summary.get('bundles_with_metadata'), digits=0)}`",
+        "",
+    ]
+    count_tables = (
+        ("Converter methods", summary.get("converter_method_counts")),
+        ("Converter variants", summary.get("converter_variant_counts")),
+        ("Converter method+variant", summary.get("converter_method_variant_counts")),
+        ("GP variants", summary.get("gp_variant_counts")),
+        ("Kernel signed", summary.get("kernel_signed_counts")),
+        ("Matrix kinds", summary.get("matrix_kind_counts")),
+        ("Activation base kinds", summary.get("activation_base_kind_counts")),
+        ("Root base kinds", summary.get("root_base_kind_counts")),
+        ("Source kinds", summary.get("source_kind_counts")),
+        ("Combine kinds", summary.get("combine_kind_counts")),
+        ("Aggregation kinds", summary.get("aggregation_kind_counts")),
+        ("Parent arities", summary.get("parent_arity_counts")),
+        ("Source-shape policy", summary.get("source_shape_policy_counts")),
+    )
+    for section_title, payload in count_tables:
+        lines.append(f"#### {section_title}")
+        lines.append("")
+        if not isinstance(payload, dict) or not payload:
+            lines.append("- No observed counts.")
+            lines.append("")
+            continue
+        lines.append("| Label | Sampled Count |")
+        lines.append("|---|---:|")
+        for label in sorted(payload):
+            lines.append(f"| {label} | {_fmt(payload.get(label), digits=0)} |")
+        lines.append("")
+
+    for section_title, payload in (
+        ("Kernel gamma", summary.get("kernel_gamma")),
+        ("Categorical cardinality", summary.get("categorical_cardinality")),
+    ):
+        lines.append(f"#### {section_title}")
+        lines.append("")
+        if not isinstance(payload, dict) or int(payload.get("count") or 0) <= 0:
+            lines.append("- No observed values.")
+            lines.append("")
+            continue
+        lines.append(
+            "- Count / mean / range: "
+            f"`{_fmt(payload.get('count'), digits=0)}` / "
+            f"`{_fmt(payload.get('mean'))}` / "
+            f"`{_fmt(payload.get('min'))}-{_fmt(payload.get('max'))}`"
+        )
+        lines.append("")
+    return lines
+
+
 def format_effective_diversity_markdown(report: dict[str, Any]) -> str:
     """Render a concise markdown summary for the diversity audit."""
 
@@ -152,6 +214,27 @@ def format_effective_diversity_markdown(report: dict[str, Any]) -> str:
             _mechanism_family_markdown_lines(
                 label,
                 variant.get("mechanism_family_summary"),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Parity Surface",
+            "",
+            *_parity_surface_markdown_lines(
+                "Baseline",
+                baseline.get("parity_surface_summary"),
+            ),
+        ]
+    )
+    for variant in variants if isinstance(variants, list) else []:
+        if not isinstance(variant, dict):
+            continue
+        label = str(variant.get("label", "-"))
+        lines.extend(
+            _parity_surface_markdown_lines(
+                label,
+                variant.get("parity_surface_summary"),
             )
         )
     return "\n".join(lines).rstrip() + "\n"

--- a/src/dagzoo/diagnostics/effective_diversity/runner.py
+++ b/src/dagzoo/diagnostics/effective_diversity/runner.py
@@ -25,10 +25,14 @@ def _probe_entry(result: CorpusProbeResult) -> dict[str, Any]:
     """Convert one probe dataclass into the persisted report entry shape."""
 
     mechanism_family_summary = None
+    parity_surface_summary = None
     if isinstance(result.coverage_summary, dict):
         payload = result.coverage_summary.get("mechanism_family_summary")
         if isinstance(payload, dict):
             mechanism_family_summary = payload
+        payload = result.coverage_summary.get("parity_surface_summary")
+        if isinstance(payload, dict):
+            parity_surface_summary = payload
     return {
         "label": result.label,
         "config_path": result.config_path,
@@ -47,6 +51,7 @@ def _probe_entry(result: CorpusProbeResult) -> dict[str, Any]:
         "filter_rejection_rate_dataset_level": result.filter_rejection_rate_dataset_level,
         "coverage_summary": result.coverage_summary,
         "mechanism_family_summary": mechanism_family_summary,
+        "parity_surface_summary": parity_surface_summary,
         "filter_summary": result.filter_summary,
     }
 

--- a/src/dagzoo/diagnostics/rd005_follow_on.py
+++ b/src/dagzoo/diagnostics/rd005_follow_on.py
@@ -1,0 +1,464 @@
+"""Maintainer helpers for RD-005 follow-on promotion decisions."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+PROMOTION_STATUS_PROMOTE = "promote"
+PROMOTION_STATUS_HOLD_INTERNAL = "hold_internal"
+PROMOTION_STATUS_STRUCTURAL_CONTROL_ONLY = "structural_control_only"
+
+LANE_ROLE_INCUMBENT = "incumbent"
+LANE_ROLE_CHALLENGER = "challenger"
+LANE_ROLE_STRUCTURAL_CONTROL = "structural_control"
+
+DEFAULT_THROUGHPUT_FLOOR_RATIO = 0.85
+
+
+@dataclass(frozen=True, slots=True)
+class RD005FollowOnLane:
+    """One carried internal lane in the RD-005 follow-on suite."""
+
+    label: str
+    stress_profile: str
+    role: str
+    description: str
+
+
+RD005_FOLLOW_ON_LANES: tuple[RD005FollowOnLane, ...] = (
+    RD005FollowOnLane(
+        label="compositional",
+        stress_profile="anti_memorization_piecewise_classification_compositional_slice_v1",
+        role=LANE_ROLE_INCUMBENT,
+        description="Current promotion incumbent.",
+    ),
+    RD005FollowOnLane(
+        label="graph-breadth",
+        stress_profile="anti_memorization_piecewise_classification_graph_breadth_slice_v1",
+        role=LANE_ROLE_STRUCTURAL_CONTROL,
+        description="Structural extreme control lane.",
+    ),
+    RD005FollowOnLane(
+        label="categorical-cardinality",
+        stress_profile="anti_memorization_piecewise_classification_categorical_cardinality_slice_v1",
+        role=LANE_ROLE_CHALLENGER,
+        description="Categorical/cardinality challenger lane.",
+    ),
+    RD005FollowOnLane(
+        label="hybrid",
+        stress_profile="anti_memorization_piecewise_classification_hybrid_slice_v1",
+        role=LANE_ROLE_CHALLENGER,
+        description="Hybrid structural plus compositional challenger lane.",
+    ),
+    RD005FollowOnLane(
+        label="robustness-composition",
+        stress_profile="anti_memorization_piecewise_classification_robustness_composition_slice_v1",
+        role=LANE_ROLE_CHALLENGER,
+        description="Missingness/shift/noise robustness challenger lane.",
+    ),
+)
+
+_LANE_INDEX = {lane.label: lane for lane in RD005_FOLLOW_ON_LANES}
+
+
+def _numeric_value(payload: dict[str, Any], key: str) -> float | None:
+    value = payload.get(key)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        candidate = float(value)
+        if math.isfinite(candidate):
+            return candidate
+    return None
+
+
+def _downstream_mean(entry: dict[str, Any]) -> float | None:
+    payload = entry.get("downstream")
+    if isinstance(payload, dict):
+        return _numeric_value(payload, "mean")
+    return None
+
+
+def _datasets_per_minute_value(entry: dict[str, Any]) -> float | None:
+    return _numeric_value(entry, "datasets_per_minute")
+
+
+def _structural_diversity_value(entry: dict[str, Any]) -> float | None:
+    return _numeric_value(entry, "structural_diversity_composite_shift_pct")
+
+
+def rd005_priority_sort_key(entry: dict[str, Any]) -> tuple[float, float, float]:
+    """Sort by structural diversity first, then throughput, then lower downstream mean."""
+
+    structural = _structural_diversity_value(entry) or 0.0
+    throughput = _datasets_per_minute_value(entry) or 0.0
+    downstream = _downstream_mean(entry)
+    downstream_value = float("inf") if downstream is None else float(downstream)
+    return (-float(structural), -float(throughput), downstream_value)
+
+
+def _variant_map(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    variants = payload.get("variants")
+    if not isinstance(variants, list):
+        return {}
+    mapped: dict[str, dict[str, Any]] = {}
+    for entry in variants:
+        if not isinstance(entry, dict):
+            continue
+        label = entry.get("label")
+        if isinstance(label, str) and label:
+            mapped[label] = entry
+    return mapped
+
+
+def _required_variant_entry(
+    payload: dict[str, Any], label: str, *, source_name: str
+) -> dict[str, Any]:
+    entry = _variant_map(payload).get(label)
+    if entry is None:
+        raise ValueError(f"{source_name} is missing required RD-005 lane {label!r}.")
+    return entry
+
+
+def _priority_rank(labels: object, label: str) -> int | None:
+    if not isinstance(labels, list):
+        return None
+    try:
+        return [str(item) for item in labels].index(label) + 1
+    except ValueError:
+        return None
+
+
+def _render_count_snapshot(payload: object) -> str:
+    if not isinstance(payload, dict) or not payload:
+        return "-"
+    parts: list[str] = []
+    for label in sorted(payload):
+        value = payload.get(label)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            parts.append(f"{label}={int(value)}")
+    return ", ".join(parts) if parts else "-"
+
+
+def _render_scalar_snapshot(payload: object) -> str:
+    if not isinstance(payload, dict):
+        return "-"
+    count = payload.get("count")
+    if not isinstance(count, (int, float)) or int(count) <= 0:
+        return "-"
+    mean_value = _numeric_value(payload, "mean")
+    min_value = _numeric_value(payload, "min")
+    max_value = _numeric_value(payload, "max")
+    if mean_value is None or min_value is None or max_value is None:
+        return "-"
+    return f"count={int(count)}, mean={mean_value:.3f}, range={min_value:.3f}-{max_value:.3f}"
+
+
+def build_rd005_follow_on_report(
+    *,
+    baseline_config_path: str,
+    diversity_report: dict[str, Any],
+    parity_report: dict[str, Any],
+    pareto_report: dict[str, Any],
+    throughput_floor_ratio: float = DEFAULT_THROUGHPUT_FLOOR_RATIO,
+) -> dict[str, Any]:
+    """Join diversity, parity, and Pareto evidence into one promotion decision."""
+
+    baseline = pareto_report.get("baseline")
+    pareto_summary = pareto_report.get("summary")
+    if not isinstance(baseline, dict) or not isinstance(pareto_summary, dict):
+        raise ValueError("pareto_report does not look like an RD-005 handoff Pareto report.")
+
+    incumbent_lane = next(
+        lane for lane in RD005_FOLLOW_ON_LANES if lane.role == LANE_ROLE_INCUMBENT
+    )
+    structural_control_lane = next(
+        lane for lane in RD005_FOLLOW_ON_LANES if lane.role == LANE_ROLE_STRUCTURAL_CONTROL
+    )
+
+    baseline_datasets_per_minute = _datasets_per_minute_value(baseline)
+    easy_task_ceiling = _numeric_value(pareto_summary, "easy_task_ceiling_downstream_mean")
+    if baseline_datasets_per_minute is None or easy_task_ceiling is None:
+        raise ValueError("pareto_report baseline is missing throughput or easy-task ceiling data.")
+
+    diversity_baseline = diversity_report.get("baseline")
+    parity_baseline = parity_report.get("baseline")
+    if not isinstance(diversity_baseline, dict) or not isinstance(parity_baseline, dict):
+        raise ValueError("diversity_report or parity_report is missing baseline data.")
+
+    diversity_variant_map = _variant_map(diversity_report)
+    parity_variant_map = _variant_map(parity_report)
+    pareto_variant_map = _variant_map(pareto_report)
+
+    incumbent_pareto_entry = _required_variant_entry(
+        pareto_report,
+        incumbent_lane.label,
+        source_name="pareto_report",
+    )
+    incumbent_sort_key = rd005_priority_sort_key(incumbent_pareto_entry)
+
+    lane_entries: list[dict[str, Any]] = []
+    for lane in RD005_FOLLOW_ON_LANES:
+        pareto_entry = pareto_variant_map.get(lane.label)
+        diversity_entry = diversity_variant_map.get(lane.label)
+        parity_entry = parity_variant_map.get(lane.label)
+        if pareto_entry is None or diversity_entry is None or parity_entry is None:
+            missing = []
+            if pareto_entry is None:
+                missing.append("pareto_report")
+            if diversity_entry is None:
+                missing.append("diversity_report")
+            if parity_entry is None:
+                missing.append("parity_report")
+            raise ValueError(f"RD-005 lane {lane.label!r} is missing from: {', '.join(missing)}.")
+
+        datasets_per_minute = _datasets_per_minute_value(pareto_entry)
+        downstream_mean = _downstream_mean(pareto_entry)
+        structural_shift = _structural_diversity_value(pareto_entry)
+        diversity_shift = _numeric_value(pareto_entry, "diversity_composite_shift_pct")
+        throughput_ratio = (
+            None
+            if datasets_per_minute is None or baseline_datasets_per_minute <= 0.0
+            else float(datasets_per_minute / baseline_datasets_per_minute)
+        )
+        easy_task_ceiling_pass = bool(pareto_entry.get("easy_task_ceiling_pass"))
+        beats_incumbent = None
+        if lane.role != LANE_ROLE_INCUMBENT:
+            beats_incumbent = bool(rd005_priority_sort_key(pareto_entry) < incumbent_sort_key)
+
+        failure_reasons: list[str] = []
+        if structural_shift is None or structural_shift <= 0.0:
+            failure_reasons.append("non_positive_structural_diversity_shift")
+        if throughput_ratio is None or throughput_ratio < float(throughput_floor_ratio):
+            failure_reasons.append("below_throughput_floor")
+        if not easy_task_ceiling_pass:
+            failure_reasons.append("above_easy_task_ceiling")
+        if lane.role != LANE_ROLE_INCUMBENT and not bool(beats_incumbent):
+            failure_reasons.append("does_not_beat_incumbent")
+
+        lane_entries.append(
+            {
+                "label": lane.label,
+                "role": lane.role,
+                "description": lane.description,
+                "stress_profile": lane.stress_profile,
+                "config_path": pareto_entry.get("config_path"),
+                "regime_id": pareto_entry.get("regime_id"),
+                "datasets_per_minute": datasets_per_minute,
+                "throughput_ratio_vs_baseline": throughput_ratio,
+                "downstream_mean": downstream_mean,
+                "easy_task_ceiling_pass": easy_task_ceiling_pass,
+                "diversity_status": pareto_entry.get("diversity_status"),
+                "diversity_composite_shift_pct": diversity_shift,
+                "structural_diversity_composite_shift_pct": structural_shift,
+                "structural_diversity_metric_shift_pct": pareto_entry.get(
+                    "structural_diversity_metric_shift_pct"
+                ),
+                "supporting_metrics": pareto_entry.get("supporting_metrics"),
+                "beats_incumbent": beats_incumbent,
+                "promotion_gate_pass": not failure_reasons,
+                "promotion_failure_reasons": failure_reasons,
+                "pareto_frontier_member": lane.label
+                in {
+                    str(item)
+                    for item in pareto_summary.get("pareto_frontier_labels", [])
+                    if isinstance(item, str)
+                },
+                "rd005_priority_rank": _priority_rank(
+                    pareto_summary.get("priority_variant_labels"), lane.label
+                ),
+                "parity_priority_rank": _priority_rank(
+                    parity_report.get("summary", {}).get("priority_variant_labels"),
+                    lane.label,
+                ),
+                "parity_surface_summary": parity_entry.get("parity_surface_summary")
+                or diversity_entry.get("parity_surface_summary")
+                or pareto_entry.get("parity_surface_summary")
+                or {},
+            }
+        )
+
+    eligible_lanes = [entry for entry in lane_entries if bool(entry["promotion_gate_pass"])]
+    winner = min(eligible_lanes, key=rd005_priority_sort_key) if eligible_lanes else None
+    winner_label = None if winner is None else str(winner["label"])
+
+    for entry in lane_entries:
+        if winner_label == entry["label"]:
+            entry["promotion_status"] = PROMOTION_STATUS_PROMOTE
+            entry["promotion_failure_reasons"] = []
+            continue
+        if entry["promotion_failure_reasons"]:
+            entry["promotion_status"] = (
+                PROMOTION_STATUS_STRUCTURAL_CONTROL_ONLY
+                if entry["role"] == LANE_ROLE_STRUCTURAL_CONTROL
+                else PROMOTION_STATUS_HOLD_INTERNAL
+            )
+            continue
+        entry["promotion_failure_reasons"] = ["outranked_by_winner"]
+        entry["promotion_status"] = (
+            PROMOTION_STATUS_STRUCTURAL_CONTROL_ONLY
+            if entry["role"] == LANE_ROLE_STRUCTURAL_CONTROL
+            else PROMOTION_STATUS_HOLD_INTERNAL
+        )
+
+    baseline_parity_surface = (
+        parity_baseline.get("parity_surface_summary")
+        or diversity_baseline.get("parity_surface_summary")
+        or baseline.get("parity_surface_summary")
+        or {}
+    )
+
+    return {
+        "schema_name": "dagzoo_rd005_follow_on_promotion_report",
+        "schema_version": 1,
+        "generated_at": dt.datetime.now(dt.UTC).isoformat(),
+        "baseline": {
+            "label": str(baseline.get("label", "baseline")),
+            "config_path": str(baseline.get("config_path", baseline_config_path)),
+            "datasets_per_minute": baseline_datasets_per_minute,
+            "downstream_mean": _downstream_mean(baseline),
+            "easy_task_ceiling_downstream_mean": easy_task_ceiling,
+            "parity_surface_summary": baseline_parity_surface,
+        },
+        "lanes": lane_entries,
+        "artifacts": {
+            "baseline_config_path": str(Path(baseline_config_path).resolve()),
+            "diversity_summary_json": diversity_report.get("summary", {}).get(
+                "source_summary_json"
+            ),
+            "parity_report_json": parity_report.get("summary", {}).get("source_parity_report_json"),
+            "pareto_summary_json": pareto_summary.get("source_pareto_summary_json"),
+        },
+        "summary": {
+            "promotion_decision": "promote" if winner is not None else "no_promotion",
+            "winner_label": winner_label,
+            "winner_role": None if winner is None else winner["role"],
+            "no_promotion_reason": None if winner is not None else "no_lane_cleared_gate",
+            "incumbent_label": incumbent_lane.label,
+            "structural_control_label": structural_control_lane.label,
+            "candidate_labels": [lane.label for lane in RD005_FOLLOW_ON_LANES],
+            "challenger_labels": [
+                lane.label for lane in RD005_FOLLOW_ON_LANES if lane.role == LANE_ROLE_CHALLENGER
+            ],
+            "priority_lane_labels": [
+                entry["label"] for entry in sorted(lane_entries, key=rd005_priority_sort_key)
+            ],
+            "parity_priority_labels": [
+                str(item)
+                for item in parity_report.get("summary", {}).get("priority_variant_labels", [])
+                if isinstance(item, str)
+            ],
+            "pareto_frontier_labels": [
+                str(item)
+                for item in pareto_summary.get("pareto_frontier_labels", [])
+                if isinstance(item, str)
+            ],
+            "throughput_floor_ratio": float(throughput_floor_ratio),
+            "baseline_datasets_per_minute": baseline_datasets_per_minute,
+            "easy_task_ceiling_downstream_mean": easy_task_ceiling,
+            "eligible_lane_labels": [entry["label"] for entry in eligible_lanes],
+        },
+    }
+
+
+def format_rd005_follow_on_markdown(report: dict[str, Any]) -> str:
+    """Render a concise maintainer markdown report for the promotion decision."""
+
+    summary = report.get("summary", {})
+    baseline = report.get("baseline", {})
+    lanes = report.get("lanes", [])
+    artifacts = report.get("artifacts", {})
+    lines = [
+        "# RD-005 Follow-On Promotion Summary",
+        "",
+        f"- Promotion decision: `{summary.get('promotion_decision', 'no_promotion')}`",
+        f"- Winner: `{summary.get('winner_label') or '-'}`",
+        f"- Incumbent: `{summary.get('incumbent_label', '-')}`",
+        f"- Structural control: `{summary.get('structural_control_label', '-')}`",
+        f"- Throughput floor ratio: `{float(summary.get('throughput_floor_ratio') or 0.0):.2f}`",
+        "- Easy-task ceiling downstream mean: "
+        f"`{float(summary.get('easy_task_ceiling_downstream_mean') or 0.0):.4f}`",
+        f"- Baseline config: `{artifacts.get('baseline_config_path', '-')}`",
+        f"- Diversity summary: `{artifacts.get('diversity_summary_json', '-')}`",
+        f"- Parity report: `{artifacts.get('parity_report_json', '-')}`",
+        f"- Pareto summary: `{artifacts.get('pareto_summary_json', '-')}`",
+        "",
+        "## Baseline",
+        "",
+        f"- Label: `{baseline.get('label', '-')}`",
+        f"- Datasets/minute: `{float(baseline.get('datasets_per_minute') or 0.0):.2f}`",
+        f"- Downstream mean: `{float(baseline.get('downstream_mean') or 0.0):.4f}`",
+        "",
+        "## Promotion Table",
+        "",
+        "| Lane | Role | Status | Structural Shift % | Throughput Ratio | Downstream Mean | Ceiling | Beats Incumbent | Reasons |",
+        "|---|---|---|---:|---:|---:|---|---|---|",
+    ]
+    for entry in lanes if isinstance(lanes, list) else []:
+        reasons = ", ".join(entry.get("promotion_failure_reasons", [])) or "-"
+        beats_incumbent = entry.get("beats_incumbent")
+        if beats_incumbent is None:
+            beats_text = "-"
+        else:
+            beats_text = "true" if bool(beats_incumbent) else "false"
+        lines.append(
+            "| "
+            f"{entry.get('label', '-')} | "
+            f"{entry.get('role', '-')} | "
+            f"{entry.get('promotion_status', '-')} | "
+            f"{float(entry.get('structural_diversity_composite_shift_pct') or 0.0):.2f} | "
+            f"{float(entry.get('throughput_ratio_vs_baseline') or 0.0):.2f} | "
+            f"{float(entry.get('downstream_mean') or 0.0):.4f} | "
+            f"{'pass' if bool(entry.get('easy_task_ceiling_pass')) else 'fail'} | "
+            f"{beats_text} | "
+            f"{reasons} |"
+        )
+
+    lines.extend(["", "## Priority Order", ""])
+    for label in summary.get("priority_lane_labels", []):
+        lines.append(f"- `{label}`")
+    lines.extend(["", "## Structural Frontier", ""])
+    for label in summary.get("pareto_frontier_labels", []):
+        lines.append(f"- `{label}`")
+    lines.extend(["", "## Parity Snapshots", ""])
+    for entry in lanes if isinstance(lanes, list) else []:
+        parity_surface_summary = entry.get("parity_surface_summary")
+        if not isinstance(parity_surface_summary, dict):
+            parity_surface_summary = {}
+        lines.extend(
+            [
+                f"### {entry.get('label', '-')}",
+                "",
+                f"- Converter methods: `{_render_count_snapshot(parity_surface_summary.get('converter_method_counts'))}`",
+                f"- GP variants: `{_render_count_snapshot(parity_surface_summary.get('gp_variant_counts'))}`",
+                f"- Matrix kinds: `{_render_count_snapshot(parity_surface_summary.get('matrix_kind_counts'))}`",
+                f"- Root base kinds: `{_render_count_snapshot(parity_surface_summary.get('root_base_kind_counts'))}`",
+                f"- Source-shape policy: `{_render_count_snapshot(parity_surface_summary.get('source_shape_policy_counts'))}`",
+                f"- Kernel gamma: `{_render_scalar_snapshot(parity_surface_summary.get('kernel_gamma'))}`",
+                f"- Categorical cardinality: `{_render_scalar_snapshot(parity_surface_summary.get('categorical_cardinality'))}`",
+                "",
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_rd005_follow_on_artifacts(
+    report: dict[str, Any],
+    *,
+    out_dir: str | Path,
+) -> dict[str, Path]:
+    """Persist the combined RD-005 follow-on promotion summary."""
+
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+    summary_json = out_path / "follow_on_promotion_summary.json"
+    summary_md = out_path / "follow_on_promotion_summary.md"
+    summary_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    summary_md.write_text(format_rd005_follow_on_markdown(report), encoding="utf-8")
+    return {
+        "summary_json": summary_json,
+        "summary_md": summary_md,
+    }

--- a/tests/scripts/test_evaluate_handoff_pareto.py
+++ b/tests/scripts/test_evaluate_handoff_pareto.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from conftest import load_script_module
 
 
@@ -103,6 +104,53 @@ def test_pareto_frontier_uses_structural_diversity_and_throughput() -> None:
     )
 
     assert frontier == ["baseline", "v1", "v2"]
+
+
+def test_build_variant_specs_uses_explicit_variant_labels(tmp_path: Path) -> None:
+    module = _load_module()
+    variant_path = tmp_path / "variant.yaml"
+    variant_path.write_text("dataset:\n  task: classification\n", encoding="utf-8")
+    args = module._CliArgs(
+        baseline_config="configs/default.yaml",
+        out_root=str(tmp_path / "out"),
+        variant_config=(str(variant_path),),
+        variant_label=("hybrid",),
+        stress_profile=(),
+        num_datasets=8,
+        seed=0,
+        device="cpu",
+        hardware_policy="none",
+        rows=None,
+        warn_threshold_pct=2.5,
+        fail_threshold_pct=5.0,
+        reuse_existing=False,
+    )
+
+    specs = module._build_variant_specs(args, temp_dir=tmp_path)
+
+    assert [spec.label for spec in specs] == ["baseline", "hybrid"]
+
+
+def test_build_variant_specs_rejects_mismatched_variant_labels(tmp_path: Path) -> None:
+    module = _load_module()
+    args = module._CliArgs(
+        baseline_config="configs/default.yaml",
+        out_root=str(tmp_path / "out"),
+        variant_config=(str(tmp_path / "a.yaml"),),
+        variant_label=("one", "two"),
+        stress_profile=(),
+        num_datasets=8,
+        seed=0,
+        device="cpu",
+        hardware_policy="none",
+        rows=None,
+        warn_threshold_pct=2.5,
+        fail_threshold_pct=5.0,
+        reuse_existing=False,
+    )
+
+    with pytest.raises(ValueError, match="--variant-label count must match --variant-config"):
+        module._build_variant_specs(args, temp_dir=tmp_path)
 
 
 def test_write_markdown_report_includes_structural_priority_fields(tmp_path: Path) -> None:

--- a/tests/scripts/test_evaluate_rd005_follow_on_suite.py
+++ b/tests/scripts/test_evaluate_rd005_follow_on_suite.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from conftest import load_script_module
+
+
+def _load_module():
+    return load_script_module(
+        "evaluate_rd005_follow_on_suite_script",
+        "scripts/evaluate_rd005_follow_on_suite.py",
+    )
+
+
+def _parity_surface(label: str) -> dict[str, object]:
+    converter_value = {
+        "compositional": 10,
+        "graph-breadth": 9,
+        "categorical-cardinality": 8,
+        "hybrid": 11,
+        "robustness-composition": 7,
+    }.get(label, 12)
+    return {
+        "metadata_coverage_rate": 1.0,
+        "bundles_with_metadata": 4,
+        "converter_method_counts": {"numeric": converter_value},
+        "gp_variant_counts": {f"gp.{label}": 4},
+        "matrix_kind_counts": {"dense": 4},
+        "root_base_kind_counts": {"piecewise": 4},
+        "source_shape_policy_counts": {"default": 4},
+        "kernel_gamma": {"count": 4, "min": 0.2, "max": 0.8, "mean": 0.5},
+        "categorical_cardinality": {"count": 4, "min": 4, "max": 32, "mean": 12.0},
+    }
+
+
+def _fake_diversity_report() -> dict[str, object]:
+    return {
+        "schema_name": "dagzoo_diversity_audit_report",
+        "baseline": {
+            "label": "baseline",
+            "config_path": "configs/default.yaml",
+            "datasets_per_minute": 100.0,
+            "parity_surface_summary": _parity_surface("baseline"),
+        },
+        "variants": [
+            {
+                "label": "compositional",
+                "config_path": "variant_inputs/compositional.yaml",
+                "parity_surface_summary": _parity_surface("compositional"),
+            },
+            {
+                "label": "graph-breadth",
+                "config_path": "variant_inputs/graph-breadth.yaml",
+                "parity_surface_summary": _parity_surface("graph-breadth"),
+            },
+            {
+                "label": "categorical-cardinality",
+                "config_path": "variant_inputs/categorical-cardinality.yaml",
+                "parity_surface_summary": _parity_surface("categorical-cardinality"),
+            },
+            {
+                "label": "hybrid",
+                "config_path": "variant_inputs/hybrid.yaml",
+                "parity_surface_summary": _parity_surface("hybrid"),
+            },
+            {
+                "label": "robustness-composition",
+                "config_path": "variant_inputs/robustness-composition.yaml",
+                "parity_surface_summary": _parity_surface("robustness-composition"),
+            },
+        ],
+        "comparisons": [],
+        "summary": {
+            "overall_status": "fail",
+            "warn_threshold_pct": 2.5,
+            "fail_threshold_pct": 5.0,
+            "num_variants": 5,
+            "probe_num_datasets": 8,
+            "probe_warmup_datasets": 0,
+            "status_counts": {"fail": 5},
+            "core_metrics": [],
+        },
+    }
+
+
+def _pareto_variant(
+    *,
+    label: str,
+    structural_shift: float,
+    datasets_per_minute: float,
+    downstream_mean: float,
+) -> dict[str, object]:
+    return {
+        "label": label,
+        "regime_id": f"stress:{label}",
+        "config_path": f"variant_inputs/{label}.yaml",
+        "generated_corpus_id": f"{label}-corpus",
+        "downstream": {"mean": downstream_mean, "median": downstream_mean},
+        "datasets_per_minute": datasets_per_minute,
+        "diversity_status": "fail",
+        "diversity_composite_shift_pct": structural_shift - 2.0,
+        "structural_diversity_composite_shift_pct": structural_shift,
+        "structural_diversity_metric_shift_pct": {"graph_depth_ratio": structural_shift},
+        "easy_task_ceiling_pass": True,
+        "supporting_metrics": {"graph_edge_density": 0.7},
+        "parity_surface_summary": _parity_surface(label),
+    }
+
+
+def test_evaluate_rd005_follow_on_suite_writes_combined_artifacts(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    diversity_report = _fake_diversity_report()
+
+    def _fake_run_effective_diversity_audit(**kwargs):
+        assert kwargs["variant_labels"] == [
+            "compositional",
+            "graph-breadth",
+            "categorical-cardinality",
+            "hybrid",
+            "robustness-composition",
+        ]
+        return diversity_report
+
+    class _ParityScript:
+        @staticmethod
+        def main(argv):
+            args = list(argv)
+            out_dir = Path(args[args.index("--out-dir") + 1])
+            out_dir.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "schema_name": "dagzoo_tabiclv2_parity_report",
+                "baseline": diversity_report["baseline"],
+                "variants": diversity_report["variants"],
+                "summary": {
+                    "priority_variant_labels": [
+                        "hybrid",
+                        "graph-breadth",
+                        "categorical-cardinality",
+                        "compositional",
+                        "robustness-composition",
+                    ]
+                },
+            }
+            (out_dir / "parity_report.json").write_text(
+                json.dumps(payload, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            (out_dir / "parity_report.md").write_text("# parity\n", encoding="utf-8")
+            return 0
+
+    class _ParetoScript:
+        @staticmethod
+        def main(argv):
+            args = list(argv)
+            variant_labels = [
+                args[index + 1] for index, value in enumerate(args) if value == "--variant-label"
+            ]
+            assert variant_labels == [
+                "compositional",
+                "graph-breadth",
+                "categorical-cardinality",
+                "hybrid",
+                "robustness-composition",
+            ]
+            out_dir = Path(args[args.index("--out-root") + 1])
+            out_dir.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "schema_name": "dagzoo_rd005_handoff_pareto_report",
+                "baseline": {
+                    "label": "baseline",
+                    "config_path": "configs/default.yaml",
+                    "datasets_per_minute": 100.0,
+                    "downstream": {"mean": 0.50, "median": 0.50},
+                    "parity_surface_summary": _parity_surface("baseline"),
+                },
+                "variants": [
+                    _pareto_variant(
+                        label="compositional",
+                        structural_shift=12.0,
+                        datasets_per_minute=90.0,
+                        downstream_mean=0.55,
+                    ),
+                    _pareto_variant(
+                        label="graph-breadth",
+                        structural_shift=14.0,
+                        datasets_per_minute=88.0,
+                        downstream_mean=0.56,
+                    ),
+                    _pareto_variant(
+                        label="categorical-cardinality",
+                        structural_shift=13.0,
+                        datasets_per_minute=86.0,
+                        downstream_mean=0.57,
+                    ),
+                    _pareto_variant(
+                        label="hybrid",
+                        structural_shift=16.0,
+                        datasets_per_minute=89.0,
+                        downstream_mean=0.54,
+                    ),
+                    _pareto_variant(
+                        label="robustness-composition",
+                        structural_shift=11.0,
+                        datasets_per_minute=87.0,
+                        downstream_mean=0.53,
+                    ),
+                ],
+                "summary": {
+                    "easy_task_ceiling_downstream_mean": 0.60,
+                    "priority_variant_labels": [
+                        "hybrid",
+                        "graph-breadth",
+                        "categorical-cardinality",
+                        "compositional",
+                        "robustness-composition",
+                    ],
+                    "pareto_frontier_labels": [
+                        "baseline",
+                        "hybrid",
+                        "graph-breadth",
+                    ],
+                },
+            }
+            (out_dir / "pareto_summary.json").write_text(
+                json.dumps(payload, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            (out_dir / "pareto_summary.md").write_text("# pareto\n", encoding="utf-8")
+            return 0
+
+    def _fake_load_repo_script_module(_module_name: str, rel_path: str):
+        if rel_path.endswith("render_tabiclv2_parity_report.py"):
+            return _ParityScript
+        if rel_path.endswith("evaluate_handoff_pareto.py"):
+            return _ParetoScript
+        raise AssertionError(f"Unexpected script load: {rel_path}")
+
+    monkeypatch.setattr(
+        module, "run_effective_diversity_audit", _fake_run_effective_diversity_audit
+    )
+    monkeypatch.setattr(module, "_load_repo_script_module", _fake_load_repo_script_module)
+
+    out_root = tmp_path / "rd005_follow_on"
+    exit_code = module.main(
+        [
+            "--baseline-config",
+            "configs/default.yaml",
+            "--out-root",
+            str(out_root),
+            "--num-datasets",
+            "8",
+            "--seed",
+            "123",
+            "--device",
+            "cpu",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(
+        (out_root / "follow_on_promotion_summary.json").read_text(encoding="utf-8")
+    )
+    markdown = (out_root / "follow_on_promotion_summary.md").read_text(encoding="utf-8")
+
+    assert payload["summary"]["candidate_labels"] == [
+        "compositional",
+        "graph-breadth",
+        "categorical-cardinality",
+        "hybrid",
+        "robustness-composition",
+    ]
+    assert payload["summary"]["winner_label"] == "hybrid"
+    lane_map = {entry["label"]: entry for entry in payload["lanes"]}
+    assert lane_map["hybrid"]["promotion_status"] == "promote"
+    assert lane_map["graph-breadth"]["promotion_status"] == "structural_control_only"
+    assert lane_map["compositional"]["promotion_failure_reasons"] == ["outranked_by_winner"]
+    assert lane_map["hybrid"]["parity_surface_summary"]["converter_method_counts"] == {
+        "numeric": 11
+    }
+    assert "## Promotion Table" in markdown
+    assert "## Parity Snapshots" in markdown

--- a/tests/scripts/test_render_tabiclv2_parity_report.py
+++ b/tests/scripts/test_render_tabiclv2_parity_report.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from conftest import load_script_module
+
+from dagzoo.diagnostics.effective_diversity import CORE_DIVERSITY_METRICS
+
+
+def _load_module():
+    return load_script_module(
+        "render_tabiclv2_parity_report_script",
+        "scripts/render_tabiclv2_parity_report.py",
+    )
+
+
+def _coverage_summary(*, mean: float, p25: float, p50: float, p75: float) -> dict[str, object]:
+    return {
+        "num_datasets": 4,
+        "mechanism_family_summary": {
+            "metadata_coverage_rate": 1.0,
+            "bundles_with_metadata": 4,
+            "sampled_family_counts": {"linear": 4},
+            "dataset_presence_rate_by_family": {"linear": 1.0},
+            "sampled_variant_counts": {},
+            "dataset_presence_rate_by_variant": {},
+            "mean_total_function_plans": 4.0,
+        },
+        "parity_surface_summary": {
+            "metadata_coverage_rate": 1.0,
+            "bundles_with_metadata": 4,
+            "converter_method_counts": {"numeric": 12},
+            "converter_method_variant_counts": {"numeric.standard": 12},
+            "gp_variant_counts": {"gp.standard": 4},
+            "matrix_kind_counts": {"dense": 8},
+            "root_base_kind_counts": {"piecewise": 4},
+            "source_shape_policy_counts": {"parent_arity_reuse": 4},
+            "kernel_gamma": {"count": 4, "min": 0.2, "max": 0.8, "mean": 0.5},
+            "categorical_cardinality": {"count": 4, "min": 4, "max": 16, "mean": 9.0},
+        },
+        "metrics": {
+            metric: {
+                "mean": float(mean),
+                "quantiles": {
+                    "p25": float(p25),
+                    "p50": float(p50),
+                    "p75": float(p75),
+                },
+            }
+            for metric in CORE_DIVERSITY_METRICS
+        },
+    }
+
+
+def test_render_tabiclv2_parity_report_writes_ranked_artifacts(tmp_path: Path) -> None:
+    module = _load_module()
+    baseline_summary = _coverage_summary(mean=1.0, p25=0.8, p50=1.0, p75=1.2)
+    summary_json = tmp_path / "summary.json"
+    summary_json.write_text(
+        json.dumps(
+            {
+                "schema_name": "dagzoo_diversity_audit_report",
+                "baseline": {
+                    "label": "baseline",
+                    "config_path": "configs/default.yaml",
+                    "datasets_per_minute": 100.0,
+                    "coverage_summary": baseline_summary,
+                    "parity_surface_summary": baseline_summary["parity_surface_summary"],
+                },
+                "variants": [
+                    {
+                        "label": "graph-breadth",
+                        "config_path": "configs/preset_stress_graph_breadth_benchmark_smoke.yaml",
+                        "datasets_per_minute": 82.0,
+                        "coverage_summary": _coverage_summary(mean=1.4, p25=1.2, p50=1.4, p75=1.6),
+                        "parity_surface_summary": {
+                            "metadata_coverage_rate": 1.0,
+                            "bundles_with_metadata": 4,
+                            "converter_method_counts": {"numeric": 8, "categorical": 4},
+                            "converter_method_variant_counts": {
+                                "categorical.quantile": 4,
+                                "numeric.standard": 8,
+                            },
+                            "gp_variant_counts": {"gp.multiscale": 4},
+                            "matrix_kind_counts": {"dense": 4, "triangular": 4},
+                            "root_base_kind_counts": {"piecewise": 2, "tree": 2},
+                            "source_shape_policy_counts": {"parent_arity_reuse": 4},
+                            "kernel_gamma": {"count": 4, "min": 0.1, "max": 1.2, "mean": 0.6},
+                            "categorical_cardinality": {
+                                "count": 4,
+                                "min": 8,
+                                "max": 48,
+                                "mean": 20.0,
+                            },
+                        },
+                    },
+                    {
+                        "label": "compositional",
+                        "config_path": "configs/preset_stress_compositional_benchmark_smoke.yaml",
+                        "datasets_per_minute": 92.0,
+                        "coverage_summary": _coverage_summary(mean=1.6, p25=1.3, p50=1.55, p75=1.8),
+                        "parity_surface_summary": {
+                            "metadata_coverage_rate": 1.0,
+                            "bundles_with_metadata": 4,
+                            "converter_method_counts": {"numeric": 10, "categorical": 6},
+                            "converter_method_variant_counts": {
+                                "categorical.quantile": 6,
+                                "numeric.standard": 10,
+                            },
+                            "gp_variant_counts": {"gp.periodic": 4, "gp.standard": 4},
+                            "matrix_kind_counts": {"dense": 6, "triangular": 2},
+                            "root_base_kind_counts": {"piecewise": 2, "product": 2, "tree": 2},
+                            "source_shape_policy_counts": {"default": 4},
+                            "kernel_gamma": {"count": 4, "min": 0.2, "max": 0.9, "mean": 0.55},
+                            "categorical_cardinality": {
+                                "count": 4,
+                                "min": 4,
+                                "max": 64,
+                                "mean": 24.0,
+                            },
+                        },
+                    },
+                ],
+                "comparisons": [
+                    {
+                        "variant_label": "graph-breadth",
+                        "diversity_status": "fail",
+                        "diversity_composite_shift_pct": 12.0,
+                        "datasets_per_minute_delta_pct": -18.0,
+                    },
+                    {
+                        "variant_label": "compositional",
+                        "diversity_status": "fail",
+                        "diversity_composite_shift_pct": 16.0,
+                        "datasets_per_minute_delta_pct": -8.0,
+                    },
+                ],
+                "summary": {
+                    "warn_threshold_pct": 2.5,
+                    "fail_threshold_pct": 5.0,
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    out_dir = tmp_path / "parity_report"
+    exit_code = module.main(["--summary-json", str(summary_json), "--out-dir", str(out_dir)])
+
+    assert exit_code == 0
+    payload = json.loads((out_dir / "parity_report.json").read_text(encoding="utf-8"))
+    markdown = (out_dir / "parity_report.md").read_text(encoding="utf-8")
+
+    assert payload["schema_name"] == "dagzoo_tabiclv2_parity_report"
+    assert payload["summary"]["priority_variant_labels"] == ["compositional", "graph-breadth"]
+    assert payload["variants"][0]["label"] == "compositional"
+    assert "## Priority Order" in markdown
+    assert "Converter method+variant" in markdown
+    assert "Source-shape policy" in markdown
+    assert "compositional" in markdown

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,6 +26,9 @@ _STRESS_PROFILES = (
     "anti_memorization_piecewise_classification_slice_v1",
     "anti_memorization_piecewise_classification_graph_breadth_slice_v1",
     "anti_memorization_piecewise_classification_compositional_slice_v1",
+    "anti_memorization_piecewise_classification_categorical_cardinality_slice_v1",
+    "anti_memorization_piecewise_classification_hybrid_slice_v1",
+    "anti_memorization_piecewise_classification_robustness_composition_slice_v1",
 )
 
 
@@ -654,6 +657,13 @@ def test_stress_profile_definition_exposes_relationship_slice_profiles() -> None
     compositional = stress_profile_definition(
         "anti_memorization_piecewise_classification_compositional_slice_v1"
     )
+    categorical = stress_profile_definition(
+        "anti_memorization_piecewise_classification_categorical_cardinality_slice_v1"
+    )
+    hybrid = stress_profile_definition("anti_memorization_piecewise_classification_hybrid_slice_v1")
+    robustness = stress_profile_definition(
+        "anti_memorization_piecewise_classification_robustness_composition_slice_v1"
+    )
 
     assert graph_breadth["filter"]["enabled"] is False
     assert graph_breadth["filter"]["min_target_indegree"] == 2
@@ -669,6 +679,16 @@ def test_stress_profile_definition_exposes_relationship_slice_profiles() -> None
     assert compositional["runtime"]["fixed_layout_target_cells"] == 8_000_000
     assert compositional["mechanism"]["function_family_mix"]["piecewise"] == pytest.approx(2.25)
     assert compositional["mechanism"]["function_family_mix"]["linear"] == pytest.approx(0.75)
+    assert categorical["dataset"]["categorical_ratio_min"] == pytest.approx(0.45)
+    assert categorical["dataset"]["max_categorical_cardinality"] == 64
+    assert categorical["runtime"]["fixed_layout_target_cells"] == 6_000_000
+    assert hybrid["graph"]["n_nodes_min"] == 12
+    assert hybrid["filter"]["min_target_indegree"] == 2
+    assert hybrid["mechanism"]["function_family_mix"]["product"] == pytest.approx(2.0)
+    assert robustness["dataset"]["missing_mechanism"] == "mnar"
+    assert robustness["shift"]["enabled"] is True
+    assert robustness["shift"]["mode"] == "mixed"
+    assert robustness["noise"]["family"] == "mixture"
 
 
 def test_stress_profile_definition_rejects_unknown_name() -> None:

--- a/tests/test_config_resolution.py
+++ b/tests/test_config_resolution.py
@@ -37,6 +37,13 @@ _TOTAL_ROWS_CAP_STRATEGY = st.integers(
 _STRESS_PROFILE = "anti_memorization_piecewise_classification_slice_v1"
 _GRAPH_BREADTH_STRESS_PROFILE = "anti_memorization_piecewise_classification_graph_breadth_slice_v1"
 _COMPOSITIONAL_STRESS_PROFILE = "anti_memorization_piecewise_classification_compositional_slice_v1"
+_CATEGORICAL_CARDINALITY_STRESS_PROFILE = (
+    "anti_memorization_piecewise_classification_categorical_cardinality_slice_v1"
+)
+_HYBRID_STRESS_PROFILE = "anti_memorization_piecewise_classification_hybrid_slice_v1"
+_ROBUSTNESS_COMPOSITION_STRESS_PROFILE = (
+    "anti_memorization_piecewise_classification_robustness_composition_slice_v1"
+)
 
 
 @st.composite
@@ -241,6 +248,63 @@ def test_resolve_generate_config_materializes_compositional_stress_profile() -> 
     assert mix["piecewise"] > mix["linear"]
     assert mix["product"] > mix["quadratic"]
     assert sum(float(value) for value in mix.values()) == pytest.approx(1.0)
+
+
+def test_resolve_generate_config_materializes_categorical_cardinality_stress_profile() -> None:
+    cfg = GeneratorConfig.from_dict(
+        {"stress": {"profile": _CATEGORICAL_CARDINALITY_STRESS_PROFILE}}
+    )
+
+    resolved = resolve_generate_config(
+        cfg,
+        device_override="cpu",
+        rows=None,
+        hardware_policy="none",
+        diagnostics_enabled=False,
+    )
+
+    assert resolved["config"].stress.profile is None
+    assert resolved["carried_stress_profile"] == _CATEGORICAL_CARDINALITY_STRESS_PROFILE
+    assert resolved["config"].dataset.categorical_ratio_min == pytest.approx(0.45)
+    assert resolved["config"].dataset.max_categorical_cardinality == 64
+    assert resolved["config"].runtime.fixed_layout_target_cells == 6_000_000
+
+
+def test_resolve_generate_config_materializes_hybrid_stress_profile() -> None:
+    cfg = GeneratorConfig.from_dict({"stress": {"profile": _HYBRID_STRESS_PROFILE}})
+
+    resolved = resolve_generate_config(
+        cfg,
+        device_override="cpu",
+        rows=None,
+        hardware_policy="none",
+        diagnostics_enabled=False,
+    )
+
+    assert resolved["config"].stress.profile is None
+    assert resolved["carried_stress_profile"] == _HYBRID_STRESS_PROFILE
+    assert resolved["config"].graph.n_nodes_min == 12
+    assert resolved["config"].filter.min_target_indegree == 2
+    assert resolved["config"].runtime.fixed_layout_target_cells == 6_000_000
+
+
+def test_resolve_generate_config_materializes_robustness_composition_stress_profile() -> None:
+    cfg = GeneratorConfig.from_dict({"stress": {"profile": _ROBUSTNESS_COMPOSITION_STRESS_PROFILE}})
+
+    resolved = resolve_generate_config(
+        cfg,
+        device_override="cpu",
+        rows=None,
+        hardware_policy="none",
+        diagnostics_enabled=False,
+    )
+
+    assert resolved["config"].stress.profile is None
+    assert resolved["carried_stress_profile"] == _ROBUSTNESS_COMPOSITION_STRESS_PROFILE
+    assert resolved["config"].dataset.missing_mechanism == "mnar"
+    assert resolved["config"].shift.enabled is True
+    assert resolved["config"].shift.mode == "mixed"
+    assert resolved["config"].noise.family == "mixture"
 
 
 def test_resolve_generate_config_leaves_sideband_unset_without_stress_profile() -> None:

--- a/tests/test_diagnostics_coverage.py
+++ b/tests/test_diagnostics_coverage.py
@@ -4,6 +4,7 @@ import json
 from dataclasses import replace
 
 import pytest
+import torch
 
 from dagzoo.config import DiagnosticsConfig, GeneratorConfig
 from dagzoo.diagnostics.coverage import (
@@ -108,6 +109,7 @@ def test_coverage_artifact_schema_required_keys(tmp_path) -> None:
     assert "generated_at" in payload
     assert payload["num_datasets"] == 1
     assert "metrics" in payload
+    assert "parity_surface_summary" in payload
     assert "steering" not in payload
 
     required_metric_keys = {
@@ -127,6 +129,61 @@ def test_coverage_artifact_schema_required_keys(tmp_path) -> None:
     metric = payload["metrics"]["pearson_abs_mean"]
     assert required_metric_keys.issubset(set(metric))
     assert {"num_bins", "covered_bins", "coverage_ratio", "bins"}.issubset(set(metric["histogram"]))
+
+
+def test_coverage_aggregator_summarizes_parity_surface_metadata() -> None:
+    agg = CoverageAggregator(CoverageAggregationConfig(histogram_bins=4))
+    bundle = DatasetBundle(
+        X_train=torch.zeros((4, 2), dtype=torch.float32),
+        y_train=torch.zeros(4, dtype=torch.float32),
+        X_test=torch.zeros((2, 2), dtype=torch.float32),
+        y_test=torch.zeros(2, dtype=torch.float32),
+        feature_types=["cat", "num"],
+        metadata={
+            "parity_surface": {
+                "schema_name": "dagzoo_fixed_layout_parity_surface",
+                "schema_version": 1,
+                "converter_method_counts": {"neighbor": 2},
+                "converter_variant_counts": {"input": 1},
+                "converter_method_variant_counts": {"neighbor.input": 1},
+                "gp_variant_counts": {"gp.periodic": 1},
+                "kernel_gamma": {
+                    "count": 2,
+                    "min": 0.25,
+                    "max": 1.50,
+                    "mean": 0.875,
+                    "total": 1.75,
+                },
+                "kernel_signed_counts": {"unsigned": 2},
+                "matrix_kind_counts": {"kernel": 2},
+                "activation_base_kind_counts": {"gaussian": 1},
+                "root_base_kind_counts": {"unit_ball": 1},
+                "source_kind_counts": {"stack": 1},
+                "combine_kind_counts": {"stack": 1},
+                "aggregation_kind_counts": {"sum": 1},
+                "parent_arity_counts": {"3plus": 1},
+                "source_shape_policy_counts": {"stack_parent3plus": 1},
+                "categorical_cardinality": {
+                    "count": 1,
+                    "min": 8.0,
+                    "max": 8.0,
+                    "mean": 8.0,
+                    "total": 8.0,
+                },
+            }
+        },
+    )
+
+    agg.update_bundle(bundle)
+    summary = agg.build_summary()["parity_surface_summary"]
+
+    assert summary["bundles_with_metadata"] == 1
+    assert summary["converter_method_counts"] == {"neighbor": 2}
+    assert summary["gp_variant_counts"] == {"gp.periodic": 1}
+    assert summary["matrix_kind_counts"] == {"kernel": 2}
+    assert summary["source_shape_policy_counts"] == {"stack_parent3plus": 1}
+    assert summary["kernel_gamma"]["mean"] == pytest.approx(0.875)
+    assert summary["categorical_cardinality"]["mean"] == pytest.approx(8.0)
 
 
 def test_coverage_aggregation_bounds_sample_memory() -> None:

--- a/tests/test_diversity_audit_cli.py
+++ b/tests/test_diversity_audit_cli.py
@@ -117,6 +117,25 @@ def test_diversity_audit_cli_writes_summary_artifacts_for_stress_profile_preset(
                     "dataset_presence_rate_by_variant": {},
                     "mean_total_function_plans": 2.0,
                 },
+                "parity_surface_summary": {
+                    "metadata_coverage_rate": 1.0,
+                    "bundles_with_metadata": 2,
+                    "converter_method_counts": {"numeric": 2},
+                    "converter_variant_counts": {"numeric.standard": 2},
+                    "converter_method_variant_counts": {"numeric.standard": 2},
+                    "gp_variant_counts": {"gp.standard": 2},
+                    "kernel_signed_counts": {"signed": 2},
+                    "matrix_kind_counts": {"dense": 2},
+                    "activation_base_kind_counts": {"piecewise": 2},
+                    "root_base_kind_counts": {"piecewise": 2},
+                    "source_kind_counts": {"latent": 2},
+                    "combine_kind_counts": {"concat": 2},
+                    "aggregation_kind_counts": {"sum": 2},
+                    "parent_arity_counts": {"single_parent": 2},
+                    "source_shape_policy_counts": {"default": 2},
+                    "kernel_gamma": {"count": 2, "min": 0.2, "max": 0.8, "mean": 0.5},
+                    "categorical_cardinality": {"count": 2, "min": 4, "max": 8, "mean": 6.0},
+                },
                 "metrics": {},
             },
             filter_summary=None,
@@ -147,6 +166,25 @@ def test_diversity_audit_cli_writes_summary_artifacts_for_stress_profile_preset(
                     "sampled_variant_counts": {},
                     "dataset_presence_rate_by_variant": {},
                     "mean_total_function_plans": 2.0,
+                },
+                "parity_surface_summary": {
+                    "metadata_coverage_rate": 1.0,
+                    "bundles_with_metadata": 2,
+                    "converter_method_counts": {"numeric": 1, "categorical": 1},
+                    "converter_variant_counts": {"categorical.quantile": 1},
+                    "converter_method_variant_counts": {"categorical.quantile": 1},
+                    "gp_variant_counts": {"gp.periodic": 2},
+                    "kernel_signed_counts": {"signed": 1, "unsigned": 1},
+                    "matrix_kind_counts": {"dense": 1, "triangular": 1},
+                    "activation_base_kind_counts": {"piecewise": 1, "tree": 1},
+                    "root_base_kind_counts": {"piecewise": 1, "tree": 1},
+                    "source_kind_counts": {"latent": 2},
+                    "combine_kind_counts": {"concat": 1, "stack": 1},
+                    "aggregation_kind_counts": {"sum": 1, "mean": 1},
+                    "parent_arity_counts": {"single_parent": 1, "multi_parent": 1},
+                    "source_shape_policy_counts": {"parent_arity_reuse": 2},
+                    "kernel_gamma": {"count": 2, "min": 0.1, "max": 1.0, "mean": 0.55},
+                    "categorical_cardinality": {"count": 2, "min": 8, "max": 16, "mean": 12.0},
                 },
                 "metrics": {},
             },
@@ -192,8 +230,16 @@ def test_diversity_audit_cli_writes_summary_artifacts_for_stress_profile_preset(
     assert markdown_path.exists()
 
     payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    markdown = markdown_path.read_text(encoding="utf-8")
     assert payload["baseline"]["config_path"] == "configs/default.yaml"
     assert (
         payload["variants"][0]["config_path"]
         == "configs/preset_stress_graph_breadth_benchmark_smoke.yaml"
     )
+    assert payload["baseline"]["parity_surface_summary"]["converter_method_counts"] == {
+        "numeric": 2
+    }
+    assert payload["variants"][0]["parity_surface_summary"]["source_shape_policy_counts"] == {
+        "parent_arity_reuse": 2
+    }
+    assert "## Parity Surface" in markdown

--- a/tests/test_effective_diversity_audit.py
+++ b/tests/test_effective_diversity_audit.py
@@ -336,6 +336,25 @@ def test_effective_diversity_artifact_writer(tmp_path) -> None:
                 "dataset_presence_rate_by_variant": {},
                 "mean_total_function_plans": 3.0,
             },
+            "parity_surface_summary": {
+                "metadata_coverage_rate": 1.0,
+                "bundles_with_metadata": 25,
+                "converter_method_counts": {"numeric": 25},
+                "converter_variant_counts": {"numeric.standard": 25},
+                "converter_method_variant_counts": {"numeric.standard": 25},
+                "gp_variant_counts": {"gp.standard": 25},
+                "kernel_signed_counts": {"signed": 25},
+                "matrix_kind_counts": {"dense": 25},
+                "activation_base_kind_counts": {"piecewise": 25},
+                "root_base_kind_counts": {"piecewise": 25},
+                "source_kind_counts": {"latent": 25},
+                "combine_kind_counts": {"concat": 25},
+                "aggregation_kind_counts": {"sum": 25},
+                "parent_arity_counts": {"single_parent": 25},
+                "source_shape_policy_counts": {"default": 25},
+                "kernel_gamma": {"count": 25, "min": 0.2, "max": 0.8, "mean": 0.5},
+                "categorical_cardinality": {"count": 25, "min": 4, "max": 16, "mean": 8.0},
+            },
         },
         "variants": [
             {
@@ -348,6 +367,25 @@ def test_effective_diversity_artifact_writer(tmp_path) -> None:
                     "sampled_variant_counts": {"gp.periodic": 25},
                     "dataset_presence_rate_by_variant": {"gp.periodic": 1.0},
                     "mean_total_function_plans": 6.0,
+                },
+                "parity_surface_summary": {
+                    "metadata_coverage_rate": 1.0,
+                    "bundles_with_metadata": 25,
+                    "converter_method_counts": {"categorical": 10, "numeric": 15},
+                    "converter_variant_counts": {"categorical.quantile": 10},
+                    "converter_method_variant_counts": {"categorical.quantile": 10},
+                    "gp_variant_counts": {"gp.periodic": 25},
+                    "kernel_signed_counts": {"signed": 15, "unsigned": 10},
+                    "matrix_kind_counts": {"dense": 20, "triangular": 5},
+                    "activation_base_kind_counts": {"piecewise": 15, "tree": 10},
+                    "root_base_kind_counts": {"piecewise": 15, "tree": 10},
+                    "source_kind_counts": {"latent": 25},
+                    "combine_kind_counts": {"concat": 15, "stack": 10},
+                    "aggregation_kind_counts": {"sum": 15, "mean": 10},
+                    "parent_arity_counts": {"single_parent": 18, "multi_parent": 7},
+                    "source_shape_policy_counts": {"parent_arity_reuse": 25},
+                    "kernel_gamma": {"count": 25, "min": 0.1, "max": 1.1, "mean": 0.6},
+                    "categorical_cardinality": {"count": 25, "min": 6, "max": 32, "mean": 14.0},
                 },
             }
         ],
@@ -378,7 +416,9 @@ def test_effective_diversity_artifact_writer(tmp_path) -> None:
     assert "summary.json` / `summary.md` are the canonical persisted artifacts" in markdown
     assert "Probe num datasets" in markdown
     assert "## Mechanism Families" in markdown
+    assert "## Parity Surface" in markdown
     assert "gp.periodic" in markdown
+    assert "parent_arity_reuse" in markdown
 
 
 def test_run_effective_diversity_audit_smoke_filter_disabled(tmp_path) -> None:

--- a/tests/test_execution_semantics.py
+++ b/tests/test_execution_semantics.py
@@ -66,6 +66,14 @@ class ConverterSpec:
     cardinality: int | None = None
 
 
+_GRAPH_BREADTH_STRESS_PROFILE = "anti_memorization_piecewise_classification_graph_breadth_slice_v1"
+_COMPOSITIONAL_STRESS_PROFILE = "anti_memorization_piecewise_classification_compositional_slice_v1"
+_HYBRID_STRESS_PROFILE = "anti_memorization_piecewise_classification_hybrid_slice_v1"
+_ROBUSTNESS_COMPOSITION_STRESS_PROFILE = (
+    "anti_memorization_piecewise_classification_robustness_composition_slice_v1"
+)
+
+
 @pytest.mark.parametrize(
     ("family", "plan"),
     [
@@ -290,13 +298,15 @@ def test_sample_activation_plan_can_emit_gumbel_softmax(
         ),
     ],
 )
-def test_sample_multi_source_plan_uses_parent_bucketed_semantic_names_for_graph_breadth(
+@pytest.mark.parametrize("profile", (_GRAPH_BREADTH_STRESS_PROFILE, _HYBRID_STRESS_PROFILE))
+def test_sample_multi_source_plan_uses_parent_bucketed_semantic_names_for_graph_enabled_profiles(
     parent_count: int,
     expected_combine_name: str,
     expected_combine_probs: tuple[float, float],
     expected_aggregation_name: str,
     expected_aggregation_probs: tuple[float, float, float, float],
     monkeypatch: pytest.MonkeyPatch,
+    profile: str,
 ) -> None:
     observed_calls: list[tuple[str, tuple[float, ...] | None]] = []
 
@@ -326,7 +336,7 @@ def test_sample_multi_source_plan_uses_parent_bucketed_semantic_names_for_graph_
         mechanism_logit_tilt=0.0,
         function_family_mix=None,
         device="cpu",
-        stress_profile_name="anti_memorization_piecewise_classification_graph_breadth_slice_v1",
+        stress_profile_name=profile,
     )
 
     assert isinstance(source, StackedNodeSource)
@@ -360,21 +370,23 @@ def test_sample_multi_source_plan_keeps_default_semantic_names_outside_graph_bre
         lambda *_args, **_kwargs: LinearFunctionPlan(matrix=GaussianMatrixPlan()),
     )
 
-    source = execution_semantics_mod.sample_multi_source_plan(
-        keyed_rng=KeyedRng(416),
-        parent_count=3,
-        out_dim=4,
-        mechanism_logit_tilt=0.0,
-        function_family_mix=None,
-        device="cpu",
-        stress_profile_name="anti_memorization_piecewise_classification_compositional_slice_v1",
-    )
+    for profile in (_COMPOSITIONAL_STRESS_PROFILE, _ROBUSTNESS_COMPOSITION_STRESS_PROFILE):
+        source = execution_semantics_mod.sample_multi_source_plan(
+            keyed_rng=KeyedRng(416),
+            parent_count=3,
+            out_dim=4,
+            mechanism_logit_tilt=0.0,
+            function_family_mix=None,
+            device="cpu",
+            stress_profile_name=profile,
+        )
 
-    assert isinstance(source, StackedNodeSource)
-    assert observed_calls == [
-        ("multi_source_combine_kind", None),
-        ("multi_source_aggregation_kind", None),
-    ]
+        assert isinstance(source, StackedNodeSource)
+        assert observed_calls == [
+            ("multi_source_combine_kind", None),
+            ("multi_source_aggregation_kind", None),
+        ]
+        observed_calls.clear()
 
 
 @pytest.mark.parametrize(
@@ -604,10 +616,18 @@ def test_fixed_layout_signature_payloads_include_kernel_hyperparameters_and_base
     assert payloads[1]["base_kind"] == "uniform"
 
 
-def test_compositional_stress_profile_uses_correlated_matrix_and_root_sampling(
+@pytest.mark.parametrize(
+    "profile",
+    (
+        _COMPOSITIONAL_STRESS_PROFILE,
+        _HYBRID_STRESS_PROFILE,
+        _ROBUSTNESS_COMPOSITION_STRESS_PROFILE,
+    ),
+)
+def test_compositional_style_stress_profiles_use_correlated_matrix_and_root_sampling(
     monkeypatch: pytest.MonkeyPatch,
+    profile: str,
 ) -> None:
-    compositional_profile = "anti_memorization_piecewise_classification_compositional_slice_v1"
     observed_names: list[str] = []
 
     def fake_sample_correlated_choice(*_args, **kwargs):
@@ -640,7 +660,7 @@ def test_compositional_stress_profile_uses_correlated_matrix_and_root_sampling(
     matrix_plan = execution_semantics_mod.sample_matrix_plan(
         keyed_rng=KeyedRng(901),
         device="cpu",
-        stress_profile_name=compositional_profile,
+        stress_profile_name=profile,
     )
     root_source = execution_semantics_mod.sample_root_source_plan(
         keyed_rng=KeyedRng(902),
@@ -648,7 +668,7 @@ def test_compositional_stress_profile_uses_correlated_matrix_and_root_sampling(
         mechanism_logit_tilt=0.0,
         function_family_mix=None,
         device="cpu",
-        stress_profile_name=compositional_profile,
+        stress_profile_name=profile,
     )
 
     assert isinstance(matrix_plan, KernelMatrixPlan)
@@ -982,7 +1002,7 @@ def test_keyed_graph_breadth_multi_parent_sampling_keeps_later_parents_stable(
             mechanism_logit_tilt=0.0,
             function_family_mix=None,
             device="cpu",
-            stress_profile_name="anti_memorization_piecewise_classification_graph_breadth_slice_v1",
+            stress_profile_name=_GRAPH_BREADTH_STRESS_PROFILE,
         )
 
         assert isinstance(source, StackedNodeSource)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -2492,6 +2492,25 @@ def test_generate_one_emits_realized_gp_variant_metadata() -> None:
     assert mechanism_families["variants_present"]
 
 
+def test_generate_one_emits_parity_surface_metadata() -> None:
+    cfg = _tiny_regression_config()
+    cfg.mechanism.function_family_mix = {"gp": 1.0}
+
+    bundle = generate_one(cfg, seed=18838, device="cpu")
+    parity_surface = bundle.metadata["parity_surface"]
+
+    assert parity_surface["schema_name"] == "dagzoo_fixed_layout_parity_surface"
+    assert parity_surface["schema_version"] == 1
+    assert set(parity_surface["gp_variant_counts"]).issubset(
+        {"gp.standard", "gp.periodic", "gp.multiscale"}
+    )
+    assert "matrix_kind_counts" in parity_surface
+    assert "root_base_kind_counts" in parity_surface
+    assert "source_shape_policy_counts" in parity_surface
+    assert "kernel_gamma" in parity_surface
+    assert "categorical_cardinality" in parity_surface
+
+
 def test_generate_one_noise_metadata_emits_gaussian_defaults() -> None:
     cfg = _tiny_regression_config()
     cfg.noise.family = "gaussian"

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -9,6 +9,7 @@ from dagzoo.rng import KeyedRng
 
 _GRAPH_BREADTH_STRESS_PROFILE = "anti_memorization_piecewise_classification_graph_breadth_slice_v1"
 _COMPOSITIONAL_STRESS_PROFILE = "anti_memorization_piecewise_classification_compositional_slice_v1"
+_HYBRID_STRESS_PROFILE = "anti_memorization_piecewise_classification_hybrid_slice_v1"
 
 
 def _small_layout_config():
@@ -104,7 +105,7 @@ def test_sample_layout_graph_breadth_prefers_higher_scoring_candidate(
     assert int(sampled.target_to_node) == 3
 
 
-def test_sample_layout_only_enables_relationship_profile_for_graph_breadth(
+def test_sample_layout_only_enables_relationship_profile_for_graph_enabled_profiles(
     monkeypatch,
 ) -> None:
     cfg = _small_layout_config()
@@ -137,6 +138,12 @@ def test_sample_layout_only_enables_relationship_profile_for_graph_breadth(
         KeyedRng(113).keyed("layout", "graph_breadth"),
         "cpu",
         stress_profile_name=_GRAPH_BREADTH_STRESS_PROFILE,
+    )
+    _ = layout_mod._sample_layout(
+        cfg,
+        KeyedRng(114).keyed("layout", "hybrid"),
+        "cpu",
+        stress_profile_name=_HYBRID_STRESS_PROFILE,
     )
 
     assert "graph_relationship_profile" in observed_names

--- a/tests/test_rd005_follow_on.py
+++ b/tests/test_rd005_follow_on.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+from dagzoo.diagnostics.rd005_follow_on import (
+    PROMOTION_STATUS_HOLD_INTERNAL,
+    PROMOTION_STATUS_PROMOTE,
+    PROMOTION_STATUS_STRUCTURAL_CONTROL_ONLY,
+    build_rd005_follow_on_report,
+)
+
+
+def _parity_surface(
+    *,
+    converter_numeric: int,
+    gp_variant: str = "gp.standard",
+    matrix_kind: str = "dense",
+    root_kind: str = "piecewise",
+    source_policy: str = "default",
+) -> dict[str, object]:
+    return {
+        "metadata_coverage_rate": 1.0,
+        "bundles_with_metadata": 4,
+        "converter_method_counts": {"numeric": converter_numeric},
+        "gp_variant_counts": {gp_variant: 4},
+        "matrix_kind_counts": {matrix_kind: 4},
+        "root_base_kind_counts": {root_kind: 4},
+        "source_shape_policy_counts": {source_policy: 4},
+        "kernel_gamma": {"count": 4, "min": 0.2, "max": 0.8, "mean": 0.5},
+        "categorical_cardinality": {"count": 4, "min": 4, "max": 32, "mean": 12.0},
+    }
+
+
+def _diversity_report() -> dict[str, object]:
+    return {
+        "baseline": {
+            "label": "baseline",
+            "config_path": "configs/default.yaml",
+            "datasets_per_minute": 100.0,
+            "parity_surface_summary": _parity_surface(converter_numeric=12),
+        },
+        "variants": [
+            {
+                "label": "compositional",
+                "config_path": "variant_inputs/compositional.yaml",
+                "parity_surface_summary": _parity_surface(
+                    converter_numeric=10,
+                    gp_variant="gp.periodic",
+                    matrix_kind="dense",
+                    root_kind="product",
+                ),
+            },
+            {
+                "label": "graph-breadth",
+                "config_path": "variant_inputs/graph-breadth.yaml",
+                "parity_surface_summary": _parity_surface(
+                    converter_numeric=9,
+                    gp_variant="gp.multiscale",
+                    matrix_kind="triangular",
+                    source_policy="parent_arity_reuse",
+                ),
+            },
+            {
+                "label": "categorical-cardinality",
+                "config_path": "variant_inputs/categorical-cardinality.yaml",
+                "parity_surface_summary": _parity_surface(
+                    converter_numeric=8,
+                    matrix_kind="dense",
+                    source_policy="categorical_reuse",
+                ),
+            },
+            {
+                "label": "hybrid",
+                "config_path": "variant_inputs/hybrid.yaml",
+                "parity_surface_summary": _parity_surface(
+                    converter_numeric=11,
+                    gp_variant="gp.periodic",
+                    matrix_kind="triangular",
+                    root_kind="tree",
+                    source_policy="parent_arity_reuse",
+                ),
+            },
+            {
+                "label": "robustness-composition",
+                "config_path": "variant_inputs/robustness-composition.yaml",
+                "parity_surface_summary": _parity_surface(
+                    converter_numeric=7,
+                    gp_variant="gp.standard",
+                    matrix_kind="dense",
+                    root_kind="piecewise",
+                ),
+            },
+        ],
+        "summary": {},
+    }
+
+
+def _parity_report() -> dict[str, object]:
+    payload = _diversity_report()
+    return {
+        "baseline": payload["baseline"],
+        "variants": payload["variants"],
+        "summary": {
+            "priority_variant_labels": [
+                "hybrid",
+                "graph-breadth",
+                "categorical-cardinality",
+                "compositional",
+                "robustness-composition",
+            ]
+        },
+    }
+
+
+def _pareto_variant(
+    *,
+    label: str,
+    structural_shift: float,
+    datasets_per_minute: float,
+    downstream_mean: float,
+    easy_task_ceiling_pass: bool = True,
+) -> dict[str, object]:
+    return {
+        "label": label,
+        "regime_id": f"stress:{label}",
+        "config_path": f"variant_inputs/{label}.yaml",
+        "generated_corpus_id": f"{label}-corpus",
+        "downstream": {
+            "mean": float(downstream_mean),
+            "median": float(downstream_mean),
+        },
+        "datasets_per_minute": float(datasets_per_minute),
+        "diversity_status": "fail",
+        "diversity_composite_shift_pct": float(structural_shift - 2.0),
+        "structural_diversity_composite_shift_pct": float(structural_shift),
+        "structural_diversity_metric_shift_pct": {
+            "graph_depth_ratio": float(structural_shift),
+        },
+        "easy_task_ceiling_pass": bool(easy_task_ceiling_pass),
+        "supporting_metrics": {"graph_edge_density": 0.7},
+        "parity_surface_summary": _parity_surface(converter_numeric=10),
+    }
+
+
+def _pareto_report(
+    *,
+    compositional: dict[str, object],
+    graph_breadth: dict[str, object],
+    categorical_cardinality: dict[str, object],
+    hybrid: dict[str, object],
+    robustness_composition: dict[str, object],
+) -> dict[str, object]:
+    return {
+        "baseline": {
+            "label": "baseline",
+            "config_path": "configs/default.yaml",
+            "datasets_per_minute": 100.0,
+            "downstream": {"mean": 0.50, "median": 0.50},
+            "parity_surface_summary": _parity_surface(converter_numeric=12),
+        },
+        "variants": [
+            compositional,
+            graph_breadth,
+            categorical_cardinality,
+            hybrid,
+            robustness_composition,
+        ],
+        "summary": {
+            "easy_task_ceiling_downstream_mean": 0.60,
+            "priority_variant_labels": [
+                "hybrid",
+                "graph-breadth",
+                "categorical-cardinality",
+                "compositional",
+                "robustness-composition",
+            ],
+            "pareto_frontier_labels": [
+                "baseline",
+                "hybrid",
+                "graph-breadth",
+            ],
+        },
+    }
+
+
+def test_build_rd005_follow_on_report_promotes_best_eligible_lane() -> None:
+    report = build_rd005_follow_on_report(
+        baseline_config_path="configs/default.yaml",
+        diversity_report=_diversity_report(),
+        parity_report=_parity_report(),
+        pareto_report=_pareto_report(
+            compositional=_pareto_variant(
+                label="compositional",
+                structural_shift=12.0,
+                datasets_per_minute=90.0,
+                downstream_mean=0.55,
+            ),
+            graph_breadth=_pareto_variant(
+                label="graph-breadth",
+                structural_shift=14.0,
+                datasets_per_minute=88.0,
+                downstream_mean=0.56,
+            ),
+            categorical_cardinality=_pareto_variant(
+                label="categorical-cardinality",
+                structural_shift=13.0,
+                datasets_per_minute=86.0,
+                downstream_mean=0.57,
+            ),
+            hybrid=_pareto_variant(
+                label="hybrid",
+                structural_shift=16.0,
+                datasets_per_minute=89.0,
+                downstream_mean=0.54,
+            ),
+            robustness_composition=_pareto_variant(
+                label="robustness-composition",
+                structural_shift=11.0,
+                datasets_per_minute=87.0,
+                downstream_mean=0.53,
+            ),
+        ),
+    )
+
+    lane_status = {entry["label"]: entry for entry in report["lanes"]}
+    assert report["summary"]["winner_label"] == "hybrid"
+    assert lane_status["hybrid"]["promotion_status"] == PROMOTION_STATUS_PROMOTE
+    assert lane_status["compositional"]["promotion_status"] == PROMOTION_STATUS_HOLD_INTERNAL
+    assert lane_status["compositional"]["promotion_failure_reasons"] == ["outranked_by_winner"]
+    assert (
+        lane_status["graph-breadth"]["promotion_status"] == PROMOTION_STATUS_STRUCTURAL_CONTROL_ONLY
+    )
+    assert lane_status["graph-breadth"]["promotion_failure_reasons"] == ["outranked_by_winner"]
+    assert lane_status["categorical-cardinality"]["beats_incumbent"] is True
+
+
+def test_build_rd005_follow_on_report_returns_no_promotion_when_all_lanes_fail_gate() -> None:
+    report = build_rd005_follow_on_report(
+        baseline_config_path="configs/default.yaml",
+        diversity_report=_diversity_report(),
+        parity_report=_parity_report(),
+        pareto_report=_pareto_report(
+            compositional=_pareto_variant(
+                label="compositional",
+                structural_shift=12.0,
+                datasets_per_minute=80.0,
+                downstream_mean=0.55,
+            ),
+            graph_breadth=_pareto_variant(
+                label="graph-breadth",
+                structural_shift=20.0,
+                datasets_per_minute=70.0,
+                downstream_mean=0.57,
+            ),
+            categorical_cardinality=_pareto_variant(
+                label="categorical-cardinality",
+                structural_shift=9.0,
+                datasets_per_minute=82.0,
+                downstream_mean=0.62,
+                easy_task_ceiling_pass=False,
+            ),
+            hybrid=_pareto_variant(
+                label="hybrid",
+                structural_shift=10.0,
+                datasets_per_minute=83.0,
+                downstream_mean=0.61,
+                easy_task_ceiling_pass=False,
+            ),
+            robustness_composition=_pareto_variant(
+                label="robustness-composition",
+                structural_shift=8.0,
+                datasets_per_minute=84.0,
+                downstream_mean=0.63,
+                easy_task_ceiling_pass=False,
+            ),
+        ),
+    )
+
+    lane_status = {entry["label"]: entry for entry in report["lanes"]}
+    assert report["summary"]["promotion_decision"] == "no_promotion"
+    assert report["summary"]["winner_label"] is None
+    assert lane_status["compositional"]["promotion_status"] == PROMOTION_STATUS_HOLD_INTERNAL
+    assert "below_throughput_floor" in lane_status["compositional"]["promotion_failure_reasons"]
+    assert (
+        lane_status["graph-breadth"]["promotion_status"] == PROMOTION_STATUS_STRUCTURAL_CONTROL_ONLY
+    )
+    assert "below_throughput_floor" in lane_status["graph-breadth"]["promotion_failure_reasons"]
+
+
+def test_build_rd005_follow_on_report_requires_challenger_to_beat_incumbent() -> None:
+    report = build_rd005_follow_on_report(
+        baseline_config_path="configs/default.yaml",
+        diversity_report=_diversity_report(),
+        parity_report=_parity_report(),
+        pareto_report=_pareto_report(
+            compositional=_pareto_variant(
+                label="compositional",
+                structural_shift=12.0,
+                datasets_per_minute=90.0,
+                downstream_mean=0.55,
+            ),
+            graph_breadth=_pareto_variant(
+                label="graph-breadth",
+                structural_shift=11.0,
+                datasets_per_minute=92.0,
+                downstream_mean=0.56,
+            ),
+            categorical_cardinality=_pareto_variant(
+                label="categorical-cardinality",
+                structural_shift=12.0,
+                datasets_per_minute=89.0,
+                downstream_mean=0.50,
+            ),
+            hybrid=_pareto_variant(
+                label="hybrid",
+                structural_shift=12.0,
+                datasets_per_minute=88.0,
+                downstream_mean=0.48,
+            ),
+            robustness_composition=_pareto_variant(
+                label="robustness-composition",
+                structural_shift=10.0,
+                datasets_per_minute=91.0,
+                downstream_mean=0.49,
+            ),
+        ),
+    )
+
+    lane_status = {entry["label"]: entry for entry in report["lanes"]}
+    assert report["summary"]["winner_label"] == "compositional"
+    assert lane_status["compositional"]["promotion_status"] == PROMOTION_STATUS_PROMOTE
+    assert lane_status["categorical-cardinality"]["beats_incumbent"] is False
+    assert lane_status["categorical-cardinality"]["promotion_status"] == (
+        PROMOTION_STATUS_HOLD_INTERNAL
+    )
+    assert lane_status["categorical-cardinality"]["promotion_failure_reasons"] == [
+        "does_not_beat_incumbent"
+    ]

--- a/tests/test_rd005_follow_on.py
+++ b/tests/test_rd005_follow_on.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from dagzoo.diagnostics.rd005_follow_on import (
     PROMOTION_STATUS_HOLD_INTERNAL,
     PROMOTION_STATUS_PROMOTE,
     PROMOTION_STATUS_STRUCTURAL_CONTROL_ONLY,
     build_rd005_follow_on_report,
+    write_rd005_follow_on_artifacts,
 )
 
 
@@ -334,3 +338,53 @@ def test_build_rd005_follow_on_report_requires_challenger_to_beat_incumbent() ->
     assert lane_status["categorical-cardinality"]["promotion_failure_reasons"] == [
         "does_not_beat_incumbent"
     ]
+
+
+def test_write_rd005_follow_on_artifacts_persists_summary_files(tmp_path: Path) -> None:
+    report = build_rd005_follow_on_report(
+        baseline_config_path="configs/default.yaml",
+        diversity_report=_diversity_report(),
+        parity_report=_parity_report(),
+        pareto_report=_pareto_report(
+            compositional=_pareto_variant(
+                label="compositional",
+                structural_shift=12.0,
+                datasets_per_minute=90.0,
+                downstream_mean=0.55,
+            ),
+            graph_breadth=_pareto_variant(
+                label="graph-breadth",
+                structural_shift=14.0,
+                datasets_per_minute=88.0,
+                downstream_mean=0.56,
+            ),
+            categorical_cardinality=_pareto_variant(
+                label="categorical-cardinality",
+                structural_shift=13.0,
+                datasets_per_minute=86.0,
+                downstream_mean=0.57,
+            ),
+            hybrid=_pareto_variant(
+                label="hybrid",
+                structural_shift=16.0,
+                datasets_per_minute=89.0,
+                downstream_mean=0.54,
+            ),
+            robustness_composition=_pareto_variant(
+                label="robustness-composition",
+                structural_shift=11.0,
+                datasets_per_minute=87.0,
+                downstream_mean=0.53,
+            ),
+        ),
+    )
+
+    artifact_paths = write_rd005_follow_on_artifacts(report, out_dir=tmp_path)
+
+    payload = json.loads(artifact_paths["summary_json"].read_text(encoding="utf-8"))
+    markdown = artifact_paths["summary_md"].read_text(encoding="utf-8")
+
+    assert artifact_paths["summary_json"] == tmp_path / "follow_on_promotion_summary.json"
+    assert artifact_paths["summary_md"] == tmp_path / "follow_on_promotion_summary.md"
+    assert payload["summary"]["winner_label"] == "hybrid"
+    assert "## Promotion Table" in markdown

--- a/tests/test_recipe_catalog.py
+++ b/tests/test_recipe_catalog.py
@@ -17,6 +17,13 @@ def test_recipe_catalog_entries_have_required_metadata() -> None:
     specs = iter_recipe_specs()
 
     assert len(specs) == 5
+    assert [spec.name for spec in specs] == [
+        "default-baseline",
+        "tabpfn-v1-prior-approx",
+        "high-cardinality-stress",
+        "missingness-robustness",
+        "shift-stress",
+    ]
     for spec in specs:
         assert spec.confidence_tier
         assert spec.expected_regime

--- a/tests/test_stress_profile_presets.py
+++ b/tests/test_stress_profile_presets.py
@@ -23,6 +23,21 @@ from dagzoo.config import GeneratorConfig
             "anti_memorization_piecewise_classification_compositional_slice_v1",
             "data/run_stress_compositional_smoke",
         ),
+        (
+            "configs/preset_stress_categorical_cardinality_generate_smoke.yaml",
+            "anti_memorization_piecewise_classification_categorical_cardinality_slice_v1",
+            "data/run_stress_categorical_cardinality_smoke",
+        ),
+        (
+            "configs/preset_stress_hybrid_generate_smoke.yaml",
+            "anti_memorization_piecewise_classification_hybrid_slice_v1",
+            "data/run_stress_hybrid_smoke",
+        ),
+        (
+            "configs/preset_stress_robustness_composition_generate_smoke.yaml",
+            "anti_memorization_piecewise_classification_robustness_composition_slice_v1",
+            "data/run_stress_robustness_composition_smoke",
+        ),
     ],
 )
 def test_stress_generate_presets_load_with_expected_profile(
@@ -59,6 +74,24 @@ def test_stress_generate_presets_load_with_expected_profile(
             "anti_memorization_piecewise_classification_compositional_slice_v1",
             "stress_compositional_smoke",
             "benchmarks/results/smoke_stress_compositional",
+        ),
+        (
+            "configs/preset_stress_categorical_cardinality_benchmark_smoke.yaml",
+            "anti_memorization_piecewise_classification_categorical_cardinality_slice_v1",
+            "stress_categorical_cardinality_smoke",
+            "benchmarks/results/smoke_stress_categorical_cardinality",
+        ),
+        (
+            "configs/preset_stress_hybrid_benchmark_smoke.yaml",
+            "anti_memorization_piecewise_classification_hybrid_slice_v1",
+            "stress_hybrid_smoke",
+            "benchmarks/results/smoke_stress_hybrid",
+        ),
+        (
+            "configs/preset_stress_robustness_composition_benchmark_smoke.yaml",
+            "anti_memorization_piecewise_classification_robustness_composition_slice_v1",
+            "stress_robustness_composition_smoke",
+            "benchmarks/results/smoke_stress_robustness_composition",
         ),
     ],
 )

--- a/uv.lock
+++ b/uv.lock
@@ -204,7 +204,7 @@ wheels = [
 
 [[package]]
 name = "dagzoo"
-version = "0.19.10"
+version = "0.19.11"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- add parity-surface diagnostics coverage and maintainer reporting for the remaining TabICLv2 RD-005 parity surfaces
- add the internal categorical/cardinality, hybrid, and robustness-composition stress lanes plus the full RD-005 follow-on promotion suite runner
- update maintainer docs, versioning, and changelog to reflect the internal promotion workflow without widening the public recipe surface

## Testing
- `.venv/bin/pytest tests/test_rd005_follow_on.py tests/scripts/test_evaluate_rd005_follow_on_suite.py tests/test_diversity_audit_cli.py tests/test_effective_diversity_audit.py tests/scripts/test_evaluate_handoff_pareto.py tests/scripts/test_render_tabiclv2_parity_report.py tests/test_recipe_catalog.py`
- `.venv/bin/nox -s quick`
- `.venv/bin/nox -s docs`
- `.venv/bin/nox -s full`
- `.venv/bin/nox -s bench_smoke`