### PR TITLE
[codex] emit parquet dataset catalogs from DagZoo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ contains imported legacy history, so date order is not strictly monotonic:
 `0.3.0` records the older `cauchy-generator -> dagzoo` rename, while `0.5.0`
 records the later `dagsynth -> dagzoo` rename on the current release line.
 
+## [0.19.13] - 2026-04-14
+
+### Changed
+
+- User-facing note: generated and curated public shard catalogs now emit
+  `dataset_catalog.parquet` natively, preserving the canonical per-dataset
+  payload in `record_json` while adding checksum and resolved scalar columns so
+  downstream corpus assembly can consume the catalog without NDJSON transcoding.
+- User-facing note: the published output-format and export-contract docs now
+  refer to the parquet-backed catalog surface instead of the removed
+  `dataset_catalog.ndjson` file.
+
 ## [0.19.12] - 2026-04-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ data/default_baseline/
   shard_00000/
     train.parquet
     test.parquet
-    dataset_catalog.ndjson
+    dataset_catalog.parquet
   internal/
     shard_00000/
       replay_catalog.ndjson

--- a/docs/export-contract-fields.md
+++ b/docs/export-contract-fields.md
@@ -5,9 +5,9 @@
 - Path patterns use `*` for dynamic map keys and `[]` for list item shapes.
 - `audit_status` is a field-review classification only; it does not change the live export surface.
 
-## dataset_catalog.ndjson record
+## dataset_catalog.parquet record payload
 
-One minimal per-dataset record written under each generated shard.
+Canonical per-dataset JSON payload stored in each generated shard catalog row.
 
 | Path | Type | Presence | Stability | Producer | Audit | Known Consumer / Rationale |
 | --- | --- | --- | --- | --- | --- | --- |

--- a/docs/features/diagnostics.md
+++ b/docs/features/diagnostics.md
@@ -9,7 +9,7 @@ missingness, parity-surface relationship reuse, and other realized properties.
 Use diagnostics when you want to compare recipes, confirm that a preset landed
 in the range you expected, or explain why one run behaves differently from
 another. Start with the coverage summaries, then drill into
-`dataset_catalog.ndjson` or in-process metadata when you need per-dataset
+`dataset_catalog.parquet` or in-process metadata when you need per-dataset
 detail.
 
 ______________________________________________________________________
@@ -55,7 +55,7 @@ ______________________________________________________________________
 
 ### Operational triggers
 
-- You need the stable public `dataset_catalog.ndjson` plus summary-level metric coverage.
+- You need the stable public `dataset_catalog.parquet` plus summary-level metric coverage.
 - You are validating whether presets or CLI overrides hit expected ranges.
 - You want benchmark runs to include richer context for guardrail review.
 
@@ -104,7 +104,7 @@ ______________________________________________________________________
 
 ## What to inspect
 
-- Public `dataset_catalog.ndjson` for stable per-dataset identity and emitted schema.
+- Public `dataset_catalog.parquet` for stable per-dataset identity and emitted schema.
 - In-process `DatasetBundle.metadata` when you need rich realized generation parameters.
 - Coverage summaries for meta-features, enabled observability metrics, parity-surface summaries, and steering movement when curriculum steering is enabled.
 - Benchmark summary guardrail sections that include diagnostics context.
@@ -132,7 +132,7 @@ emitting a separate artifact family. That section reports:
   emitted metadata for the generated run.
 
 This steering analysis is additive: it does not add new CLI flags and does not
-change the public per-dataset `dataset_catalog.ndjson` contract.
+change the public per-dataset `dataset_catalog.parquet` contract.
 
 ______________________________________________________________________
 

--- a/docs/features/interventions.md
+++ b/docs/features/interventions.md
@@ -95,7 +95,7 @@ ______________________________________________________________________
 - in-process `DatasetBundle.metadata` adds a top-level
   `metadata.intervention = {mode, signature}` summary for hard-interventional
   runs
-- public `dataset_catalog.ndjson` records expose only that summary object
+- public `dataset_catalog.parquet` records expose only that summary object
 - `handoff_manifest.json` aggregates one optional
   `provenance.intervention = {mode, signature}` summary per generated corpus
 - observational runs omit intervention fields from public artifacts entirely

--- a/docs/features/missingness.md
+++ b/docs/features/missingness.md
@@ -137,7 +137,7 @@ ______________________________________________________________________
   configuration and realized rates.
 - In-process `DatasetBundle.metadata["prior"]` for the latent-node target
   semantics versus the later observation-model step.
-- Public `dataset_catalog.ndjson` for the stable emitted dataset identity and
+- Public `dataset_catalog.parquet` for the stable emitted dataset identity and
   schema surface.
 - Benchmark summaries for `preset_results[*].scenarios.missingness` (when enabled).
 

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -111,7 +111,7 @@ out_dir/
   shard_00000/
     train.parquet
     test.parquet
-    dataset_catalog.ndjson
+    dataset_catalog.parquet
   shard_00001/
     ...
   internal/
@@ -148,54 +148,33 @@ Compression is `zstd` by default.
 
 ______________________________________________________________________
 
-## Dataset Catalog NDJSON
+## Dataset Catalog Parquet
 
-Each public shard writes one `dataset_catalog.ndjson` file with one JSON record
-per dataset. Current record keys are:
+Each public shard writes one `dataset_catalog.parquet` file with one row per
+dataset. The row stores the canonical semantic payload in `record_json`, plus a
+checksum and resolved scalar columns that downstream tooling can filter without
+re-parsing every record.
 
-| Key                 | Type              | Description                                             |
-| ------------------- | ----------------- | ------------------------------------------------------- |
-| `dataset_index`     | int               | Global dataset index                                    |
-| `dataset_id`        | str               | Stable dataset identifier                               |
-| `task`              | str               | `classification` or `regression`                        |
-| `n_train`           | int               | Train row count                                         |
-| `n_test`            | int               | Test row count                                          |
-| `n_features`        | int               | Emitted feature count                                   |
-| `feature_types`     | list[str]         | Per-feature type annotations                            |
-| `n_classes`         | int or null       | Realized emitted class count (`null` for regression)    |
-| `group_ids`         | object (optional) | Stable downstream grouping keys                         |
-| `intervention`      | object (optional) | Summary-only intervention regime metadata               |
-| `target_derivation` | str (optional)    | Current target-construction marker                      |
-| `target_relevance`  | object (optional) | Summary of which emitted features reach the target node |
+| Column                          | Type        | Description                                                     |
+| ------------------------------- | ----------- | --------------------------------------------------------------- |
+| `dataset_index`                 | int64       | Shard-local dataset index                                       |
+| `record_json`                   | large_string| Canonical JSON payload for the dataset catalog record           |
+| `record_sha256`                 | string      | SHA-256 of `record_json`                                        |
+| `resolved_dataset_id`           | string|null | Stable dataset identifier                                       |
+| `resolved_request_run`          | string|null | Stable request-run grouping key when available                  |
+| `resolved_task`                 | string      | `classification` or `regression`                                |
+| `resolved_n_train`              | int64       | Train row count                                                 |
+| `resolved_n_test`               | int64       | Test row count                                                  |
+| `resolved_n_features`           | int64       | Emitted feature count                                           |
+| `resolved_n_classes`            | int64|null  | Realized emitted class count (`null` for regression)            |
+| `resolved_filter_mode`          | string|null | Filter mode summary when curated/filter metadata is available   |
+| `resolved_filter_status`        | string|null | Filter status summary when curated/filter metadata is available |
+| `resolved_filter_accepted`      | bool|null   | Accepted-only decision when curated/filter metadata is available|
+| `teacher_conditionals_available`| bool        | Whether teacher conditionals were available for the dataset     |
 
-### `group_ids` sub-object
-
-Present when public grouping ids are available.
-
-| Key           | Type | Description                                                    |
-| ------------- | ---- | -------------------------------------------------------------- |
-| `request_run` | str  | Stable grouping key for one requested public run               |
-| `cohort`      | str  | Stable grouping key for heterogeneous raw-generation cohorts   |
-| `layout_plan` | str  | Stable grouping key for datasets sharing one reused execution plan |
-
-### `intervention` sub-object
-
-Present when hard-intervention metadata is available.
-Observational runs omit this field entirely.
-
-| Key         | Type | Description                             |
-| ----------- | ---- | --------------------------------------- |
-| `mode`      | str  | Emitted intervention regime             |
-| `signature` | str  | Stable summary intervention identifier  |
-
-### `target_relevance` sub-object
-
-Present when lineage target-relevance metadata is available.
-
-| Key                | Type  | Description                                                           |
-| ------------------ | ----- | --------------------------------------------------------------------- |
-| `feature_count`    | int   | Number of emitted features whose latent node reaches `target_to_node` |
-| `feature_fraction` | float | `feature_count / n_features`                                          |
+The semantic payload embedded in `record_json` carries the stable per-dataset
+fields used by downstream consumers, including `dataset_id`, `task`,
+`group_ids`, `intervention`, `target_derivation`, and `target_relevance`.
 
 ______________________________________________________________________
 
@@ -211,7 +190,7 @@ handoff_root/
     shard_00000/
       train.parquet
       test.parquet
-      dataset_catalog.ndjson
+      dataset_catalog.parquet
   internal/
     effective_config.yaml
     effective_config_trace.yaml
@@ -370,7 +349,7 @@ When diagnostics are enabled, the run root also includes:
 - `coverage_summary.md`
 
 These artifacts summarize corpus-level coverage and do not alter the public
-parquet or `dataset_catalog.ndjson` contract.
+parquet or `dataset_catalog.parquet` contract.
 
 The exhaustive field list for diagnostics summaries lives in
 [export-contract-fields.md](export-contract-fields.md).

--- a/docs/publish-hub.md
+++ b/docs/publish-hub.md
@@ -28,7 +28,7 @@ handoffs/default_baseline/
     shard_00000/
       train.parquet
       test.parquet
-      dataset_catalog.ndjson
+      dataset_catalog.parquet
   internal/
     effective_config.yaml
     effective_config_trace.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dagzoo"
-version = "0.19.12"
+version = "0.19.13"
 description = "Synthetic tabular data generator for causal modeling"
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [

--- a/reference/export_contract_inventory.yaml
+++ b/reference/export_contract_inventory.yaml
@@ -1,8 +1,8 @@
 schema: dagzoo-export-contract-inventory-v1
 artifacts:
   dataset_catalog_record:
-    label: dataset_catalog.ndjson record
-    description: One minimal per-dataset record written under each generated shard.
+    label: dataset_catalog.parquet record payload
+    description: Canonical per-dataset JSON payload stored in each generated shard catalog row.
   parquet_split_row:
     label: Packed parquet split row
     description: Row schema shared by shard train.parquet and test.parquet.

--- a/src/dagzoo/filtering/deferred_filter_artifacts.py
+++ b/src/dagzoo/filtering/deferred_filter_artifacts.py
@@ -6,14 +6,13 @@ import json
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, TextIO
+from typing import Any, TextIO, cast
 
 import numpy as np
 
 from dagzoo.core.staged_artifacts import staged_output_path as _staged_output_path
 from dagzoo.io.parquet_writer import (
     _close_packed_shard_handles,
-    _ensure_metadata_file_open,
     _PackedShardState,
     _write_packed_split,
 )
@@ -89,12 +88,6 @@ def _create_curated_shard_writer(
     )
 
 
-def _ensure_curated_metadata_file_open(state: _CuratedShardWriter) -> TextIO:
-    """Return an append-ready metadata handle for a curated shard."""
-
-    return _ensure_metadata_file_open(state.shard_state)
-
-
 def _write_curated_split(
     *,
     state: _CuratedShardWriter,
@@ -142,8 +135,7 @@ def _write_curated_dataset(
         y=test_split.y,
         compression="zstd",
     )
-    metadata_file = _ensure_curated_metadata_file_open(state)
-    _write_ndjson_record(metadata_file, record)
+    state.shard_state.catalog_records.append(cast(dict[str, Any], dict(record)))
 
 
 def _close_curated_shard_writer(state: _CuratedShardWriter | None) -> None:

--- a/src/dagzoo/io/parquet_writer.py
+++ b/src/dagzoo/io/parquet_writer.py
@@ -29,6 +29,7 @@ from dagzoo.io.shard_contract import (
     build_dataset_catalog_record,
     internal_shard_dir,
     resolve_internal_root,
+    write_dataset_catalog_records,
 )
 from dagzoo.math import sanitize_json as _sanitize_json
 from dagzoo.math import to_numpy as _to_numpy
@@ -97,7 +98,7 @@ class _PackedShardState:
     metadata_path: Path
     train_writer: Any | None = None
     test_writer: Any | None = None
-    metadata_file: TextIO | None = None
+    catalog_records: list[dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass(slots=True)
@@ -252,17 +253,6 @@ def _ensure_shard_blob_open(state: _ShardLineageState) -> BinaryIO:
     return opened
 
 
-def _ensure_metadata_file_open(state: _PackedShardState) -> TextIO:
-    """Return an append-ready catalog handle, opening it once per shard."""
-
-    metadata_file = state.metadata_file
-    if metadata_file is not None and not metadata_file.closed:
-        return metadata_file
-    opened = state.metadata_path.open("a", encoding="utf-8")
-    state.metadata_file = opened
-    return opened
-
-
 def _ensure_replay_file_open(state: _ReplayShardState) -> TextIO:
     """Return an append-ready replay sidecar handle, opening it once per shard."""
 
@@ -299,10 +289,9 @@ def _close_packed_shard_handles(state: _PackedShardState) -> None:
         test_writer.close()
         state.test_writer = None
 
-    metadata_file = state.metadata_file
-    if metadata_file is not None:
-        metadata_file.close()
-        state.metadata_file = None
+    if state.catalog_records:
+        write_dataset_catalog_records(state.metadata_path, state.catalog_records)
+        state.catalog_records = []
 
 
 def _close_replay_shard_handles(state: _ReplayShardState) -> None:
@@ -552,7 +541,6 @@ def _write_metadata_record(
 ) -> None:
     """Append one public dataset-catalog record to the shard catalog stream."""
 
-    metadata_file = _ensure_metadata_file_open(state)
     payload = build_dataset_catalog_record(
         dataset_index=dataset_index,
         n_train=n_train,
@@ -561,14 +549,7 @@ def _write_metadata_record(
         feature_types=feature_types,
         metadata=metadata,
     )
-    metadata_file.write(
-        json.dumps(
-            _sanitize_json(payload),
-            sort_keys=True,
-            allow_nan=False,
-        )
-    )
-    metadata_file.write("\n")
+    state.catalog_records.append(cast(dict[str, Any], _sanitize_json(payload)))
 
 
 def _write_replay_record(

--- a/src/dagzoo/io/shard_contract.py
+++ b/src/dagzoo/io/shard_contract.py
@@ -3,15 +3,29 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator, Mapping, Sequence
+from hashlib import sha256
 from pathlib import Path
 from typing import Any
 
-DATASET_CATALOG_FILENAME = "dataset_catalog.ndjson"
+try:
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+except Exception:  # pragma: no cover - optional dependency in some read-only contexts
+    pa = None
+    pq = None
+
+
+DATASET_CATALOG_FILENAME = "dataset_catalog.parquet"
 INTERNAL_DIRNAME = "internal"
 REPLAY_CATALOG_FILENAME = "replay_catalog.ndjson"
 RUN_CONTEXT_FILENAME = "run_context.json"
 _BLAKE2S_HEX_LENGTH = 32
+
+
+def _require_pyarrow() -> None:
+    if pa is None or pq is None:
+        raise RuntimeError("pyarrow is required for parquet-backed shard catalogs.")
 
 
 def _is_direct_shard_input(path: Path) -> bool:
@@ -138,6 +152,83 @@ def build_dataset_catalog_record(
     return record
 
 
+def _canonical_record_json(record: Mapping[str, Any]) -> str:
+    return json.dumps(dict(record), sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+def build_dataset_catalog_parquet_row(record: Mapping[str, Any]) -> dict[str, Any]:
+    record_json = _canonical_record_json(record)
+    metadata = record.get("metadata")
+    metadata_mapping = metadata if isinstance(metadata, Mapping) else None
+    filter_payload = (
+        metadata_mapping.get("filter") if isinstance(metadata_mapping, Mapping) else None
+    )
+    split_groups = record.get("group_ids")
+    request_run = split_groups.get("request_run") if isinstance(split_groups, Mapping) else None
+    teacher_conditionals = record.get("teacher_conditionals")
+    return {
+        "dataset_index": int(record["dataset_index"]),
+        "record_json": record_json,
+        "record_sha256": sha256(record_json.encode("utf-8")).hexdigest(),
+        "resolved_dataset_id": record.get("dataset_id"),
+        "resolved_request_run": request_run,
+        "resolved_task": str(
+            record.get("task") or infer_task_from_metadata(metadata_mapping or {})
+        ),
+        "resolved_n_train": int(record["n_train"]),
+        "resolved_n_test": int(record["n_test"]),
+        "resolved_n_features": int(record["n_features"]),
+        "resolved_n_classes": (
+            None if record.get("n_classes") is None else int(record["n_classes"])
+        ),
+        "resolved_filter_mode": (
+            filter_payload.get("mode") if isinstance(filter_payload, Mapping) else None
+        ),
+        "resolved_filter_status": (
+            filter_payload.get("status") if isinstance(filter_payload, Mapping) else None
+        ),
+        "resolved_filter_accepted": (
+            filter_payload.get("accepted")
+            if isinstance(filter_payload, Mapping)
+            and isinstance(filter_payload.get("accepted"), bool)
+            else None
+        ),
+        "teacher_conditionals_available": bool(
+            isinstance(teacher_conditionals, Mapping)
+            and teacher_conditionals.get("available") is True
+        ),
+    }
+
+
+def dataset_catalog_schema():
+    _require_pyarrow()
+    return pa.schema(
+        [
+            pa.field("dataset_index", pa.int64()),
+            pa.field("record_json", pa.large_string()),
+            pa.field("record_sha256", pa.string()),
+            pa.field("resolved_dataset_id", pa.string()),
+            pa.field("resolved_request_run", pa.string()),
+            pa.field("resolved_task", pa.string()),
+            pa.field("resolved_n_train", pa.int64()),
+            pa.field("resolved_n_test", pa.int64()),
+            pa.field("resolved_n_features", pa.int64()),
+            pa.field("resolved_n_classes", pa.int64()),
+            pa.field("resolved_filter_mode", pa.string()),
+            pa.field("resolved_filter_status", pa.string()),
+            pa.field("resolved_filter_accepted", pa.bool_()),
+            pa.field("teacher_conditionals_available", pa.bool_()),
+        ]
+    )
+
+
+def write_dataset_catalog_records(path: str | Path, records: Sequence[Mapping[str, Any]]) -> None:
+    _require_pyarrow()
+    rows = [build_dataset_catalog_parquet_row(record) for record in records]
+    table = pa.Table.from_pylist(rows, schema=dataset_catalog_schema())
+    pq.write_table(table, Path(path), compression="zstd")
+
+
 def resolve_internal_root(
     public_root: str | Path,
     *,
@@ -167,9 +258,31 @@ def internal_shard_dir(
 
 
 def iter_ndjson_records(path: str | Path) -> Iterator[dict[str, Any]]:
-    """Yield JSON-object NDJSON records from one file."""
+    """Yield catalog records from either parquet-backed or NDJSON-backed shard catalogs."""
 
-    with Path(path).open("r", encoding="utf-8") as handle:
+    resolved_path = Path(path)
+    if resolved_path.suffix == ".parquet":
+        try:
+            _require_pyarrow()
+            rows = pq.read_table(resolved_path, columns=["record_json"]).to_pylist()
+        except Exception:
+            rows = None
+        if rows is not None:
+            for row_number, row in enumerate(rows, start=1):
+                record_json = row.get("record_json")
+                if not isinstance(record_json, str):
+                    raise ValueError(
+                        f"Invalid parquet catalog row in {path}:{row_number}: missing record_json."
+                    )
+                payload = json.loads(record_json)
+                if not isinstance(payload, dict):
+                    raise ValueError(
+                        f"Invalid parquet catalog row in {path}:{row_number}: expected object."
+                    )
+                yield payload
+            return
+
+    with resolved_path.open("r", encoding="utf-8") as handle:
         for line_number, line in enumerate(handle, start=1):
             if not line.strip():
                 continue

--- a/src/dagzoo/publish/hub.py
+++ b/src/dagzoo/publish/hub.py
@@ -255,7 +255,7 @@ def build_hub_dataset_card(
             "",
             "## What is included",
             "",
-            "- `generated/`: public parquet shards plus per-shard `dataset_catalog.ndjson` summaries",
+            "- `generated/`: public parquet shards plus per-shard `dataset_catalog.parquet` catalogs",
             "- `curated/`: optional accepted-only shards written later by `dagzoo filter`",
             "- `handoff_manifest.json`: portable corpus identity and provenance metadata",
             "",

--- a/tests/test_contract_goldens.py
+++ b/tests/test_contract_goldens.py
@@ -25,7 +25,11 @@ from dagzoo.diagnostics.coverage import (
 )
 from dagzoo.diagnostics.types import DatasetMetrics
 from dagzoo.io.parquet_writer import write_packed_parquet_shards_stream
-from dagzoo.io.shard_contract import DATASET_CATALOG_FILENAME
+from dagzoo.io.shard_contract import (
+    DATASET_CATALOG_FILENAME,
+    iter_ndjson_records,
+    write_dataset_catalog_records,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -155,65 +159,56 @@ def _write_generated_metadata(run_root: Path) -> None:
     generated_dir = run_root / "generated"
     shard_dir = generated_dir / "shard_00000"
     shard_dir.mkdir(parents=True, exist_ok=True)
-    (shard_dir / DATASET_CATALOG_FILENAME).write_text(
-        "\n".join(
-            [
-                json.dumps(
-                    {
-                        "dataset_index": 0,
-                        "dataset_id": "2" * 32,
-                        "task": "classification",
-                        "n_train": 16,
-                        "n_test": 8,
-                        "n_features": 8,
-                        "feature_types": ["num"] * 8,
-                        "n_classes": 3,
-                        "group_ids": {
-                            "request_run": "1" * 32,
-                            "layout_plan": "4" * 32,
-                        },
-                        "intervention": {
-                            "mode": "hard_interventional",
-                            "signature": "a" * 32,
-                        },
-                        "target_derivation": "tabiclv2_latent_node",
-                        "target_relevance": {
-                            "feature_count": 5,
-                            "feature_fraction": 0.625,
-                        },
-                    },
-                    sort_keys=True,
-                ),
-                json.dumps(
-                    {
-                        "dataset_index": 1,
-                        "dataset_id": "3" * 32,
-                        "task": "classification",
-                        "n_train": 16,
-                        "n_test": 8,
-                        "n_features": 8,
-                        "feature_types": ["num"] * 8,
-                        "n_classes": 3,
-                        "group_ids": {
-                            "request_run": "1" * 32,
-                            "layout_plan": "4" * 32,
-                        },
-                        "intervention": {
-                            "mode": "hard_interventional",
-                            "signature": "a" * 32,
-                        },
-                        "target_derivation": "tabiclv2_latent_node",
-                        "target_relevance": {
-                            "feature_count": 6,
-                            "feature_fraction": 0.75,
-                        },
-                    },
-                    sort_keys=True,
-                ),
-            ]
-        )
-        + "\n",
-        encoding="utf-8",
+    write_dataset_catalog_records(
+        shard_dir / DATASET_CATALOG_FILENAME,
+        [
+            {
+                "dataset_index": 0,
+                "dataset_id": "2" * 32,
+                "task": "classification",
+                "n_train": 16,
+                "n_test": 8,
+                "n_features": 8,
+                "feature_types": ["num"] * 8,
+                "n_classes": 3,
+                "group_ids": {
+                    "request_run": "1" * 32,
+                    "layout_plan": "4" * 32,
+                },
+                "intervention": {
+                    "mode": "hard_interventional",
+                    "signature": "a" * 32,
+                },
+                "target_derivation": "tabiclv2_latent_node",
+                "target_relevance": {
+                    "feature_count": 5,
+                    "feature_fraction": 0.625,
+                },
+            },
+            {
+                "dataset_index": 1,
+                "dataset_id": "3" * 32,
+                "task": "classification",
+                "n_train": 16,
+                "n_test": 8,
+                "n_features": 8,
+                "feature_types": ["num"] * 8,
+                "n_classes": 3,
+                "group_ids": {
+                    "request_run": "1" * 32,
+                    "layout_plan": "4" * 32,
+                },
+                "intervention": {
+                    "mode": "hard_interventional",
+                    "signature": "a" * 32,
+                },
+                "target_derivation": "tabiclv2_latent_node",
+                "target_relevance": {
+                    "feature_count": 6,
+                    "feature_fraction": 0.75,
+                },
+            },
+        ],
     )
 
 
@@ -380,9 +375,7 @@ def test_generated_metadata_record_paths_contract_golden(tmp_path: Path) -> None
 
     batch = generate_batch(cfg, num_datasets=1, seed=123, device="cpu")
     write_packed_parquet_shards_stream(batch, tmp_path, shard_size=8, compression="zstd")
-    record = json.loads(
-        (tmp_path / "shard_00000" / DATASET_CATALOG_FILENAME).read_text().splitlines()[0]
-    )
+    record = next(iter_ndjson_records(tmp_path / "shard_00000" / DATASET_CATALOG_FILENAME))
 
     actual_paths = sorted({_format_tokens(tokens) for tokens in _flatten_path_tokens(record)})
 
@@ -397,9 +390,9 @@ def test_public_docs_do_not_reference_removed_target_head_contract() -> None:
         "conditional target head": r"conditional target head",
         "latent_complete_x_conditional": r"latent_complete_x_conditional",
         "posterior_predictive": r"posterior_predictive",
-        "teacher_conditionals": r"teacher_conditionals",
         "teacher-conditional": r"teacher-conditional",
         "metadata.ndjson": r"metadata\.ndjson",
+        "dataset_catalog.ndjson": r"dataset_catalog\.ndjson",
         "tab-foundry": r"tab-foundry",
     }
 

--- a/tests/test_deferred_filter.py
+++ b/tests/test_deferred_filter.py
@@ -16,7 +16,12 @@ from dagzoo.io.lineage_schema import (
     LINEAGE_SCHEMA_VERSION_DENSE,
 )
 from dagzoo.io.parquet_writer import write_packed_parquet_shards_stream
-from dagzoo.io.shard_contract import DATASET_CATALOG_FILENAME, REPLAY_CATALOG_FILENAME
+from dagzoo.io.shard_contract import (
+    DATASET_CATALOG_FILENAME,
+    REPLAY_CATALOG_FILENAME,
+    iter_ndjson_records,
+    write_dataset_catalog_records,
+)
 from dagzoo.types import DatasetBundle
 
 
@@ -80,14 +85,13 @@ def _bundle_without_config(seed: int) -> DatasetBundle:
 
 
 def _load_ndjson(path) -> list[dict[str, object]]:
-    payload: list[dict[str, object]] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        if line.strip():
-            payload.append(json.loads(line))
-    return payload
+    return [dict(record) for record in iter_ndjson_records(path)]
 
 
 def _write_ndjson_records(path, records: list[dict[str, object]]) -> None:
+    if Path(path).suffix == ".parquet":
+        write_dataset_catalog_records(path, records)
+        return
     path.write_text(
         "".join(json.dumps(record, sort_keys=True) + "\n" for record in records),
         encoding="utf-8",

--- a/tests/test_export_contract_inventory.py
+++ b/tests/test_export_contract_inventory.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -15,7 +14,7 @@ from dagzoo.core.dataset import generate_batch
 from dagzoo.core.generate_handoff import build_generate_handoff_manifest
 from dagzoo.diagnostics.coverage import CoverageAggregationConfig, CoverageAggregator
 from dagzoo.io.parquet_writer import write_packed_parquet_shards_stream
-from dagzoo.io.shard_contract import DATASET_CATALOG_FILENAME
+from dagzoo.io.shard_contract import DATASET_CATALOG_FILENAME, iter_ndjson_records
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 INVENTORY_PATH = REPO_ROOT / "reference" / "export_contract_inventory.yaml"
@@ -208,8 +207,8 @@ def _contract_sample_artifacts(tmp_path: Path) -> dict[str, Any]:
     effective_config_path.write_text("seed: 123\n", encoding="utf-8")
     effective_trace_path.write_text("- source: unit-test\n", encoding="utf-8")
 
-    catalog_record = json.loads(
-        (generated_dir / "shard_00000" / DATASET_CATALOG_FILENAME).read_text().splitlines()[0]
+    catalog_record = next(
+        iter_ndjson_records(generated_dir / "shard_00000" / DATASET_CATALOG_FILENAME)
     )
     train_row = (
         pyarrow_parquet.read_table(generated_dir / "shard_00000" / "train.parquet")

--- a/tests/test_generate_handoff.py
+++ b/tests/test_generate_handoff.py
@@ -17,7 +17,12 @@ from dagzoo.core.generate_handoff import (
     write_generate_handoff_manifest,
 )
 from dagzoo.core.identity import stable_blake2s_hex
-from dagzoo.io.shard_contract import DATASET_CATALOG_FILENAME, REPLAY_CATALOG_FILENAME
+from dagzoo.io.shard_contract import (
+    DATASET_CATALOG_FILENAME,
+    REPLAY_CATALOG_FILENAME,
+    iter_ndjson_records,
+    write_dataset_catalog_records,
+)
 
 _UNIT_REQUEST_RUN_ID = "1" * 32
 _UNIT_LAYOUT_PLAN_ID = "4" * 32
@@ -82,6 +87,9 @@ def _catalog_record(
 
 def _write_ndjson(path: Path, records: list[dict[str, object]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    if path.suffix == ".parquet":
+        write_dataset_catalog_records(path, records)
+        return
     path.write_text(
         "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
         encoding="utf-8",
@@ -89,9 +97,7 @@ def _write_ndjson(path: Path, records: list[dict[str, object]]) -> None:
 
 
 def _load_ndjson(path: Path) -> list[dict[str, object]]:
-    return [
-        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
-    ]
+    return [dict(record) for record in iter_ndjson_records(path)]
 
 
 def _write_generate_run_artifacts(

--- a/tests/test_parquet_writer.py
+++ b/tests/test_parquet_writer.py
@@ -17,7 +17,11 @@ from dagzoo.io.lineage_schema import (
     validate_lineage_payload,
 )
 from dagzoo.io.parquet_writer import _sanitize_json, write_packed_parquet_shards_stream
-from dagzoo.io.shard_contract import DATASET_CATALOG_FILENAME, REPLAY_CATALOG_FILENAME
+from dagzoo.io.shard_contract import (
+    DATASET_CATALOG_FILENAME,
+    REPLAY_CATALOG_FILENAME,
+    iter_ndjson_records,
+)
 from dagzoo.types import DatasetBundle
 
 
@@ -103,10 +107,7 @@ def _stub_write_packed_split(*, state, split, dataset_index, x, y, compression) 
 
 
 def _load_ndjson_records(path: Path) -> list[dict[str, object]]:
-    records: list[dict[str, object]] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        records.append(json.loads(line))
-    return records
+    return [dict(record) for record in iter_ndjson_records(path)]
 
 
 def test_io_exports_resolve_lineage_path(tmp_path) -> None:

--- a/tests/test_publish_hub.py
+++ b/tests/test_publish_hub.py
@@ -7,6 +7,7 @@ import pytest
 from huggingface_hub.errors import LocalTokenNotFoundError
 
 from dagzoo.core.generate_handoff import build_generate_handoff_manifest
+from dagzoo.io.shard_contract import DATASET_CATALOG_FILENAME, write_dataset_catalog_records
 from dagzoo.publish.hub import build_hub_dataset_card, publish_handoff_to_hub
 
 _REQUEST_RUN_ID = "1" * 32
@@ -17,6 +18,9 @@ _INTERVENTION = {"mode": "hard_interventional", "signature": "a" * 32}
 
 def _write_ndjson(path: Path, records: list[dict[str, object]]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    if path.suffix == ".parquet":
+        write_dataset_catalog_records(path, records)
+        return
     path.write_text(
         "\n".join(json.dumps(record, sort_keys=True) for record in records) + "\n",
         encoding="utf-8",
@@ -61,12 +65,12 @@ def _write_corpus(
         for index, dataset_id in enumerate(_DATASET_IDS)
     ]
     generated_shard = root / "generated" / "shard_00000"
-    _write_ndjson(generated_shard / "dataset_catalog.ndjson", generated_records)
+    _write_ndjson(generated_shard / DATASET_CATALOG_FILENAME, generated_records)
     (generated_shard / "train.parquet").write_bytes(b"train")
     (generated_shard / "test.parquet").write_bytes(b"test")
     if include_curated:
         curated_shard = root / "curated" / "shard_00000"
-        _write_ndjson(curated_shard / "dataset_catalog.ndjson", generated_records[:1])
+        _write_ndjson(curated_shard / DATASET_CATALOG_FILENAME, generated_records[:1])
         (curated_shard / "train.parquet").write_bytes(b"curated-train")
         (curated_shard / "test.parquet").write_bytes(b"curated-test")
 


### PR DESCRIPTION
## Summary
- emit `dataset_catalog.parquet` as the canonical curated shard catalog artifact
- keep catalog readers compatible where the handoff/publish flow still needs to consume catalog records
- align the shard contract with the parquet-catalog path consumed by `tab-realdata-hub` and `tab-foundry`

## Relationship
- Related to foundry manifest-speedup PR: https://github.com/bensonlee5/tab-foundry/pull/270
- Not required for the foundry PR to stay compatible with `tab-realdata-hub 0.1.8`, but this is the canonical producer-side contract update.

## Verification
- `.venv/bin/nox -s quick`
  - Passed
